### PR TITLE
Unpin `url`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,6 @@ jobs:
           cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
           cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
           cargo update -p home --precise "0.5.5" --verbose # home v0.5.9 requires rustc 1.70 or newer
-          cargo update -p url --precise "2.5.0" --verbose # url v2.5.1 requires rustc 1.67 or newer
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"


### PR DESCRIPTION
... as the MSRV breakage was fixed with `url` 2.5.2.

This reverts commit 0285b55c84f292da9bc4f3a60e748509fc54bafe.