### PR TITLE
Update serialization field numbers for consistency and to break compat. with alpha

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -87,22 +87,22 @@ impl_writeable_tlv_based_enum!(Event,
 	},
 	(2, PaymentReceived) => {
 		(0, payment_hash, required),
-		(1, amount_msat, required),
+		(2, amount_msat, required),
 	},
 	(3, ChannelReady) => {
 		(0, channel_id, required),
-		(1, user_channel_id, required),
+		(2, user_channel_id, required),
 	},
 	(4, ChannelPending) => {
 		(0, channel_id, required),
-		(1, user_channel_id, required),
-		(2, former_temporary_channel_id, required),
-		(3, counterparty_node_id, required),
-		(4, funding_txo, required),
+		(2, user_channel_id, required),
+		(4, former_temporary_channel_id, required),
+		(6, counterparty_node_id, required),
+		(8, funding_txo, required),
 	},
 	(5, ChannelClosed) => {
 		(0, channel_id, required),
-		(1, user_channel_id, required),
+		(2, user_channel_id, required),
 	};
 );
 

--- a/src/payment_store.rs
+++ b/src/payment_store.rs
@@ -31,11 +31,11 @@ pub struct PaymentDetails {
 
 impl_writeable_tlv_based!(PaymentDetails, {
 	(0, hash, required),
-	(1, preimage, required),
-	(2, secret, required),
-	(3, amount_msat, required),
-	(4, direction, required),
-	(5, status, required)
+	(2, preimage, required),
+	(4, secret, required),
+	(6, amount_msat, required),
+	(8, direction, required),
+	(10, status, required)
 });
 
 /// Represents the direction of a payment.


### PR DESCRIPTION
Leading up to the 0.1 release, we update the field numbers of `PaymentDetails` and `Event` to make them even.

While this is nice for consistency's sake, it also has the added benefit that users running the serialization-incompatible alpha versions would fail to read rather than (unknowingly) reading bogus data.