### PR TITLE
Move `Builder` to own module, allow for shared runtime reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use ldk_node::bitcoin::Network;
 use std::str::FromStr;
 
 fn main() {
-	let builder = Builder::new();
+	let mut builder = Builder::new();
 	builder.set_network(Network::Testnet);
 	builder.set_esplora_server("https://blockstream.info/testnet/api".to_string());
 	builder.set_gossip_source_rgs("https://rapidsync.lightningdevkit.org/testnet/snapshot".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! use std::str::FromStr;
 //!
 //! fn main() {
-//! 	let builder = Builder::new();
+//! 	let mut builder = Builder::new();
 //! 	builder.set_network(Network::Testnet);
 //! 	builder.set_esplora_server("https://blockstream.info/testnet/api".to_string());
 //! 	builder.set_gossip_source_rgs("https://rapidsync.lightningdevkit.org/testnet/snapshot".to_string());
@@ -109,7 +109,11 @@ pub use types::NetAddress;
 #[cfg(feature = "uniffi")]
 use {bip39::Mnemonic, bitcoin::OutPoint, lightning::ln::PaymentSecret, uniffi_types::*};
 
-pub use builder::Builder;
+#[cfg(feature = "uniffi")]
+pub use builder::ArcedNodeBuilder as Builder;
+#[cfg(not(feature = "uniffi"))]
+pub use builder::NodeBuilder as Builder;
+
 use event::{EventHandler, EventQueue};
 use gossip::GossipSource;
 use io::KVStore;

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -1,13 +1,12 @@
+use crate::builder::NodeBuilder;
 use crate::io::KVStore;
 use crate::test::utils::*;
 use crate::test::utils::{expect_event, random_config};
-use crate::{Builder, Error, Event, Node, PaymentDirection, PaymentStatus};
+use crate::{Error, Event, Node, PaymentDirection, PaymentStatus};
 
 use bitcoin::Amount;
 use electrsd::bitcoind::BitcoinD;
 use electrsd::ElectrsD;
-
-use std::sync::Arc;
 
 #[test]
 fn channel_full_cycle() {
@@ -15,14 +14,14 @@ fn channel_full_cycle() {
 	println!("== Node A ==");
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config_a = random_config();
-	let builder_a = Builder::from_config(config_a);
+	let mut builder_a = NodeBuilder::from_config(config_a);
 	builder_a.set_esplora_server(esplora_url.clone());
 	let node_a = builder_a.build();
 	node_a.start().unwrap();
 
 	println!("\n== Node B ==");
 	let config_b = random_config();
-	let builder_b = Builder::from_config(config_b);
+	let mut builder_b = NodeBuilder::from_config(config_b);
 	builder_b.set_esplora_server(esplora_url);
 	let node_b = builder_b.build();
 	node_b.start().unwrap();
@@ -36,7 +35,7 @@ fn channel_full_cycle_0conf() {
 	println!("== Node A ==");
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config_a = random_config();
-	let builder_a = Builder::from_config(config_a);
+	let mut builder_a = NodeBuilder::from_config(config_a);
 	builder_a.set_esplora_server(esplora_url.clone());
 	let node_a = builder_a.build();
 	node_a.start().unwrap();
@@ -45,7 +44,7 @@ fn channel_full_cycle_0conf() {
 	let mut config_b = random_config();
 	config_b.trusted_peers_0conf.push(node_a.node_id());
 
-	let builder_b = Builder::from_config(config_b);
+	let mut builder_b = NodeBuilder::from_config(config_b);
 	builder_b.set_esplora_server(esplora_url.clone());
 	let node_b = builder_b.build();
 
@@ -55,8 +54,7 @@ fn channel_full_cycle_0conf() {
 }
 
 fn do_channel_full_cycle<K: KVStore + Sync + Send>(
-	node_a: Arc<Node<K>>, node_b: Arc<Node<K>>, bitcoind: &BitcoinD, electrsd: &ElectrsD,
-	allow_0conf: bool,
+	node_a: Node<K>, node_b: Node<K>, bitcoind: &BitcoinD, electrsd: &ElectrsD, allow_0conf: bool,
 ) {
 	let addr_a = node_a.new_funding_address().unwrap();
 	let addr_b = node_b.new_funding_address().unwrap();
@@ -276,7 +274,7 @@ fn channel_open_fails_when_funds_insufficient() {
 	println!("== Node A ==");
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config_a = random_config();
-	let builder_a = Builder::from_config(config_a);
+	let mut builder_a = NodeBuilder::from_config(config_a);
 	builder_a.set_esplora_server(esplora_url.clone());
 	let node_a = builder_a.build();
 	node_a.start().unwrap();
@@ -284,7 +282,7 @@ fn channel_open_fails_when_funds_insufficient() {
 
 	println!("\n== Node B ==");
 	let config_b = random_config();
-	let builder_b = Builder::from_config(config_b);
+	let mut builder_b = NodeBuilder::from_config(config_b);
 	builder_b.set_esplora_server(esplora_url);
 	let node_b = builder_b.build();
 	node_b.start().unwrap();
@@ -320,7 +318,7 @@ fn channel_open_fails_when_funds_insufficient() {
 fn connect_to_public_testnet_esplora() {
 	let mut config = random_config();
 	config.network = bitcoin::Network::Testnet;
-	let builder = Builder::from_config(config);
+	let mut builder = NodeBuilder::from_config(config);
 	builder.set_esplora_server("https://blockstream.info/testnet/api".to_string());
 	let node = builder.build();
 	node.start().unwrap();
@@ -333,7 +331,7 @@ fn start_stop_reinit() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config = random_config();
-	let builder = Builder::from_config(config.clone());
+	let mut builder = NodeBuilder::from_config(config.clone());
 	builder.set_esplora_server(esplora_url.clone());
 	let node = builder.build();
 	let expected_node_id = node.node_id();
@@ -363,7 +361,7 @@ fn start_stop_reinit() {
 	assert_eq!(node.stop(), Err(Error::NotRunning));
 	drop(node);
 
-	let new_builder = Builder::from_config(config);
+	let mut new_builder = NodeBuilder::from_config(config);
 	new_builder.set_esplora_server(esplora_url);
 	let reinitialized_node = builder.build();
 	assert_eq!(reinitialized_node.node_id(), expected_node_id);
@@ -389,7 +387,7 @@ fn start_stop_reinit_fs_store() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config = random_config();
-	let builder = Builder::from_config(config.clone());
+	let mut builder = NodeBuilder::from_config(config.clone());
 	builder.set_esplora_server(esplora_url.clone());
 	let node = builder.build_with_fs_store();
 	let expected_node_id = node.node_id();
@@ -416,7 +414,7 @@ fn start_stop_reinit_fs_store() {
 	assert_eq!(node.stop(), Err(Error::NotRunning));
 	drop(node);
 
-	let new_builder = Builder::from_config(config);
+	let mut new_builder = NodeBuilder::from_config(config);
 	new_builder.set_esplora_server(esplora_url);
 	let reinitialized_node = builder.build_with_fs_store();
 	assert_eq!(reinitialized_node.node_id(), expected_node_id);
@@ -443,14 +441,14 @@ fn onchain_spend_receive() {
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 
 	let config_a = random_config();
-	let builder_a = Builder::from_config(config_a);
+	let mut builder_a = NodeBuilder::from_config(config_a);
 	builder_a.set_esplora_server(esplora_url.clone());
 	let node_a = builder_a.build();
 	node_a.start().unwrap();
 	let addr_a = node_a.new_funding_address().unwrap();
 
 	let config_b = random_config();
-	let builder_b = Builder::from_config(config_b);
+	let mut builder_b = NodeBuilder::from_config(config_b);
 	builder_b.set_esplora_server(esplora_url);
 	let node_b = builder_b.build();
 	node_b.start().unwrap();
@@ -498,7 +496,7 @@ fn sign_verify_msg() {
 	let (_bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 	let config = random_config();
-	let builder = Builder::from_config(config.clone());
+	let mut builder = NodeBuilder::from_config(config.clone());
 	builder.set_esplora_server(esplora_url.clone());
 	let node = builder.build();
 


### PR DESCRIPTION
Firstly, as `lib.rs` got quite big and `Builder` made up a good chunk of it, we now move it to a dedicated submodule.

We then split the actual logic of `build_with_store` from the API method, which is needed as VSS in the
future will need to share the Runtime, i.e., will need to hand in a `Arc<Rwlock<Runtime>>>` parameter that we'll set `Some` in `Node::start`.

Finally, we do exactly that: we allow `build_with_store_internal` to take a runtime parameter.