### PR TITLE
Set `mempool.space` as esplora server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use std::str::FromStr;
 fn main() {
 	let mut builder = Builder::new();
 	builder.set_network(Network::Testnet);
-	builder.set_esplora_server("https://blockstream.info/testnet/api".to_string());
+	builder.set_esplora_server("https://mempool.space/testnet/api".to_string());
 	builder.set_gossip_source_rgs("https://rapidsync.lightningdevkit.org/testnet/snapshot".to_string());
 
 	let node = builder.build().unwrap();


### PR DESCRIPTION
The synchronization of LDK-Node with the Blockstream Esplora server on testnet is currently experiencing difficulties due to rate limiting (https://github.com/Blockstream/esplora/issues/449).

To enhance the user experience and prevent potential issues during initial testing, this PR suggests updating the README to recommend using `mempool.space` as the Esplora server for LDK-Node setup. This adjustment aims to ensure a smoother onboarding process for users exploring LDK-Node for the first time.