### PR TITLE
Call `stop()` on `Node` drop

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -38,11 +38,11 @@ interface Node {
 	[Throws=NodeError]
 	void connect(PublicKey node_id, SocketAddr address, boolean permanently);
 	[Throws=NodeError]
-	void disconnect([ByRef]PublicKey node_id);
+	void disconnect(PublicKey node_id);
 	[Throws=NodeError]
 	void connect_open_channel(PublicKey node_id, SocketAddr address, u64 channel_amount_sats, u64? push_to_counterparty_msat, boolean announce_channel);
 	[Throws=NodeError]
-	void close_channel([ByRef]ChannelId channel_id, [ByRef]PublicKey counterparty_node_id);
+	void close_channel([ByRef]ChannelId channel_id, PublicKey counterparty_node_id);
 	[Throws=NodeError]
 	void sync_wallets();
 	[Throws=NodeError]
@@ -50,7 +50,7 @@ interface Node {
 	[Throws=NodeError]
 	PaymentHash send_payment_using_amount([ByRef]Invoice invoice, u64 amount_msat);
 	[Throws=NodeError]
-	PaymentHash send_spontaneous_payment(u64 amount_msat, [ByRef]PublicKey node_id);
+	PaymentHash send_spontaneous_payment(u64 amount_msat, PublicKey node_id);
 	[Throws=NodeError]
 	Invoice receive_payment(u64 amount_msat, [ByRef]string description, u32 expiry_secs);
 	[Throws=NodeError]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,7 +953,7 @@ impl Node {
 	///
 	/// Will also remove the peer from the peer store, i.e., after this has been called we won't
 	/// try to reconnect on restart.
-	pub fn disconnect(&self, counterparty_node_id: &PublicKey) -> Result<(), Error> {
+	pub fn disconnect(&self, counterparty_node_id: PublicKey) -> Result<(), Error> {
 		let rt_lock = self.runtime.read().unwrap();
 		if rt_lock.is_none() {
 			return Err(Error::NotRunning);
@@ -968,7 +968,7 @@ impl Node {
 			}
 		}
 
-		self.peer_manager.disconnect_by_node_id(*counterparty_node_id);
+		self.peer_manager.disconnect_by_node_id(counterparty_node_id);
 		Ok(())
 	}
 
@@ -1126,10 +1126,10 @@ impl Node {
 
 	/// Close a previously opened channel.
 	pub fn close_channel(
-		&self, channel_id: &ChannelId, counterparty_node_id: &PublicKey,
+		&self, channel_id: &ChannelId, counterparty_node_id: PublicKey,
 	) -> Result<(), Error> {
-		self.peer_store.remove_peer(counterparty_node_id)?;
-		match self.channel_manager.close_channel(&channel_id.0, counterparty_node_id) {
+		self.peer_store.remove_peer(&counterparty_node_id)?;
+		match self.channel_manager.close_channel(&channel_id.0, &counterparty_node_id) {
 			Ok(_) => Ok(()),
 			Err(_) => Err(Error::ChannelClosingFailed),
 		}
@@ -1291,7 +1291,7 @@ impl Node {
 
 	/// Send a spontaneous, aka. "keysend", payment
 	pub fn send_spontaneous_payment(
-		&self, amount_msat: u64, node_id: &PublicKey,
+		&self, amount_msat: u64, node_id: PublicKey,
 	) -> Result<PaymentHash, Error> {
 		let rt_lock = self.runtime.read().unwrap();
 		if rt_lock.is_none() {
@@ -1303,7 +1303,7 @@ impl Node {
 
 		let route_params = RouteParameters {
 			payment_params: PaymentParameters::from_node_id(
-				*node_id,
+				node_id,
 				self.config.default_cltv_expiry_delta,
 			),
 			final_value_msat: amount_msat,

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -181,7 +181,7 @@ fn channel_full_cycle() {
 	assert_eq!(node_b.payment(&payment_hash).unwrap().direction, PaymentDirection::Inbound);
 	assert_eq!(node_b.payment(&payment_hash).unwrap().amount_msat, Some(determined_amount_msat));
 
-	node_b.close_channel(&channel_id, &node_a.node_id()).unwrap();
+	node_b.close_channel(&channel_id, node_a.node_id()).unwrap();
 	expect_event!(node_a, ChannelClosed);
 	expect_event!(node_b, ChannelClosed);
 


### PR DESCRIPTION
Fixes #79 

We simply call `stop()` on dropping the `Node` object to allow for a cleaner shutdown by default.

We also include a minor commit which changes the API to take `SocketAddrs` and `PublicKey`s by value as they'll be copied/dereferenced in most cases anyways and this makes the API a tiny bit more uniform.