### PR TITLE
Avoid blocking and panicking where possible

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -548,7 +548,8 @@ where
 			}
 			LdkEvent::SpendableOutputs { outputs } => {
 				// TODO: We should eventually remember the outputs and supply them to the wallet's coin selection, once BDK allows us to do so.
-				let destination_address = self.wallet.get_new_address().unwrap();
+				let destination_address =
+					self.wallet.get_new_address().expect("Failed to get destination address");
 				let output_descriptors = &outputs.iter().collect::<Vec<_>>();
 				let tx_feerate =
 					self.wallet.get_est_sat_per_1000_weight(ConfirmationTarget::Normal);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,7 +839,9 @@ impl Node {
 	///
 	/// **Note:** This **MUST** be called after each event has been handled.
 	pub fn event_handled(&self) {
-		self.event_queue.event_handled().unwrap();
+		self.event_queue
+			.event_handled()
+			.expect("Couldn't mark event handled due to persistence failure");
 	}
 
 	/// Returns our own node id

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -15,7 +15,7 @@ pub(crate) struct FilesystemLogger {
 impl FilesystemLogger {
 	pub(crate) fn new(file_path: String) -> Self {
 		if let Some(parent_dir) = Path::new(&file_path).parent() {
-			fs::create_dir_all(parent_dir).unwrap();
+			fs::create_dir_all(parent_dir).expect("Failed to create log parent directory");
 		}
 		Self { file_path }
 	}
@@ -35,8 +35,8 @@ impl Logger for FilesystemLogger {
 			.create(true)
 			.append(true)
 			.open(self.file_path.clone())
-			.unwrap()
+			.expect("Failed to open log file")
 			.write_all(log.as_bytes())
-			.unwrap();
+			.expect("Failed to write to log file")
 	}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -283,7 +283,7 @@ impl UniffiCustomTypeConverter for Network {
 impl UniffiCustomTypeConverter for Txid {
 	type Builtin = String;
 	fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-		Ok(Txid::from_str(&val).unwrap())
+		Ok(Txid::from_str(&val)?)
 	}
 
 	fn from_custom(obj: Self) -> Self::Builtin {


### PR DESCRIPTION
Fixes #50

We avoid unwraps in a number of cases and switch some out for except.

Also, we had previously experienced cases where calling in via `sync_wallets` could block the world. Here we avoid calling `block_on` where possible to ensure we don't hit these cases anymore.