### PR TITLE
add `[Node::block_height]` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,6 +802,25 @@ impl<K: KVStore + Sync + Send + 'static> Node<K> {
 		Ok(self.wallet.get_balance().map(|bal| bal.get_total())?)
 	}
 
+	/// Retrieve the current block height.
+	pub fn block_height(&self) -> Result<u32, Error> {
+		let wallet = Arc::clone(&self.wallet);
+		tokio::task::block_in_place(move || {
+			tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(
+				async move {
+					match wallet.get_height().await {
+						Ok(h) => {
+							return Ok(h);
+						}
+						Err(e) => {
+							return Err(e);
+						}
+					};
+				},
+			)
+		})
+	}
+
 	/// Send an on-chain payment to the given address.
 	pub fn send_to_onchain_address(
 		&self, address: &bitcoin::Address, amount_sats: u64,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -154,6 +154,13 @@ where
 		Ok(())
 	}
 
+	pub(crate) async fn get_height(&self) -> Result<u32, Error> {
+		Ok(self.blockchain.get_height().await.map_err(|e| {
+			log_error!(self.logger, "Failed to retrieve blockchain height: {}", e);
+			Error::ConnectionFailed
+		})?)
+	}
+
 	pub(crate) fn create_funding_transaction(
 		&self, output_script: Script, value_sats: u64, confirmation_target: ConfirmationTarget,
 		locktime: LockTime,


### PR DESCRIPTION
hello
I think this function can be useful for users who want to get blockchain info. this is returning the `block_height` as known by `blockchain` inside `wallet` 

resolves #172 