### PR TITLE
Balance values are Long rather than Int

### DIFF
--- a/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
+++ b/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
@@ -155,10 +155,10 @@ class LibraryTest {
         println("Spendable balance 2: $spendableBalance1")
         println("Total balance 1: $totalBalance1")
         println("Total balance 2: $totalBalance1")
-        assertEquals(100000u, spendableBalance1)
-        assertEquals(100000u, spendableBalance2)
-        assertEquals(100000u, totalBalance1)
-        assertEquals(100000u, totalBalance2)
+        assertEquals(100000uL, spendableBalance1)
+        assertEquals(100000uL, spendableBalance2)
+        assertEquals(100000uL, totalBalance1)
+        assertEquals(100000uL, totalBalance2)
 
         node1.connectOpenChannel(nodeId2, listenAddress2, 50000u, null, null, true)
 
@@ -190,7 +190,7 @@ class LibraryTest {
         println("Spendable balance 2 after open: $spendableBalance2AfterOpen")
         assert(spendableBalance1AfterOpen > 49000u)
         assert(spendableBalance1AfterOpen < 50000u)
-        assertEquals(100000u, spendableBalance2AfterOpen)
+        assertEquals(100000uL, spendableBalance2AfterOpen)
 
         val channelReadyEvent1 = node1.waitNextEvent()
         println("Got event: $channelReadyEvent1")
@@ -247,7 +247,7 @@ class LibraryTest {
         println("Spendable balance 2 after close: $spendableBalance2AfterClose")
         assert(spendableBalance1AfterClose > 95000u)
         assert(spendableBalance1AfterClose < 100000u)
-        assertEquals(101000u, spendableBalance2AfterClose)
+        assertEquals(101000uL, spendableBalance2AfterClose)
 
         node1.stop()
         node2.stop()


### PR DESCRIPTION
I run the LDK node Kotlin test standalone and it was failing with:

```
org.opentest4j.AssertionFailedError: expected: kotlin.UInt@602e0143<100000> but was: kotlin.ULong@2c07545f<100000>
Expected :100000
Actual   :100000
<Click to see difference>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1142)
	at org.mendrugo.korko.LdkNodeTest.testFullLifecycle(LdkNodeTest.kt:85)
```

According to the decompiled class:

```
public open fun spendableOnchainBalanceSats(): kotlin.ULong { /* compiled code */ }
```