### PR TITLE
chore: dont use chrono default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bitcoin = "0.29.2"
 bip39 = "2.0.0"
 
 rand = "0.8.5"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 futures = "0.3"
 serde_json = { version = "1.0" }
 tokio = { version = "1", default-features = false, features = [ "rt-multi-thread", "time", "sync" ] }


### PR DESCRIPTION
The `chrono` crate has a dependency on an old version of the `time` crate, which has a potential segfault: https://stackoverflow.com/questions/75556326/rust-segmentation-fault-in-chrono

I was attempting to use LDK Node in Fedimint and our crate audit flagged this dependency. Changing the `chrono` crate to not use the default features fixed it: https://github.com/fedimint/fedimint/pull/2869