### PR TITLE
Pin BDK to fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,8 @@ bitcoin = "0.29.2"
 bip39 = "2.0.0"
 
 rand = "0.8.5"
-chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures = "0.3"
-serde_json = { version = "1.0" }
 tokio = { version = "1", default-features = false, features = [ "rt-multi-thread", "time", "sync" ] }
 esplora-client = { version = "0.4", default-features = false }
 libc = "0.2"


### PR DESCRIPTION
BDK 0.28.1 patch release upgraded the `esplora-client` dependency to 0.5, which is API incompatible with the 0.4 release we use in `lightning-transaction-sync`. In order to fix our builds, we pin BDK to the older version until we had a chance to upgrade `lightning-transaction-sync`.