### PR TITLE
Disallow empty fee estimates on Mainnet

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -508,8 +508,11 @@ fn build_with_store_internal<K: KVStore + Sync + Send + 'static>(
 				tx_sync.client().clone(),
 				Arc::clone(&logger),
 			));
-			let fee_estimator =
-				Arc::new(OnchainFeeEstimator::new(tx_sync.client().clone(), Arc::clone(&logger)));
+			let fee_estimator = Arc::new(OnchainFeeEstimator::new(
+				tx_sync.client().clone(),
+				Arc::clone(&config),
+				Arc::clone(&logger),
+			));
 			(blockchain, tx_sync, tx_broadcaster, fee_estimator)
 		}
 		None => {
@@ -523,8 +526,11 @@ fn build_with_store_internal<K: KVStore + Sync + Send + 'static>(
 				tx_sync.client().clone(),
 				Arc::clone(&logger),
 			));
-			let fee_estimator =
-				Arc::new(OnchainFeeEstimator::new(tx_sync.client().clone(), Arc::clone(&logger)));
+			let fee_estimator = Arc::new(OnchainFeeEstimator::new(
+				tx_sync.client().clone(),
+				Arc::clone(&config),
+				Arc::clone(&logger),
+			));
 			(blockchain, tx_sync, tx_broadcaster, fee_estimator)
 		}
 	};


### PR DESCRIPTION
We generally want to properly be able to detect whenever a fee estimation would fail, as we need to fail startup if we can't retrieve the latest fee rates.

However, currently the `convert_fee_estimates` function would fallback to a default of 1sat/vbyte if the retrieved estimate map is empty. This is fine/potentially needed for, e.g., Signet where Esplora's `fee-estimates` endpoint would return an empty dictionary.

However, we need to detect the empty map and fail our fee estimation if we encounter such a case, rather than using the 1 sat/vbyte fallback on mainnet, where differences in fee estimation could lead to costly force-closures. Here we do this and just return a
`FeerateEstimationUpdateFailed` if we hit such a case.

Related issue on `rust-esplora-client`: https://github.com/bitcoindevkit/rust-esplora-client/issues/80