### PR TITLE
Disable `electrum-client` default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ winapi = { version = "0.3", features = ["winbase"] }
 [dev-dependencies]
 lightning = { version = "0.0.121", features = ["std", "_test_utils"] }
 #lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main", features = ["std", "_test_utils"] }
-electrum-client = { version = "0.15.1", default-features = true }
+electrum-client = { version = "0.15.1", default-features = false }
 bitcoincore-rpc = { version = "0.17.0", default-features = false }
 proptest = "1.0.0"
 regex = "1.5.6"


### PR DESCRIPTION
Closes #283.

RUSTSEC-2024-0336 pertains older versions of `rustls` that were used by our dev depedency `electrum-client` in v0.15.1.

As we're blocked from upgrading until LDK supports `rust-bitcoin` 0.31, and we don't use TLS in tests anyways, we just disable the default features for now. We will have to re-enable them once we actually use Electrum syncing though.