### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,13 @@ jobs:
         toolchain: [
           stable,
           beta,
-          1.60.0, # Our MSRV
+          1.63.0, # Our MSRV
           ]
         include:
           - toolchain: stable
             check-fmt: true
             build-uniffi: true
-          - toolchain: 1.60.0
+          - toolchain: 1.63.0
             msrv: true
     runs-on: ubuntu-latest
     steps:
@@ -28,8 +28,7 @@ jobs:
       - name: Pin packages to allow for MSRV
         if: matrix.msrv
         run: |
-          cargo update -p hashlink --precise "0.8.1" --verbose # hashlink 0.8.2 requires hashbrown 0.13, requiring 1.61.0
-          cargo update -p tempfile --precise "3.6.0" --verbose # tempfile 3.7.0 requires rustc 1.63.0
+          cargo update -p hashlink --precise "0.8.2" --verbose # hashlink 0.8.3 requires hashbrown 0.14, requiring 1.64.0
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Build with UniFFI support on Rust ${{ matrix.toolchain }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ LDK Node currently comes with a decidedly opinionated set of design choices:
 LDK Node itself is written in [Rust][rust] and may therefore be natively added as a library dependency to any `std` Rust program. However, beyond its Rust API it also offers language bindings for [Swift][swift], [Kotlin][kotlin], and [Python][python] based on the [UniFFI](https://github.com/mozilla/uniffi-rs/). Moreover, [Flutter bindings][flutter_bindings] are also available.
 
 ## MSRV
-The Minimum Supported Rust Version (MSRV) is currently 1.60.0.
+The Minimum Supported Rust Version (MSRV) is currently 1.63.0.
 
 [api_docs]: https://docs.rs/ldk-node/*/ldk_node/
 [api_docs_node]: https://docs.rs/ldk-node/*/ldk_node/struct.Node.html


### PR DESCRIPTION
We bump the MSRV to 1.63, which is the rustc version shipped in Debian bookworm.