### PR TITLE
Bump `esplora-client` and unpin BDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,7 @@ lightning-transaction-sync = { version = "0.0.116", features = ["esplora-async-h
 #lightning-rapid-gossip-sync = { path = "../rust-lightning/lightning-rapid-gossip-sync" }
 #lightning-transaction-sync = { path = "../rust-lightning/lightning-transaction-sync", features = ["esplora-async"] }
 
-# TODO: unpin BDK once we upgraded the esplora client to 0.5 everywhere.
-bdk = { version = "=0.28.0", default-features = false, features = ["std", "async-interface", "use-esplora-async", "sqlite-bundled", "keys-bip39"]}
+bdk = { version = "0.28.0", default-features = false, features = ["std", "async-interface", "use-esplora-async", "sqlite-bundled", "keys-bip39"]}
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 bitcoin = "0.29.2"


### PR DESCRIPTION
This can only happen after `lightning-transaction-sync` bumped as well, so blocked on upstream for now.