### PR TITLE
Upgrade `download-artifact` action in `publish-jvm.yml`

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -67,7 +67,7 @@ jobs:
           ./scripts/uniffi_bindgen_generate_kotlin.sh
 
       - name: Download macOS native libraries from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           # download the artifact created in the prior job (named "artifact")


### PR DESCRIPTION
While we currently never use these scripts, I still want to keep them around for now.


Given that `download-artifact` currently had a [security advisory](https://github.com/advisories/GHSA-cxww-7g56-2vh6), we now upgrade it to `v4`.