### PR TITLE
Introduce `default_config` top-level function

### DIFF
--- a/bindings/kotlin/ldk-node-android/lib/src/androidTest/kotlin/org/lightningdevkit/ldknode/AndroidLibTest.kt
+++ b/bindings/kotlin/ldk-node-android/lib/src/androidTest/kotlin/org/lightningdevkit/ldknode/AndroidLibTest.kt
@@ -24,13 +24,13 @@ class AndroidLibTest {
         val listenAddress1 = "127.0.0.1:2323"
         val listenAddress2 = "127.0.0.1:2324"
 
-        val config1 = Config()
+        val config1 = defaultConfig()
         config1.storageDirPath = tmpDir1
         config1.listeningAddresses = listOf(listenAddress1)
         config1.network = Network.REGTEST
         config1.logLevel = LogLevel.TRACE
 
-        val config2 = Config()
+        val config2 = defaultConfig()
         config2.storageDirPath = tmpDir2
         config2.listeningAddresses = listOf(listenAddress2)
         config2.network = Network.REGTEST

--- a/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
+++ b/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
@@ -114,7 +114,7 @@ class LibraryTest {
         val listenAddress1 = "127.0.0.1:2323"
         val listenAddress2 = "127.0.0.1:2324"
 
-        val config1 = Config()
+        val config1 = defaultConfig()
         config1.storageDirPath = tmpDir1
         config1.listeningAddresses = listOf(listenAddress1)
         config1.network = Network.REGTEST
@@ -122,7 +122,7 @@ class LibraryTest {
 
         println("Config 1: $config1")
 
-        val config2 = Config()
+        val config2 = defaultConfig()
         config2.storageDirPath = tmpDir2
         config2.listeningAddresses = listOf(listenAddress2)
         config2.network = Network.REGTEST

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -1,19 +1,20 @@
 namespace ldk_node {
 	Mnemonic generate_entropy_mnemonic();
+	Config default_config();
 };
 
 dictionary Config {
-	string storage_dir_path = "/tmp/ldk_node/";
-	string? log_dir_path = null;
-	Network network = "Bitcoin";
-	sequence<SocketAddress>? listening_addresses = null;
-	u32 default_cltv_expiry_delta = 144;
-	u64 onchain_wallet_sync_interval_secs = 80;
-	u64 wallet_sync_interval_secs = 30;
-	u64 fee_rate_cache_update_interval_secs = 600;
-	sequence<PublicKey> trusted_peers_0conf = [];
-	u64 probing_liquidity_limit_multiplier = 3;
-	LogLevel log_level = "Debug";
+	string storage_dir_path;
+	string? log_dir_path;
+	Network network;
+	sequence<SocketAddress>? listening_addresses;
+	u32 default_cltv_expiry_delta;
+	u64 onchain_wallet_sync_interval_secs;
+	u64 wallet_sync_interval_secs;
+	u64 fee_rate_cache_update_interval_secs;
+	sequence<PublicKey> trusted_peers_0conf;
+	u64 probing_liquidity_limit_multiplier;
+	LogLevel log_level;
 };
 
 interface Builder {

--- a/bindings/python/src/ldk_node/test_ldk_node.py
+++ b/bindings/python/src/ldk_node/test_ldk_node.py
@@ -81,7 +81,7 @@ def send_to_address(address, amount_sats):
 
 
 def setup_node(tmp_dir, esplora_endpoint, listening_addresses):
-    config = Config()
+    config = default_config()
     builder = Builder.from_config(config)
     builder.set_storage_dir_path(tmp_dir)
     builder.set_esplora_server(esplora_endpoint)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,16 @@ impl Default for Config {
 	}
 }
 
+/// Returns a [`Config`] object populated with default values.
+///
+/// See the documentation of [`Config`] for more information on the used defaults.
+///
+/// This is mostly meant for use in bindings, in Rust this is synonymous with
+/// [`Config::default()`].
+pub fn default_config() -> Config {
+	Config::default()
+}
+
 /// The main interface object of LDK Node, wrapping the necessary LDK and BDK functionalities.
 ///
 /// Needs to be initialized and instantiated through [`Builder::build`].


### PR DESCRIPTION
.. this allows us the retrieve a `Config` prepopulated with default values in bindings (where `Default::default()` isn't available), even if it includes complex structures for which we can't set default values in the UDL file.