### PR TITLE
Fix: added `cfg(cln_test)` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,4 +111,5 @@ check-cfg = [
 	"cfg(vss_test)",
 	"cfg(ldk_bench)",
 	"cfg(tokio_unstable)",
+	"cfg(cln_test)",
 ]


### PR DESCRIPTION
This fixes the unrecognized `cln_test` config, resolving errors in integration tests.