### PR TITLE
Skip node ann. broadcast if the public channel isn't ready yet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,8 +580,8 @@ impl Node {
 								continue;
 							}
 
-							if !bcast_cm.list_channels().iter().any(|chan| chan.is_public) {
-								// Skip if we don't have any public channels.
+							if !bcast_cm.list_channels().iter().any(|chan| chan.is_public && chan.is_channel_ready) {
+								// Skip if we don't have any public channels that are ready.
 								continue;
 							}
 


### PR DESCRIPTION
Previously, we'd only skip broadcasting a node announcement if we don't have public channel. However, this could lead to us broadcasting the initial node announcement too early: it would be broadcast after the channel is pending but before it's confirmed and we had a chance to generate and exchange the channel announcement, leading to our counterparty ignoring the node announcement.

Here, we just check that the public channel is actually ready (but don't bother if it's useable) before we trigger the broadcast.

Note that this wouldn't have been a big issue before as we expect announced nodes to be always-online and we'd have rebroadcast the announcement after an hour anyways. However, it can be annoying in testing.