### PR TITLE
Fix trying node announcement broadcast for unannouced nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,7 @@ impl<K: KVStore + Sync + Send + 'static> Node<K> {
 								continue;
 							}
 
-							if bcast_cm.list_channels().iter().any(|chan| chan.is_public) {
+							if !bcast_cm.list_channels().iter().any(|chan| chan.is_public) {
 								// Skip if we don't have any public channels.
 								continue;
 							}


### PR DESCRIPTION
Previously, we would skip broadcasting node announcements if we had any public channel. Here, we fix this bug and instead skip broadcasts if we *don't* have any public channels.