### PR TITLE
chore: update rusqlite 0.28.0 -> 0.32.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ bdk_esplora = { version = "=0.18.0", default-features = false, features = ["asyn
 bdk_wallet = { version = "=1.0.0-beta.4", default-features = false, features = ["std", "keys-bip39"]}
 
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
-rusqlite = { version = "0.28.0", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 bitcoin = "0.32.2"
 bip39 = "2.0.0"
 bip21 = { version = "0.5", features = ["std"], default-features = false }


### PR DESCRIPTION
rusqlite 0.28 is 2 years old at this point, and since cargo allows only one version of native dependencies, this creates conflicts with other dependencies that want to use sqlite.