### PR TITLE
Use Multi threaded runtime in `sync_wallets`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,7 +1003,7 @@ impl<K: KVStore + Sync + Send + 'static> Node<K> {
 		];
 
 		tokio::task::block_in_place(move || {
-			tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(
+			tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap().block_on(
 				async move {
 					let now = Instant::now();
 					match wallet.sync().await {


### PR DESCRIPTION
This is needed since so that components(such as `KVStore`) can use `block_in_place`. 
`block_in_place` is only allowed inside a multi-threaded runtime. 
`sync_wallets` internally syncs channel_manager and chain_monitor which results in persistence using `KVStore`.
Using blocking `sync_wallets` should be avoided but is mostly used in functional_tests.