### PR TITLE
Skip channels used for probing based on available liquidity

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -11,8 +11,9 @@ dictionary Config {
 	u64 onchain_wallet_sync_interval_secs = 80;
 	u64 wallet_sync_interval_secs = 30;
 	u64 fee_rate_cache_update_interval_secs = 600;
-	LogLevel log_level = "Debug";
 	sequence<PublicKey> trusted_peers_0conf = [];
+	u64 probing_liquidity_limit_multiplier = 3;
+	LogLevel log_level = "Debug";
 };
 
 interface Builder {


### PR DESCRIPTION
Fixes #155.

As pre-flight probes might take up some of the available liquidity, we here introduce that channels whose available liquidity is less than the required amount times `Config::probing_liquidity_limit_multiplier` won't be used to send pre-flight probes.

(cc @TonyGiorgio)