### PR TITLE
Fix reachable `unwrap` of `outbound_htlc_minimum_msat`

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -204,7 +204,7 @@ dictionary ChannelDetails {
 	boolean is_public;
 	u16? cltv_expiry_delta;
 	u64 counterparty_unspendable_punishment_reserve;
-	u64 counterparty_outbound_htlc_minimum_msat;
+	u64? counterparty_outbound_htlc_minimum_msat;
 	u64? counterparty_outbound_htlc_maximum_msat;
 	u32? counterparty_forwarding_info_fee_base_msat;
 	u32? counterparty_forwarding_info_fee_proportional_millionths;


### PR DESCRIPTION
Fixes #208.

As the `unwrap` previously was reachable we now expose the field as an `Option`. Additionally, we document the unwrap safety of the other `ChannelDetails` fields where applicable.