### PR TITLE
Feature: sign arbitrary msg and verify msg' sig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1556,6 +1556,14 @@ impl Node {
 			})
 			.collect()
 	}
+
+	pub fn sign_message(&self, msg: &[u8]) -> Result<String, Error> {
+		self.keys_manager.sign_message(msg)
+	}
+
+	pub fn verify_signature(&self, msg: &[u8], sig: &str) -> bool {
+		self.keys_manager.verify_signature(msg, sig)
+	}
 }
 
 impl Drop for Node {

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -363,3 +363,17 @@ fn onchain_spend_receive() {
 	assert!(node_b.onchain_balance().unwrap().get_spendable() > 99000);
 	assert!(node_b.onchain_balance().unwrap().get_spendable() < 100000);
 }
+
+// Tests arbitrary message signing and later verification 
+#[test]
+fn sign_verify_msg() {
+	let (_, electrsd) = setup_bitcoind_and_electrsd();
+	let esplora_url = electrsd.esplora_url.as_ref().unwrap();
+	let node = Builder::from_config(random_config(esplora_url)).build();
+	
+	node.start().unwrap();
+
+	let msg = "OK computer".as_bytes();
+	let sig = node.sign_message(msg).unwrap();
+	assert!(node.verify_signature(msg, sig.as_str()));
+}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -13,6 +13,8 @@ use lightning::chain::keysinterface::{
 use lightning::ln::msgs::{DecodeError, UnsignedGossipMessage};
 use lightning::ln::script::ShutdownScript;
 
+use lightning::util::message_signing;
+
 use bdk::blockchain::{Blockchain, EsploraBlockchain};
 use bdk::database::BatchDatabase;
 use bdk::wallet::AddressIndex;
@@ -372,6 +374,17 @@ where
 			feerate_sat_per_1000_weight,
 			secp_ctx,
 		)
+	}
+
+	pub fn sign_message(&self, msg: &[u8]) -> Result<String, Error> {
+		message_signing::sign(msg, &self.inner.get_node_secret_key())
+			.or(Err(Error::WalletSigningFailed))
+	}
+
+	pub fn verify_signature(&self, msg: &[u8], sig: &str) -> bool {
+		let pkey = PublicKey::from_secret_key(&Secp256k1::new(),
+			&self.inner.get_node_secret_key());
+		message_signing::verify(msg, sig, &pkey)
 	}
 }
 


### PR DESCRIPTION
Closes #97 

This adds new methods to Node & KeysManager to sign any message and verify signature.
Both rely on ldk::util to do it and use node' secret and derived public key.

Plus it adds a test for above methods.