### PR TITLE
Fix logger symlink setup

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -29,14 +29,16 @@ impl FilesystemLogger {
 				.create(true)
 				.append(true)
 				.open(log_file_path.clone())
-				.map_err(|_| ())?;
+				.map_err(|e| eprintln!("ERROR: Failed to open log file: {}", e))?;
 
 			// Create a symlink to the current log file, with prior cleanup
 			let log_file_symlink = parent_dir.join("ldk_node_latest.log");
-			if log_file_symlink.as_path().exists() && log_file_symlink.as_path().is_symlink() {
-				fs::remove_file(&log_file_symlink).map_err(|_| ())?;
+			if log_file_symlink.as_path().is_symlink() {
+				fs::remove_file(&log_file_symlink)
+					.map_err(|e| eprintln!("ERROR: Failed to remove log file symlink: {}", e))?;
 			}
-			symlink(&log_file_name, &log_file_symlink).map_err(|_| ())?;
+			symlink(&log_file_name, &log_file_symlink)
+				.map_err(|e| eprintln!("ERROR: Failed to create log file symlink: {}", e))?;
 		}
 
 		Ok(Self { file_path: log_file_path, level })


### PR DESCRIPTION
Currently we check the for the existence of the log file the symlink is pointing to before removing the symlink. This could lead to weird issues when a log file was removed, as we'd then never remove and update the symlink.

Here, we remove the superfluous check and just check that the path in question is indeed a symlink before removing it.

While we're at it we introduce some logging to `stderr` that might help debug issues arising during logger setup.