### PR TITLE
Minor follow-up to #271

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -87,8 +87,7 @@ macro_rules! expect_payment_received_event {
 				println!("{} got event {:?}", $node.node_id(), e);
 				assert_eq!(amount_msat, $amount_msat);
 				$node.event_handled();
-				let result = Ok(payment_hash);
-				result
+				payment_hash
 			},
 			ref e => {
 				panic!("{} got unexpected event!: {:?}", std::stringify!(node_b), e);

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -10,7 +10,6 @@ use common::{
 use ldk_node::{Builder, Event, NodeError};
 
 use bitcoin::{Amount, Network};
-use lightning::ln::PaymentHash;
 
 use std::sync::Arc;
 
@@ -135,10 +134,9 @@ fn multi_hop_sending() {
 	let invoice = nodes[4].receive_payment(2_500_000, &"asdf", 9217).unwrap();
 	nodes[0].send_payment(&invoice).unwrap();
 
-	let payment_hash: Result<PaymentHash, ()> =
-		expect_payment_received_event!(&nodes[4], 2_500_000);
+	let payment_hash = expect_payment_received_event!(&nodes[4], 2_500_000);
 	let fee_paid_msat = Some(2000);
-	expect_payment_successful_event!(nodes[0], payment_hash.unwrap(), fee_paid_msat);
+	expect_payment_successful_event!(nodes[0], payment_hash, fee_paid_msat);
 }
 
 #[test]


### PR DESCRIPTION
In #271 we discovered that `common.rs` was at the wrong place in the tree, here we mainly move it to `tests/common/mod.rs` to have Rust ignore it.