### PR TITLE
Expose BIP39 Mnemonic generation in bindings

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -1,4 +1,5 @@
 namespace ldk_node {
+	Mnemonic generate_entropy_mnemonic();
 };
 
 dictionary Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ mod wallet;
 pub use bip39;
 pub use bitcoin;
 pub use lightning;
-use lightning::ln::msgs::RoutingMessageHandler;
 pub use lightning_invoice;
 
 pub use error::Error as NodeError;
@@ -101,6 +100,8 @@ use error::Error;
 
 pub use event::Event;
 pub use types::NetAddress;
+
+pub use io::utils::generate_entropy_mnemonic;
 
 #[cfg(feature = "uniffi")]
 use {bitcoin::OutPoint, lightning::ln::PaymentSecret, uniffi_types::*};
@@ -126,6 +127,7 @@ use lightning::chain::{chainmonitor, BestBlock, Confirm, Watch};
 use lightning::ln::channelmanager::{
 	self, ChainParameters, ChannelManagerReadArgs, PaymentId, RecipientOnionFields, Retry,
 };
+use lightning::ln::msgs::RoutingMessageHandler;
 use lightning::ln::peer_handler::{IgnoringMessageHandler, MessageHandler};
 use lightning::ln::{PaymentHash, PaymentPreimage};
 use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringParameters};


### PR DESCRIPTION
~~Based on #88~~, closes #112

We already re-export the `bip39` crate to allow users to generate Mnemonics. However, doing the same is not trivial in bindings.

Here we expose a simple convenience function that returns a random mnemonic, allowig users to generate them without relying on a third-party library.