### PR TITLE
Drop `unsafeFlags` also from SwiftPM's `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,7 @@ let package = Package(
         .target(
             name: "LDKNode",
             dependencies: ["LDKNodeFFI"],
-            path: "./bindings/swift/Sources",
-            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]
+            path: "./bindings/swift/Sources"
         ),
         .binaryTarget(
             name: "LDKNodeFFI",


### PR DESCRIPTION
Weirdly, Xcode seems to complain about `unsafeFlags` under very specific circumstances. While we dropped it a while back in the 'local-bindings' `Package.swift`, we now also do so for the SwiftPM one to be sure.