### PR TITLE
Add `fee_paid_msat` to `PaymentSuccessful` event

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -154,7 +154,7 @@ enum BuildError {
 
 [Enum]
 interface Event {
-	PaymentSuccessful(PaymentHash payment_hash);
+	PaymentSuccessful(PaymentHash payment_hash, u64? fee_paid_msat);
 	PaymentFailed(PaymentHash payment_hash, PaymentFailureReason? reason);
 	PaymentReceived(PaymentHash payment_hash, u64 amount_msat);
 	ChannelPending(ChannelId channel_id, UserChannelId user_channel_id, ChannelId former_temporary_channel_id, PublicKey counterparty_node_id, OutPoint funding_txo);

--- a/src/event.rs
+++ b/src/event.rs
@@ -47,6 +47,8 @@ pub enum Event {
 	PaymentSuccessful {
 		/// The hash of the payment.
 		payment_hash: PaymentHash,
+		/// The total fee which was spent at intermediate hops in this payment.
+		fee_paid_msat: Option<u64>,
 	},
 	/// A sent payment has failed.
 	PaymentFailed {
@@ -106,6 +108,7 @@ pub enum Event {
 impl_writeable_tlv_based_enum!(Event,
 	(0, PaymentSuccessful) => {
 		(0, payment_hash, required),
+		(1, fee_paid_msat, option),
 	},
 	(1, PaymentFailed) => {
 		(0, payment_hash, required),
@@ -611,7 +614,7 @@ where
 					);
 				}
 				self.event_queue
-					.add_event(Event::PaymentSuccessful { payment_hash })
+					.add_event(Event::PaymentSuccessful { payment_hash, fee_paid_msat })
 					.unwrap_or_else(|e| {
 						log_error!(self.logger, "Failed to push to event queue: {}", e);
 						panic!("Failed to push to event queue");

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -80,6 +80,43 @@ macro_rules! expect_channel_ready_event {
 
 pub(crate) use expect_channel_ready_event;
 
+macro_rules! expect_payment_received_event {
+	($node: expr, $amount_msat: expr) => {{
+		match $node.wait_next_event() {
+			ref e @ Event::PaymentReceived { payment_hash, amount_msat } => {
+				println!("{} got event {:?}", $node.node_id(), e);
+				assert_eq!(amount_msat, $amount_msat);
+				$node.event_handled();
+				let result = Ok(payment_hash);
+				result
+			},
+			ref e => {
+				panic!("{} got unexpected event!: {:?}", std::stringify!(node_b), e);
+			},
+		}
+	}};
+}
+
+pub(crate) use expect_payment_received_event;
+
+macro_rules! expect_payment_successful_event {
+	($node: expr, $payment_hash: expr, $fee_paid_msat: expr) => {{
+		match $node.wait_next_event() {
+			ref e @ Event::PaymentSuccessful { payment_hash, fee_paid_msat } => {
+				println!("{} got event {:?}", $node.node_id(), e);
+				assert_eq!(fee_paid_msat, $fee_paid_msat);
+				assert_eq!(payment_hash, $payment_hash);
+				$node.event_handled();
+			},
+			ref e => {
+				panic!("{} got unexpected event!: {:?}", std::stringify!(node_b), e);
+			},
+		}
+	}};
+}
+
+pub(crate) use expect_payment_successful_event;
+
 pub(crate) fn setup_bitcoind_and_electrsd() -> (BitcoinD, ElectrsD) {
 	let bitcoind_exe =
 		env::var("BITCOIND_EXE").ok().or_else(|| bitcoind::downloaded_exe_path().ok()).expect(


### PR DESCRIPTION
Resolves the first part of #255 adding the paid fee to the `PaymentSuccessful` event. 
