### PR TITLE
Add configurable logger

### DIFF
--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -6,7 +6,7 @@
 // accordance with one or both of these licenses.
 
 use crate::config::RGS_SYNC_TIMEOUT_SECS;
-use crate::logger::{log_trace, FilesystemLogger, Logger};
+use crate::logger::{log_trace, LdkNodeLogger, Logger};
 use crate::types::{GossipSync, Graph, P2PGossipSync, RapidGossipSync};
 use crate::Error;
 
@@ -24,12 +24,12 @@ pub(crate) enum GossipSource {
 		gossip_sync: Arc<RapidGossipSync>,
 		server_url: String,
 		latest_sync_timestamp: AtomicU32,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 	},
 }
 
 impl GossipSource {
-	pub fn new_p2p(network_graph: Arc<Graph>, logger: Arc<FilesystemLogger>) -> Self {
+	pub fn new_p2p(network_graph: Arc<Graph>, logger: Arc<LdkNodeLogger>) -> Self {
 		let gossip_sync = Arc::new(P2PGossipSync::new(
 			network_graph,
 			None::<Arc<dyn UtxoLookup + Send + Sync>>,
@@ -40,7 +40,7 @@ impl GossipSource {
 
 	pub fn new_rgs(
 		server_url: String, latest_sync_timestamp: u32, network_graph: Arc<Graph>,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		let gossip_sync = Arc::new(RapidGossipSync::new(network_graph, Arc::clone(&logger)));
 		let latest_sync_timestamp = AtomicU32::new(latest_sync_timestamp);

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -13,7 +13,7 @@ use crate::fee_estimator::OnchainFeeEstimator;
 use crate::io::{
 	NODE_METRICS_KEY, NODE_METRICS_PRIMARY_NAMESPACE, NODE_METRICS_SECONDARY_NAMESPACE,
 };
-use crate::logger::{log_error, FilesystemLogger};
+use crate::logger::{log_error, LdkNodeLogger};
 use crate::peer_store::PeerStore;
 use crate::sweep::DeprecatedSpendableOutputInfo;
 use crate::types::{Broadcaster, DynStore, KeysManager, Sweeper};
@@ -226,7 +226,7 @@ where
 pub(crate) fn read_output_sweeper(
 	broadcaster: Arc<Broadcaster>, fee_estimator: Arc<OnchainFeeEstimator>,
 	chain_data_source: Arc<ChainSource>, keys_manager: Arc<KeysManager>, kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 ) -> Result<Sweeper, std::io::Error> {
 	let mut reader = Cursor::new(kv_store.read(
 		OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
@@ -600,7 +600,7 @@ impl_read_write_change_set_type!(
 
 // Reads the full BdkWalletChangeSet or returns default fields
 pub(crate) fn read_bdk_wallet_change_set(
-	kv_store: Arc<DynStore>, logger: Arc<FilesystemLogger>,
+	kv_store: Arc<DynStore>, logger: Arc<LdkNodeLogger>,
 ) -> Result<Option<BdkWalletChangeSet>, std::io::Error> {
 	let mut change_set = BdkWalletChangeSet::default();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use types::{
 };
 pub use types::{ChannelDetails, PeerDetails, UserChannelId};
 
-use logger::{log_error, log_info, log_trace, FilesystemLogger, Logger};
+use logger::{log_error, log_info, log_trace, LdkNodeLogger, Logger};
 
 use lightning::chain::BestBlock;
 use lightning::events::bump_transaction::Wallet as LdkWallet;
@@ -180,23 +180,23 @@ pub struct Node {
 	wallet: Arc<Wallet>,
 	chain_source: Arc<ChainSource>,
 	tx_broadcaster: Arc<Broadcaster>,
-	event_queue: Arc<EventQueue<Arc<FilesystemLogger>>>,
+	event_queue: Arc<EventQueue<Arc<LdkNodeLogger>>>,
 	channel_manager: Arc<ChannelManager>,
 	chain_monitor: Arc<ChainMonitor>,
 	output_sweeper: Arc<Sweeper>,
 	peer_manager: Arc<PeerManager>,
 	onion_messenger: Arc<OnionMessenger>,
-	connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+	connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 	keys_manager: Arc<KeysManager>,
 	network_graph: Arc<Graph>,
 	gossip_source: Arc<GossipSource>,
-	liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
+	liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
 	kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 	_router: Arc<Router>,
 	scorer: Arc<Mutex<Scorer>>,
-	peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
+	peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
 	is_listening: Arc<AtomicBool>,
 	node_metrics: Arc<RwLock<NodeMetrics>>,
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -12,19 +12,50 @@ use lightning::util::logger::{Level, Record};
 
 use chrono::Utc;
 
+use std::fmt::Debug;
 use std::fs;
 use std::io::Write;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::symlink;
 use std::path::Path;
+use std::sync::Mutex;
 
-pub(crate) struct LdkNodeLogger {
-	file_path: String,
+pub struct LdkNodeLogger {
 	level: Level,
+	formatter: Box<dyn Fn(&Record) -> String + Send + Sync>,
+	writer: Box<dyn Fn(&String) + Send + Sync>,
 }
 
 impl LdkNodeLogger {
-	pub(crate) fn new(log_dir: String, level: Level) -> Result<Self, ()> {
+	pub fn new(
+		level: Level, formatter: Box<dyn Fn(&Record) -> String + Send + Sync>,
+		writer: Box<dyn Fn(&String) + Send + Sync>,
+	) -> Result<Self, ()> {
+		Ok(Self { level, formatter, writer })
+	}
+}
+
+impl Debug for LdkNodeLogger {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "LdkNodeLogger level: {}", self.level)
+	}
+}
+
+impl Logger for LdkNodeLogger {
+	fn log(&self, record: Record) {
+		if record.level < self.level {
+			return;
+		}
+		(self.writer)(&(self.formatter)(&record))
+	}
+}
+
+pub(crate) struct FilesystemLogWriter {
+	log_file: Mutex<fs::File>,
+}
+
+impl FilesystemLogWriter {
+	pub fn new(log_dir: String) -> Result<Self, ()> {
 		let log_file_name =
 			format!("ldk_node_{}.log", chrono::offset::Local::now().format("%Y_%m_%d"));
 		let log_file_path = format!("{}/{}", log_dir, log_file_name);
@@ -53,29 +84,33 @@ impl LdkNodeLogger {
 			}
 		}
 
-		Ok(Self { file_path: log_file_path, level })
-	}
-}
-impl Logger for LdkNodeLogger {
-	fn log(&self, record: Record) {
-		if record.level < self.level {
-			return;
-		}
-		let raw_log = record.args.to_string();
-		let log = format!(
-			"{} {:<5} [{}:{}] {}\n",
-			Utc::now().format("%Y-%m-%d %H:%M:%S"),
-			record.level.to_string(),
-			record.module_path,
-			record.line,
-			raw_log
+		let log_file = Mutex::new(
+			fs::OpenOptions::new()
+				.create(true)
+				.append(true)
+				.open(log_file_path.clone())
+				.map_err(|e| eprintln!("ERROR: Failed to open log file: {}", e))?,
 		);
-		fs::OpenOptions::new()
-			.create(true)
-			.append(true)
-			.open(self.file_path.clone())
-			.expect("Failed to open log file")
+		Ok(Self { log_file })
+	}
+
+	pub fn write(&self, log: &String) {
+		self.log_file
+			.lock()
+			.expect("log file lock poisoned")
 			.write_all(log.as_bytes())
 			.expect("Failed to write to log file")
 	}
+}
+
+pub(crate) fn default_format(record: &Record) -> String {
+	let raw_log = record.args.to_string();
+	format!(
+		"{} {:<5} [{}:{}] {}\n",
+		Utc::now().format("%Y-%m-%d %H:%M:%S"),
+		record.level.to_string(),
+		record.module_path,
+		record.line,
+		raw_log
+	)
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -18,12 +18,12 @@ use std::io::Write;
 use std::os::unix::fs::symlink;
 use std::path::Path;
 
-pub(crate) struct FilesystemLogger {
+pub(crate) struct LdkNodeLogger {
 	file_path: String,
 	level: Level,
 }
 
-impl FilesystemLogger {
+impl LdkNodeLogger {
 	pub(crate) fn new(log_dir: String, level: Level) -> Result<Self, ()> {
 		let log_file_name =
 			format!("ldk_node_{}.log", chrono::offset::Local::now().format("%Y_%m_%d"));
@@ -56,7 +56,7 @@ impl FilesystemLogger {
 		Ok(Self { file_path: log_file_path, level })
 	}
 }
-impl Logger for FilesystemLogger {
+impl Logger for LdkNodeLogger {
 	fn log(&self, record: Record) {
 		if record.level < self.level {
 			return;

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -13,7 +13,7 @@ use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::connection::ConnectionManager;
 use crate::error::Error;
 use crate::liquidity::LiquiditySource;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	LSPFeeLimits, PaymentDetails, PaymentDetailsUpdate, PaymentDirection, PaymentKind,
 	PaymentStatus, PaymentStore,
@@ -48,25 +48,25 @@ use std::time::SystemTime;
 pub struct Bolt11Payment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
-	connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+	connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 	keys_manager: Arc<KeysManager>,
-	liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-	peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>,
+	liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+	peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl Bolt11Payment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 		channel_manager: Arc<ChannelManager>,
-		connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+		connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 		keys_manager: Arc<KeysManager>,
-		liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-		peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>, config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
+		payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+		peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>, config: Arc<Config>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self {
 			runtime,

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -11,7 +11,7 @@
 
 use crate::config::LDK_PAYMENT_RETRY_TIMEOUT;
 use crate::error::Error;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, PaymentStore,
 };
@@ -39,15 +39,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub struct Bolt12Payment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-	logger: Arc<FilesystemLogger>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl Bolt12Payment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
-		channel_manager: Arc<ChannelManager>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>, logger: Arc<FilesystemLogger>,
+		channel_manager: Arc<ChannelManager>, payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, channel_manager, payment_store, logger }
 	}

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -9,7 +9,7 @@
 
 use crate::config::Config;
 use crate::error::Error;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::types::{ChannelManager, Wallet};
 
 use bitcoin::{Address, Amount, Txid};
@@ -26,13 +26,13 @@ pub struct OnchainPayment {
 	wallet: Arc<Wallet>,
 	channel_manager: Arc<ChannelManager>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl OnchainPayment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>, wallet: Arc<Wallet>,
-		channel_manager: Arc<ChannelManager>, config: Arc<Config>, logger: Arc<FilesystemLogger>,
+		channel_manager: Arc<ChannelManager>, config: Arc<Config>, logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, wallet, channel_manager, config, logger }
 	}

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -9,7 +9,7 @@
 
 use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::error::Error;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, PaymentStore,
 };
@@ -37,17 +37,17 @@ pub struct SpontaneousPayment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
 	keys_manager: Arc<KeysManager>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl SpontaneousPayment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 		channel_manager: Arc<ChannelManager>, keys_manager: Arc<KeysManager>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>, config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>, config: Arc<Config>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, channel_manager, keys_manager, payment_store, config, logger }
 	}

--- a/src/payment/unified_qr.rs
+++ b/src/payment/unified_qr.rs
@@ -12,7 +12,7 @@
 //! [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 //! [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
 use crate::error::Error;
-use crate::logger::{log_error, FilesystemLogger, Logger};
+use crate::logger::{log_error, LdkNodeLogger, Logger};
 use crate::payment::{Bolt11Payment, Bolt12Payment, OnchainPayment};
 use crate::Config;
 
@@ -50,13 +50,13 @@ pub struct UnifiedQrPayment {
 	bolt11_invoice: Arc<Bolt11Payment>,
 	bolt12_payment: Arc<Bolt12Payment>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl UnifiedQrPayment {
 	pub(crate) fn new(
 		onchain_payment: Arc<OnchainPayment>, bolt11_invoice: Arc<Bolt11Payment>,
-		bolt12_payment: Arc<Bolt12Payment>, config: Arc<Config>, logger: Arc<FilesystemLogger>,
+		bolt12_payment: Arc<Bolt12Payment>, config: Arc<Config>, logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { onchain_payment, bolt11_invoice, bolt12_payment, config, logger }
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@
 use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
 use crate::fee_estimator::OnchainFeeEstimator;
-use crate::logger::FilesystemLogger;
+use crate::logger::LdkNodeLogger;
 use crate::message_handler::NodeCustomMessageHandler;
 
 use lightning::chain::chainmonitor;
@@ -38,7 +38,7 @@ pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
 	Arc<ChainSource>,
 	Arc<Broadcaster>,
 	Arc<OnchainFeeEstimator>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<DynStore>,
 >;
 
@@ -47,8 +47,8 @@ pub(crate) type PeerManager = lightning::ln::peer_handler::PeerManager<
 	Arc<ChannelManager>,
 	Arc<dyn RoutingMessageHandler + Send + Sync>,
 	Arc<OnionMessenger>,
-	Arc<FilesystemLogger>,
-	Arc<NodeCustomMessageHandler<Arc<FilesystemLogger>>>,
+	Arc<LdkNodeLogger>,
+	Arc<NodeCustomMessageHandler<Arc<LdkNodeLogger>>>,
 	Arc<KeysManager>,
 >;
 
@@ -63,51 +63,51 @@ pub(crate) type ChannelManager = lightning::ln::channelmanager::ChannelManager<
 	Arc<KeysManager>,
 	Arc<OnchainFeeEstimator>,
 	Arc<Router>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
-pub(crate) type Broadcaster = crate::tx_broadcaster::TransactionBroadcaster<Arc<FilesystemLogger>>;
+pub(crate) type Broadcaster = crate::tx_broadcaster::TransactionBroadcaster<Arc<LdkNodeLogger>>;
 
 pub(crate) type Wallet =
-	crate::wallet::Wallet<Arc<Broadcaster>, Arc<OnchainFeeEstimator>, Arc<FilesystemLogger>>;
+	crate::wallet::Wallet<Arc<Broadcaster>, Arc<OnchainFeeEstimator>, Arc<LdkNodeLogger>>;
 
 pub(crate) type KeysManager = crate::wallet::WalletKeysManager<
 	Arc<Broadcaster>,
 	Arc<OnchainFeeEstimator>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
 pub(crate) type Router = DefaultRouter<
 	Arc<Graph>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 	Arc<Mutex<Scorer>>,
 	ProbabilisticScoringFeeParameters,
 	Scorer,
 >;
-pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<FilesystemLogger>>;
+pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<LdkNodeLogger>>;
 
-pub(crate) type Graph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
+pub(crate) type Graph = gossip::NetworkGraph<Arc<LdkNodeLogger>>;
 
 pub(crate) type UtxoLookup = dyn lightning::routing::utxo::UtxoLookup + Send + Sync;
 
 pub(crate) type P2PGossipSync =
-	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<FilesystemLogger>>;
+	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<LdkNodeLogger>>;
 pub(crate) type RapidGossipSync =
-	lightning_rapid_gossip_sync::RapidGossipSync<Arc<Graph>, Arc<FilesystemLogger>>;
+	lightning_rapid_gossip_sync::RapidGossipSync<Arc<Graph>, Arc<LdkNodeLogger>>;
 
 pub(crate) type GossipSync = lightning_background_processor::GossipSync<
 	Arc<P2PGossipSync>,
 	Arc<RapidGossipSync>,
 	Arc<Graph>,
 	Arc<UtxoLookup>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
 pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMessenger<
 	Arc<KeysManager>,
 	Arc<KeysManager>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<ChannelManager>,
 	Arc<MessageRouter>,
 	Arc<ChannelManager>,
@@ -117,7 +117,7 @@ pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMesse
 
 pub(crate) type MessageRouter = lightning::onion_message::messenger::DefaultMessageRouter<
 	Arc<Graph>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 >;
 
@@ -127,16 +127,16 @@ pub(crate) type Sweeper = OutputSweeper<
 	Arc<OnchainFeeEstimator>,
 	Arc<ChainSource>,
 	Arc<DynStore>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 >;
 
 pub(crate) type BumpTransactionEventHandler =
 	lightning::events::bump_transaction::BumpTransactionEventHandler<
 		Arc<Broadcaster>,
-		Arc<lightning::events::bump_transaction::Wallet<Arc<Wallet>, Arc<FilesystemLogger>>>,
+		Arc<lightning::events::bump_transaction::Wallet<Arc<Wallet>, Arc<LdkNodeLogger>>>,
 		Arc<KeysManager>,
-		Arc<FilesystemLogger>,
+		Arc<LdkNodeLogger>,
 	>;
 
 /// A local, potentially user-provided, identifier of a channel.

--- a/src/wallet/persist.rs
+++ b/src/wallet/persist.rs
@@ -10,7 +10,7 @@ use crate::io::utils::{
 	write_bdk_wallet_indexer, write_bdk_wallet_local_chain, write_bdk_wallet_network,
 	write_bdk_wallet_tx_graph,
 };
-use crate::logger::{log_error, FilesystemLogger};
+use crate::logger::{log_error, LdkNodeLogger};
 use crate::types::DynStore;
 
 use lightning::util::logger::Logger;
@@ -22,11 +22,11 @@ use std::sync::Arc;
 pub(crate) struct KVStoreWalletPersister {
 	latest_change_set: Option<ChangeSet>,
 	kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl KVStoreWalletPersister {
-	pub(crate) fn new(kv_store: Arc<DynStore>, logger: Arc<FilesystemLogger>) -> Self {
+	pub(crate) fn new(kv_store: Arc<DynStore>, logger: Arc<LdkNodeLogger>) -> Self {
 		Self { latest_change_set: None, kv_store, logger }
 	}
 }


### PR DESCRIPTION
## Description

Adds logger configuration to `ldk-node`.

## Motivation

The first impulse for this was to be able to write to stdout, as that's more desirable for some containerized infrastructure. But rather than add a specific stdout implementation, we thought it better to make this extensible to write to arbitrary destinations (for example, a network log ingester). This additionally has the benefit of letting you customize how the writing happens; for example the `tracing-appender` crate uses an `mpsc` for writers, with a single thread performing all the actual I/O off of the queue.

## Details

The PR has three commits:

   - [Rename FilesystemLogger to LdkNodeLogger.](https://github.com/lightningdevkit/ldk-node/pull/393/commits/4f82769974241f2b7ca8b233f128f02194a2a4f2) This renames the logger to an implementation-agnostic name. Hopefully this commit is easy to ignore when reviewing implementation.
   - [Make LdkNodeLogger technically customizable, retain default behavior.](https://github.com/lightningdevkit/ldk-node/pull/393/commits/2c54a18c5b74c654651d7e70bcf206c126b47aa2) This sets up the configurable logger, and then statically configures it to retain the existing behavior.
   - [Add customizable logging to configuration.](https://github.com/lightningdevkit/ldk-node/pull/393/commits/b0e7fef9098aee27622234a01604a9249ba38d03) This adds configuration points to the `Config` struct itself. Users of the `::default()` configuration should see no change in behavior.