### PR TITLE
Fix `send_to_address` variable naming in bindings

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -144,7 +144,7 @@ interface OnchainPayment {
 	[Throws=NodeError]
 	Address new_address();
 	[Throws=NodeError]
-	Txid send_to_address([ByRef]Address address, u64 amount_msat);
+	Txid send_to_address([ByRef]Address address, u64 amount_sats);
 	[Throws=NodeError]
 	Txid send_all_to_address([ByRef]Address address);
 };


### PR DESCRIPTION
Fix #332.