### PR TITLE
Hide `vss-client` dependency behind `cfg` flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ tokio = { version = "1", default-features = false, features = [ "rt-multi-thread
 esplora-client = { version = "0.4", default-features = false }
 libc = "0.2"
 uniffi = { version = "0.23.0", features = ["build"], optional = true }
+
+[target.'cfg(vss)'.dependencies]
 vss-client = "0.1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Fixes #197

Recently, we introduced first steps towards VSS support. Unfortunately, `vss-client` has a build dependency on blocking `reqwest` which defaults to use `native-tls`, pulling in `openssl-sys`, which in turn fails for the Android targets.

Here, we preliminarily hide the `vss-client` dependency behind the `cfg(vss)` flag to fix our Android builds.