### PR TITLE
Drop `ahash` pin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,6 @@ jobs:
           cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
           cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
           cargo update -p home --precise "0.5.5" --verbose # home v0.5.9, requires rustc 1.70 or newer
-          cargo update -p ahash@0.8.8 --precise "0.8.6" --verbose # ahash v0.8.7 is broken and v0.8.8 requires rustc 1.72.0
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"


### PR DESCRIPTION
... since they reverted the MSRV bump with the just-released 0.8.9.

See https://github.com/tkaitchuck/aHash/pull/208.