### PR TITLE
Add script and config for C# bindings

### DIFF
--- a/scripts/uniffi_bindgen_generate.sh
+++ b/scripts/uniffi_bindgen_generate.sh
@@ -2,4 +2,4 @@
 source ./scripts/uniffi_bindgen_generate_kotlin.sh || exit 1
 source ./scripts/uniffi_bindgen_generate_python.sh || exit 1
 source ./scripts/uniffi_bindgen_generate_swift.sh || exit 1
-
+source ./scripts/uniffi_bindgen_generate_csharp.sh || exit 1

--- a/scripts/uniffi_bindgen_generate_csharp.sh
+++ b/scripts/uniffi_bindgen_generate_csharp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs
+BINDINGS_DIR="./bindings/csharp"
+
+mkdir -p $BINDINGS_DIR
+
+cargo build --release --features uniffi || exit 1
+uniffi-bindgen-cs bindings/ldk_node.udl -o "$BINDINGS_DIR" || exit 1
+cp ./target/release/libldk_node.{a,so} "$BINDINGS_DIR" || exit 1

--- a/uniffi.toml
+++ b/uniffi.toml
@@ -10,3 +10,8 @@ module_name = "LDKNode"
 ffi_module_name = "LDKNodeFFI"
 ffi_module_filename ="LDKNodeFFI"
 cdylib_name = "ldk_node"
+
+[bindings.csharp]
+module_name = "LdkNode"
+type_name = "LdkNode"
+cdylib_name = "ldk_node"


### PR DESCRIPTION
Sharing the code for the C# integration, but this isn't fully complete yet, as the `uniffi-bindgen-cs` templates use different casings for the generated types. I tried adapting the config vars `module_name` and `type_name`, but the generator spits out different casings in those two templates:

- `LdkNodeSafeHandle` https://github.com/NordSecurity/uniffi-bindgen-cs/blob/main/bindgen/templates/ObjectTemplate.cs#L6
- `LDKNodeSafeHandle` https://github.com/NordSecurity/uniffi-bindgen-cs/blob/main/bindgen/templates/NamespaceLibraryTemplate.cs#L16

