### PR TITLE
Pin `reqwest` to fix MSRV builds in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,8 @@ jobs:
           cargo update -p hashlink --precise "0.8.2" --verbose # hashlink 0.8.3 requires hashbrown 0.14, requiring 1.64.0
           cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
           cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
-          cargo update -p home --precise "0.5.5" --verbose # home v0.5.9, requires rustc 1.70 or newer
+          cargo update -p home --precise "0.5.5" --verbose # home v0.5.9 requires rustc 1.70 or newer
+          cargo update -p reqwest --precise "0.11.24" --verbose # reqwest v0.11.25 requires rustc 1.64 or newer
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"


### PR DESCRIPTION
Unfortunately `reqwest` v0.11.25 bumped their `system-configuration` dependency breaking MSRV builds on macOS (cf. https://github.com/seanmonstar/reqwest/issues/2169).

Here, we pin the old `reqwest` version in CI to fix our MSRV builds.