### PR TITLE
Replay events on event handling failures due to persistence failures.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -935,12 +935,13 @@ where
 				}
 			},
 			LdkEvent::SpendableOutputs { outputs, channel_id } => {
-				self.output_sweeper
-					.track_spendable_outputs(outputs, channel_id, true, None)
-					.unwrap_or_else(|_| {
+				match self.output_sweeper.track_spendable_outputs(outputs, channel_id, true, None) {
+					Ok(_) => return Ok(()),
+					Err(_) => {
 						log_error!(self.logger, "Failed to track spendable outputs");
-						panic!("Failed to track spendable outputs");
-					});
+						return Err(ReplayEvent());
+					},
+				};
 			},
 			LdkEvent::OpenChannelRequest {
 				temporary_channel_id,


### PR DESCRIPTION
Handle 3 types of failures mainly:
* Failed to update payment_store due to persistence failure.
* Failed to push ldk_node event to event_queue due to persistence failure.
* Output tracking failure in output_sweeper due to persistence failure.

