### PR TITLE
Allow pushing some msats on channel open

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fn main() {
 	
 	node.sync_wallets().unwrap();
 
-	node.connect_open_channel("NODE_ID@PEER_ADDR:PORT", 10000, false).unwrap();
+	node.connect_open_channel("NODE_ID@PEER_ADDR:PORT", 10000, None, false).unwrap();
 
 	let invoice = Invoice::from_str("INVOICE_STR").unwrap();
 	node.send_payment(invoice).unwrap();


### PR DESCRIPTION
We had so far omitted the `push_msat` field, but it's likely useful, so we add it here.