### PR TITLE
feat: add customizable logging system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ libc = "0.2"
 uniffi = { version = "0.27.3", features = ["build"], optional = true }
 serde = { version = "1.0.210", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.128", default-features = false, features = ["std"] }
-
+log = { version = "0.4.22" }
 vss-client = "0.3"
 prost = { version = "0.11.6", default-features = false}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ panic = 'abort'     # Abort on panic
 
 [features]
 default = []
+log_relay = ["log"]
 
 [dependencies]
 lightning = { version = "0.0.125", features = ["std"] }
@@ -75,7 +76,7 @@ libc = "0.2"
 uniffi = { version = "0.27.3", features = ["build"], optional = true }
 serde = { version = "1.0.210", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.128", default-features = false, features = ["std"] }
-log = { version = "0.4.22" }
+log = { version = "0.4.22", optional = true}
 vss-client = "0.3"
 prost = { version = "0.11.6", default-features = false}
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -21,7 +21,7 @@ use crate::fee_estimator::{
 	ConfirmationTarget, OnchainFeeEstimator,
 };
 use crate::io::utils::write_node_metrics;
-use crate::logger::{log_bytes, log_error, log_info, log_trace, FilesystemLogger, Logger};
+use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkNodeLogger, Logger};
 use crate::types::{Broadcaster, ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
 
@@ -112,13 +112,13 @@ pub(crate) enum ChainSource {
 		esplora_client: EsploraAsyncClient,
 		onchain_wallet: Arc<Wallet>,
 		onchain_wallet_sync_status: Mutex<WalletSyncStatus>,
-		tx_sync: Arc<EsploraSyncClient<Arc<FilesystemLogger>>>,
+		tx_sync: Arc<EsploraSyncClient<Arc<LdkNodeLogger>>>,
 		lightning_wallet_sync_status: Mutex<WalletSyncStatus>,
 		fee_estimator: Arc<OnchainFeeEstimator>,
 		tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>,
 		config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
 	},
 	BitcoindRpc {
@@ -131,7 +131,7 @@ pub(crate) enum ChainSource {
 		tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>,
 		config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
 	},
 }
@@ -140,7 +140,7 @@ impl ChainSource {
 	pub(crate) fn new_esplora(
 		server_url: String, sync_config: EsploraSyncConfig, onchain_wallet: Arc<Wallet>,
 		fee_estimator: Arc<OnchainFeeEstimator>, tx_broadcaster: Arc<Broadcaster>,
-		kv_store: Arc<DynStore>, config: Arc<Config>, logger: Arc<FilesystemLogger>,
+		kv_store: Arc<DynStore>, config: Arc<Config>, logger: Arc<LdkNodeLogger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
 	) -> Self {
 		let mut client_builder = esplora_client::Builder::new(&server_url);
@@ -170,7 +170,7 @@ impl ChainSource {
 		host: String, port: u16, rpc_user: String, rpc_password: String,
 		onchain_wallet: Arc<Wallet>, fee_estimator: Arc<OnchainFeeEstimator>,
 		tx_broadcaster: Arc<Broadcaster>, kv_store: Arc<DynStore>, config: Arc<Config>,
-		logger: Arc<FilesystemLogger>, node_metrics: Arc<RwLock<NodeMetrics>>,
+		logger: Arc<LdkNodeLogger>, node_metrics: Arc<RwLock<NodeMetrics>>,
 	) -> Self {
 		let bitcoind_rpc_client =
 			Arc::new(BitcoindRpcClient::new(host, port, rpc_user, rpc_password));
@@ -1123,7 +1123,7 @@ impl Filter for ChainSource {
 
 fn periodically_archive_fully_resolved_monitors(
 	channel_manager: Arc<ChannelManager>, chain_monitor: Arc<ChainMonitor>,
-	kv_store: Arc<DynStore>, logger: Arc<FilesystemLogger>, node_metrics: Arc<RwLock<NodeMetrics>>,
+	kv_store: Arc<DynStore>, logger: Arc<LdkNodeLogger>, node_metrics: Arc<RwLock<NodeMetrics>>,
 ) -> Result<(), Error> {
 	let mut locked_node_metrics = node_metrics.write().unwrap();
 	let cur_height = channel_manager.current_best_block().height;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@
 
 //! Objects for configuring the node.
 
+use crate::logger::LdkNodeLogger;
 use crate::payment::SendingParameters;
 
 use lightning::ln::msgs::SocketAddress;
@@ -108,6 +109,9 @@ pub struct Config {
 	/// If set to `None`, logs can be found in `ldk_node.log` in the [`Config::storage_dir_path`]
 	/// directory.
 	pub log_file_path: Option<String>,
+	/// In the default configuration logs can be found in the `logs` subdirectory in
+	/// [`Config::storage_dir_path`], and the log level is set to [`DEFAULT_LOG_LEVEL`].
+	pub logging_config: LoggingConfig,
 	/// The used Bitcoin network.
 	pub network: Network,
 	/// The addresses on which the node will listen for incoming connections.
@@ -133,10 +137,6 @@ pub struct Config {
 	/// Channels with available liquidity less than the required amount times this value won't be
 	/// used to send pre-flight probes.
 	pub probing_liquidity_limit_multiplier: u64,
-	/// The level at which we log messages.
-	///
-	/// Any messages below this level will be excluded from the logs.
-	pub log_level: LogLevel,
 	/// Configuration options pertaining to Anchor channels, i.e., channels for which the
 	/// `option_anchors_zero_fee_htlc_tx` channel type is negotiated.
 	///
@@ -169,14 +169,42 @@ impl Default for Config {
 		Self {
 			storage_dir_path: DEFAULT_STORAGE_DIR_PATH.to_string(),
 			log_file_path: None,
+			logging_config: LoggingConfig::default(),
 			network: DEFAULT_NETWORK,
 			listening_addresses: None,
 			trusted_peers_0conf: Vec::new(),
 			probing_liquidity_limit_multiplier: DEFAULT_PROBING_LIQUIDITY_LIMIT_MULTIPLIER,
-			log_level: DEFAULT_LOG_LEVEL,
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			sending_parameters: None,
 			node_alias: None,
+		}
+	}
+}
+
+/// Configuration options for logging.
+#[derive(Debug, Clone)]
+pub enum LoggingConfig {
+	/// An opinionated filesystem logger.
+	///
+	/// This logger will always write at `{log_dir}/ldk_node_latest.log`, which is a symlink to the
+	/// most recent log file, which is created and timestamped at initialization.
+	Filesystem {
+		/// The absolute path where logs are stored.
+		log_dir: String,
+		/// The level at which we log messages.
+		///
+		/// Any messages below this level will be excluded from the logs.
+		log_level: LogLevel,
+	},
+	/// A custom logger.
+	Custom(std::sync::Arc<LdkNodeLogger>),
+}
+
+impl Default for LoggingConfig {
+	fn default() -> Self {
+		Self::Filesystem {
+			log_dir: format!("{}/{}", DEFAULT_STORAGE_DIR_PATH, "logs"),
+			log_level: DEFAULT_LOG_LEVEL,
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use bitcoin::Network;
 use std::time::Duration;
 
 // Config defaults
-const DEFAULT_STORAGE_DIR_PATH: &str = "/tmp/ldk_node/";
+const DEFAULT_STORAGE_DIR_PATH: &str = "/tmp/ldk_node";
 const DEFAULT_NETWORK: Network = Network::Bitcoin;
 const DEFAULT_BDK_WALLET_SYNC_INTERVAL_SECS: u64 = 80;
 const DEFAULT_LDK_WALLET_SYNC_INTERVAL_SECS: u64 = 30;
@@ -104,12 +104,7 @@ pub(crate) const WALLET_KEYS_SEED_LEN: usize = 64;
 pub struct Config {
 	/// The path where the underlying LDK and BDK persist their data.
 	pub storage_dir_path: String,
-	/// The path where logs are stored.
-	///
-	/// If set to `None`, logs can be found in `ldk_node.log` in the [`Config::storage_dir_path`]
-	/// directory.
-	pub log_file_path: Option<String>,
-	/// In the default configuration logs can be found in the `logs` subdirectory in
+	/// In the default configuration logs can be found in the [`DEFAULT_STORAGE_DIR_PATH`] subdirectory in
 	/// [`Config::storage_dir_path`], and the log level is set to [`DEFAULT_LOG_LEVEL`].
 	pub logging_config: LoggingConfig,
 	/// The used Bitcoin network.
@@ -168,7 +163,6 @@ impl Default for Config {
 	fn default() -> Self {
 		Self {
 			storage_dir_path: DEFAULT_STORAGE_DIR_PATH.to_string(),
-			log_file_path: None,
 			logging_config: LoggingConfig::default(),
 			network: DEFAULT_NETWORK,
 			listening_addresses: None,
@@ -190,7 +184,7 @@ pub enum LoggingConfig {
 	/// most recent log file, which is created and timestamped at initialization.
 	Filesystem {
 		/// The absolute path where logs are stored.
-		log_dir: String,
+		log_file_path: String,
 		/// The level at which we log messages.
 		///
 		/// Any messages below this level will be excluded from the logs.
@@ -203,7 +197,7 @@ pub enum LoggingConfig {
 impl Default for LoggingConfig {
 	fn default() -> Self {
 		Self::Filesystem {
-			log_dir: format!("{}/{}", DEFAULT_STORAGE_DIR_PATH, "logs"),
+			log_file_path: format!("{}/{}", DEFAULT_STORAGE_DIR_PATH, "ldk_node.log"),
 			log_level: DEFAULT_LOG_LEVEL,
 		}
 	}

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -6,7 +6,7 @@
 // accordance with one or both of these licenses.
 
 use crate::config::RGS_SYNC_TIMEOUT_SECS;
-use crate::logger::{log_trace, FilesystemLogger, Logger};
+use crate::logger::{log_trace, LdkNodeLogger, Logger};
 use crate::types::{GossipSync, Graph, P2PGossipSync, RapidGossipSync};
 use crate::Error;
 
@@ -24,12 +24,12 @@ pub(crate) enum GossipSource {
 		gossip_sync: Arc<RapidGossipSync>,
 		server_url: String,
 		latest_sync_timestamp: AtomicU32,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 	},
 }
 
 impl GossipSource {
-	pub fn new_p2p(network_graph: Arc<Graph>, logger: Arc<FilesystemLogger>) -> Self {
+	pub fn new_p2p(network_graph: Arc<Graph>, logger: Arc<LdkNodeLogger>) -> Self {
 		let gossip_sync = Arc::new(P2PGossipSync::new(
 			network_graph,
 			None::<Arc<dyn UtxoLookup + Send + Sync>>,
@@ -40,7 +40,7 @@ impl GossipSource {
 
 	pub fn new_rgs(
 		server_url: String, latest_sync_timestamp: u32, network_graph: Arc<Graph>,
-		logger: Arc<FilesystemLogger>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		let gossip_sync = Arc::new(RapidGossipSync::new(network_graph, Arc::clone(&logger)));
 		let latest_sync_timestamp = AtomicU32::new(latest_sync_timestamp);

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -13,7 +13,7 @@ use crate::fee_estimator::OnchainFeeEstimator;
 use crate::io::{
 	NODE_METRICS_KEY, NODE_METRICS_PRIMARY_NAMESPACE, NODE_METRICS_SECONDARY_NAMESPACE,
 };
-use crate::logger::{log_error, FilesystemLogger};
+use crate::logger::{log_error, LdkNodeLogger};
 use crate::peer_store::PeerStore;
 use crate::sweep::DeprecatedSpendableOutputInfo;
 use crate::types::{Broadcaster, DynStore, KeysManager, Sweeper};
@@ -226,7 +226,7 @@ where
 pub(crate) fn read_output_sweeper(
 	broadcaster: Arc<Broadcaster>, fee_estimator: Arc<OnchainFeeEstimator>,
 	chain_data_source: Arc<ChainSource>, keys_manager: Arc<KeysManager>, kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 ) -> Result<Sweeper, std::io::Error> {
 	let mut reader = Cursor::new(kv_store.read(
 		OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
@@ -600,7 +600,7 @@ impl_read_write_change_set_type!(
 
 // Reads the full BdkWalletChangeSet or returns default fields
 pub(crate) fn read_bdk_wallet_change_set(
-	kv_store: Arc<DynStore>, logger: Arc<FilesystemLogger>,
+	kv_store: Arc<DynStore>, logger: Arc<LdkNodeLogger>,
 ) -> Result<Option<BdkWalletChangeSet>, std::io::Error> {
 	let mut change_set = BdkWalletChangeSet::default();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ use types::{
 };
 pub use types::{ChannelDetails, PeerDetails, UserChannelId};
 
-use logger::{log_error, log_info, log_trace, FilesystemLogger, Logger};
+use logger::{log_error, log_info, log_trace, LdkNodeLogger, Logger};
 
 use lightning::chain::BestBlock;
 use lightning::events::bump_transaction::Wallet as LdkWallet;
@@ -180,23 +180,23 @@ pub struct Node {
 	wallet: Arc<Wallet>,
 	chain_source: Arc<ChainSource>,
 	tx_broadcaster: Arc<Broadcaster>,
-	event_queue: Arc<EventQueue<Arc<FilesystemLogger>>>,
+	event_queue: Arc<EventQueue<Arc<LdkNodeLogger>>>,
 	channel_manager: Arc<ChannelManager>,
 	chain_monitor: Arc<ChainMonitor>,
 	output_sweeper: Arc<Sweeper>,
 	peer_manager: Arc<PeerManager>,
 	onion_messenger: Arc<OnionMessenger>,
-	connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+	connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 	keys_manager: Arc<KeysManager>,
 	network_graph: Arc<Graph>,
 	gossip_source: Arc<GossipSource>,
-	liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
+	liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
 	kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 	_router: Arc<Router>,
 	scorer: Arc<Mutex<Scorer>>,
-	peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
+	peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
 	is_listening: Arc<AtomicBool>,
 	node_metrics: Arc<RwLock<NodeMetrics>>,
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -11,23 +11,113 @@ pub(crate) use lightning::{log_bytes, log_debug, log_error, log_info, log_trace}
 use lightning::util::logger::{Level, Record};
 
 use chrono::Utc;
+use log::{debug, error, info, trace, warn};
 
 use std::fmt::Debug;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use crate::config::{FormatterConfig, WriterType};
+
+/// [`LogWriter`] trait to write/forward/relay logs to different destinations
+/// such as the filesystem, and other loggers.
+pub trait LogWriter: Debug + Send + Sync {
+	/// Write log to destination.
+	fn write(&self, level: Level, message: &str);
+}
+
+/// [`LdkNodeLogger`] writer variants.
+#[derive(Debug)]
+pub enum Writer {
+	/// Writes logs to filesystem.
+	FileWriter { log_file: Mutex<fs::File> },
+	/// Relays logs to [`log`] logger.
+	LogRelayWriter,
+	/// Forwards logs to a custom logger.
+	CustomWriter { inner: Arc<dyn LogWriter + Send + Sync> },
+}
+
+impl Writer {
+	/// Creates a new writer given the writer's type.
+	pub fn new(writer_type: &WriterType) -> Result<Self, ()> {
+		match &writer_type {
+			// Initial logic for Writer that writes directly to a
+			// specified file on the filesystem.
+			WriterType::File(file_writer_config) => {
+				let log_file_path = &file_writer_config.log_file_path;
+				if let Some(parent_dir) = Path::new(log_file_path).parent() {
+					fs::create_dir_all(parent_dir).map_err(|e| {
+						eprintln!("ERROR: Failed to create log file directory: {}", e);
+						()
+					})?;
+				}
+
+				let log_file = Mutex::new(
+					fs::OpenOptions::new().create(true).append(true).open(&log_file_path).map_err(
+						|e| {
+							eprintln!("ERROR: Failed to open log file: {}", e);
+							()
+						},
+					)?,
+				);
+				let writer = Writer::FileWriter { log_file };
+
+				Ok(writer)
+			},
+			// Initial logic for Writer that forwards to any logger that
+			// implements the `log` facade.
+			WriterType::LogRelay(_log_relay_writer_config) => Ok(Writer::LogRelayWriter),
+			// Initial logic for Writer that forwards to any custom logger.
+			WriterType::Custom(custom_writer_config) => {
+				Ok(Writer::CustomWriter { inner: custom_writer_config.inner.clone() })
+			},
+		}
+	}
+}
+
+impl LogWriter for Writer {
+	fn write(&self, level: Level, message: &str) {
+		match self {
+			Writer::FileWriter { log_file } => log_file
+				.lock()
+				.expect("log file lock poisoned")
+				.write_all(message.as_bytes())
+				.expect("Failed to write to log file"),
+			Writer::LogRelayWriter => match level {
+				Level::Gossip => {
+					// trace!(..) used for gossip logs here.
+					trace!("{message}")
+				},
+				Level::Trace => trace!("{message}"),
+				Level::Debug => debug!("{message}"),
+				Level::Info => info!("{message}"),
+				Level::Warn => warn!("{message}"),
+				Level::Error => error!("{message}"),
+			},
+			Writer::CustomWriter { inner } => {
+				inner.write(level, message);
+			},
+		}
+	}
+}
+
+pub type Formatter = Box<dyn Fn(&Record) -> String + Send + Sync>;
+
+/// Logger for LDK Node.
 pub struct LdkNodeLogger {
+	/// Specifies the log level.
 	level: Level,
-	formatter: Box<dyn Fn(&Record) -> String + Send + Sync>,
-	writer: Box<dyn Fn(&String) + Send + Sync>,
+	/// Specifies the logger's formatter.
+	formatter: Formatter,
+	/// Specifies the logger's writer.
+	writer: Writer,
 }
 
 impl LdkNodeLogger {
 	pub fn new(
-		level: Level, formatter: Box<dyn Fn(&Record) -> String + Send + Sync>,
-		writer: Box<dyn Fn(&String) + Send + Sync>,
+		level: Level, formatter: Box<dyn Fn(&Record) -> String + Send + Sync>, writer: Writer,
 	) -> Result<Self, ()> {
 		Ok(Self { level, formatter, writer })
 	}
@@ -44,51 +134,45 @@ impl Logger for LdkNodeLogger {
 		if record.level < self.level {
 			return;
 		}
-		(self.writer)(&(self.formatter)(&record))
+		let message = (self.formatter)(&record);
+		self.writer.write(self.level, &message)
 	}
 }
 
-pub(crate) struct FileWriter {
-	log_file: Mutex<fs::File>,
-}
+/// Builds a formatter given the formatter's configuration options.
+pub(crate) fn build_formatter(formatter_config: FormatterConfig) -> Formatter {
+	let fn_closure = move |record: &Record| {
+		let raw_log = record.args.to_string();
 
-impl FileWriter {
-	/// Creates a new filesystem writer.
-	pub(crate) fn new(log_file_path: String) -> Result<Self, ()> {
-		if let Some(parent_dir) = Path::new(&log_file_path).parent() {
-			fs::create_dir_all(parent_dir).map_err(|e| {
-				eprintln!("ERROR: Failed to create log file directory: {}", e);
-				()
-			})?;
-		}
+		let ts_format = formatter_config.timestamp_format.as_deref().unwrap_or("%Y-%m-%d %H:%M:%S");
 
-		let log_file = Mutex::new(
-			fs::OpenOptions::new().create(true).append(true).open(&log_file_path).map_err(|e| {
-				eprintln!("ERROR: Failed to open log file: {}", e);
-				()
-			})?,
-		);
+		let msg_tmpl = formatter_config
+			.message_template
+			.as_deref()
+			.unwrap_or("{timestamp} {level:<5} [{module_path}:{line}] {message}\n");
 
-		Ok(Self { log_file })
-	}
+		let timestamp = if formatter_config.include_timestamp {
+			Utc::now().format(&ts_format).to_string()
+		} else {
+			String::new()
+		};
 
-	pub fn write(&self, log: &String) {
-		self.log_file
-			.lock()
-			.expect("log file lock poisoned")
-			.write_all(log.as_bytes())
-			.expect("Failed to write to log file")
-	}
-}
+		let level = if formatter_config.include_level {
+			format!("{:<5}", record.level)
+		} else {
+			String::new()
+		};
 
-pub(crate) fn default_format(record: &Record) -> String {
-	let raw_log = record.args.to_string();
-	format!(
-		"{} {:<5} [{}:{}] {}\n",
-		Utc::now().format("%Y-%m-%d %H:%M:%S"),
-		record.level.to_string(),
-		record.module_path,
-		record.line,
-		raw_log
-	)
+		let mut log = msg_tmpl.to_string();
+		log = log
+			.replace("{timestamp}", &timestamp)
+			.replace("{level}", &level)
+			.replace("{module_path}", &record.module_path)
+			.replace("{line}", &format!("{}", record.line))
+			.replace("{message}", &raw_log);
+
+		log
+	};
+
+	Box::new(fn_closure)
 }

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -13,7 +13,7 @@ use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::connection::ConnectionManager;
 use crate::error::Error;
 use crate::liquidity::LiquiditySource;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	LSPFeeLimits, PaymentDetails, PaymentDetailsUpdate, PaymentDirection, PaymentKind,
 	PaymentStatus, PaymentStore,
@@ -48,25 +48,25 @@ use std::time::SystemTime;
 pub struct Bolt11Payment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
-	connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+	connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 	keys_manager: Arc<KeysManager>,
-	liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-	peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>,
+	liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+	peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl Bolt11Payment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 		channel_manager: Arc<ChannelManager>,
-		connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
+		connection_manager: Arc<ConnectionManager<Arc<LdkNodeLogger>>>,
 		keys_manager: Arc<KeysManager>,
-		liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-		peer_store: Arc<PeerStore<Arc<FilesystemLogger>>>, config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		liquidity_source: Option<Arc<LiquiditySource<Arc<LdkNodeLogger>>>>,
+		payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+		peer_store: Arc<PeerStore<Arc<LdkNodeLogger>>>, config: Arc<Config>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self {
 			runtime,

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -11,7 +11,7 @@
 
 use crate::config::LDK_PAYMENT_RETRY_TIMEOUT;
 use crate::error::Error;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, PaymentStore,
 };
@@ -39,15 +39,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub struct Bolt12Payment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
-	logger: Arc<FilesystemLogger>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl Bolt12Payment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
-		channel_manager: Arc<ChannelManager>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>, logger: Arc<FilesystemLogger>,
+		channel_manager: Arc<ChannelManager>, payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, channel_manager, payment_store, logger }
 	}

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -9,7 +9,7 @@
 
 use crate::config::Config;
 use crate::error::Error;
-use crate::logger::{log_info, FilesystemLogger, Logger};
+use crate::logger::{log_info, LdkNodeLogger, Logger};
 use crate::types::{ChannelManager, Wallet};
 use crate::wallet::OnchainSendAmount;
 
@@ -27,13 +27,13 @@ pub struct OnchainPayment {
 	wallet: Arc<Wallet>,
 	channel_manager: Arc<ChannelManager>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl OnchainPayment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>, wallet: Arc<Wallet>,
-		channel_manager: Arc<ChannelManager>, config: Arc<Config>, logger: Arc<FilesystemLogger>,
+		channel_manager: Arc<ChannelManager>, config: Arc<Config>, logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, wallet, channel_manager, config, logger }
 	}

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -9,7 +9,7 @@
 
 use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::error::Error;
-use crate::logger::{log_error, log_info, FilesystemLogger, Logger};
+use crate::logger::{log_error, log_info, LdkNodeLogger, Logger};
 use crate::payment::store::{
 	PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, PaymentStore,
 };
@@ -37,17 +37,17 @@ pub struct SpontaneousPayment {
 	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	channel_manager: Arc<ChannelManager>,
 	keys_manager: Arc<KeysManager>,
-	payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>,
+	payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl SpontaneousPayment {
 	pub(crate) fn new(
 		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 		channel_manager: Arc<ChannelManager>, keys_manager: Arc<KeysManager>,
-		payment_store: Arc<PaymentStore<Arc<FilesystemLogger>>>, config: Arc<Config>,
-		logger: Arc<FilesystemLogger>,
+		payment_store: Arc<PaymentStore<Arc<LdkNodeLogger>>>, config: Arc<Config>,
+		logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { runtime, channel_manager, keys_manager, payment_store, config, logger }
 	}

--- a/src/payment/unified_qr.rs
+++ b/src/payment/unified_qr.rs
@@ -12,7 +12,7 @@
 //! [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 //! [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
 use crate::error::Error;
-use crate::logger::{log_error, FilesystemLogger, Logger};
+use crate::logger::{log_error, LdkNodeLogger, Logger};
 use crate::payment::{Bolt11Payment, Bolt12Payment, OnchainPayment};
 use crate::Config;
 
@@ -50,13 +50,13 @@ pub struct UnifiedQrPayment {
 	bolt11_invoice: Arc<Bolt11Payment>,
 	bolt12_payment: Arc<Bolt12Payment>,
 	config: Arc<Config>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl UnifiedQrPayment {
 	pub(crate) fn new(
 		onchain_payment: Arc<OnchainPayment>, bolt11_invoice: Arc<Bolt11Payment>,
-		bolt12_payment: Arc<Bolt12Payment>, config: Arc<Config>, logger: Arc<FilesystemLogger>,
+		bolt12_payment: Arc<Bolt12Payment>, config: Arc<Config>, logger: Arc<LdkNodeLogger>,
 	) -> Self {
 		Self { onchain_payment, bolt11_invoice, bolt12_payment, config, logger }
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@
 use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
 use crate::fee_estimator::OnchainFeeEstimator;
-use crate::logger::FilesystemLogger;
+use crate::logger::LdkNodeLogger;
 use crate::message_handler::NodeCustomMessageHandler;
 
 use lightning::chain::chainmonitor;
@@ -38,7 +38,7 @@ pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
 	Arc<ChainSource>,
 	Arc<Broadcaster>,
 	Arc<OnchainFeeEstimator>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<DynStore>,
 >;
 
@@ -47,8 +47,8 @@ pub(crate) type PeerManager = lightning::ln::peer_handler::PeerManager<
 	Arc<ChannelManager>,
 	Arc<dyn RoutingMessageHandler + Send + Sync>,
 	Arc<OnionMessenger>,
-	Arc<FilesystemLogger>,
-	Arc<NodeCustomMessageHandler<Arc<FilesystemLogger>>>,
+	Arc<LdkNodeLogger>,
+	Arc<NodeCustomMessageHandler<Arc<LdkNodeLogger>>>,
 	Arc<KeysManager>,
 >;
 
@@ -63,51 +63,51 @@ pub(crate) type ChannelManager = lightning::ln::channelmanager::ChannelManager<
 	Arc<KeysManager>,
 	Arc<OnchainFeeEstimator>,
 	Arc<Router>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
-pub(crate) type Broadcaster = crate::tx_broadcaster::TransactionBroadcaster<Arc<FilesystemLogger>>;
+pub(crate) type Broadcaster = crate::tx_broadcaster::TransactionBroadcaster<Arc<LdkNodeLogger>>;
 
 pub(crate) type Wallet =
-	crate::wallet::Wallet<Arc<Broadcaster>, Arc<OnchainFeeEstimator>, Arc<FilesystemLogger>>;
+	crate::wallet::Wallet<Arc<Broadcaster>, Arc<OnchainFeeEstimator>, Arc<LdkNodeLogger>>;
 
 pub(crate) type KeysManager = crate::wallet::WalletKeysManager<
 	Arc<Broadcaster>,
 	Arc<OnchainFeeEstimator>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
 pub(crate) type Router = DefaultRouter<
 	Arc<Graph>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 	Arc<Mutex<Scorer>>,
 	ProbabilisticScoringFeeParameters,
 	Scorer,
 >;
-pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<FilesystemLogger>>;
+pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<LdkNodeLogger>>;
 
-pub(crate) type Graph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
+pub(crate) type Graph = gossip::NetworkGraph<Arc<LdkNodeLogger>>;
 
 pub(crate) type UtxoLookup = dyn lightning::routing::utxo::UtxoLookup + Send + Sync;
 
 pub(crate) type P2PGossipSync =
-	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<FilesystemLogger>>;
+	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<LdkNodeLogger>>;
 pub(crate) type RapidGossipSync =
-	lightning_rapid_gossip_sync::RapidGossipSync<Arc<Graph>, Arc<FilesystemLogger>>;
+	lightning_rapid_gossip_sync::RapidGossipSync<Arc<Graph>, Arc<LdkNodeLogger>>;
 
 pub(crate) type GossipSync = lightning_background_processor::GossipSync<
 	Arc<P2PGossipSync>,
 	Arc<RapidGossipSync>,
 	Arc<Graph>,
 	Arc<UtxoLookup>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 >;
 
 pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMessenger<
 	Arc<KeysManager>,
 	Arc<KeysManager>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<ChannelManager>,
 	Arc<MessageRouter>,
 	Arc<ChannelManager>,
@@ -117,7 +117,7 @@ pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMesse
 
 pub(crate) type MessageRouter = lightning::onion_message::messenger::DefaultMessageRouter<
 	Arc<Graph>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 >;
 
@@ -127,16 +127,16 @@ pub(crate) type Sweeper = OutputSweeper<
 	Arc<OnchainFeeEstimator>,
 	Arc<ChainSource>,
 	Arc<DynStore>,
-	Arc<FilesystemLogger>,
+	Arc<LdkNodeLogger>,
 	Arc<KeysManager>,
 >;
 
 pub(crate) type BumpTransactionEventHandler =
 	lightning::events::bump_transaction::BumpTransactionEventHandler<
 		Arc<Broadcaster>,
-		Arc<lightning::events::bump_transaction::Wallet<Arc<Wallet>, Arc<FilesystemLogger>>>,
+		Arc<lightning::events::bump_transaction::Wallet<Arc<Wallet>, Arc<LdkNodeLogger>>>,
 		Arc<KeysManager>,
-		Arc<FilesystemLogger>,
+		Arc<LdkNodeLogger>,
 	>;
 
 /// A local, potentially user-provided, identifier of a channel.

--- a/src/wallet/persist.rs
+++ b/src/wallet/persist.rs
@@ -10,7 +10,7 @@ use crate::io::utils::{
 	write_bdk_wallet_indexer, write_bdk_wallet_local_chain, write_bdk_wallet_network,
 	write_bdk_wallet_tx_graph,
 };
-use crate::logger::{log_error, FilesystemLogger};
+use crate::logger::{log_error, LdkNodeLogger};
 use crate::types::DynStore;
 
 use lightning::util::logger::Logger;
@@ -22,11 +22,11 @@ use std::sync::Arc;
 pub(crate) struct KVStoreWalletPersister {
 	latest_change_set: Option<ChangeSet>,
 	kv_store: Arc<DynStore>,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<LdkNodeLogger>,
 }
 
 impl KVStoreWalletPersister {
-	pub(crate) fn new(kv_store: Arc<DynStore>, logger: Arc<FilesystemLogger>) -> Self {
+	pub(crate) fn new(kv_store: Arc<DynStore>, logger: Arc<LdkNodeLogger>) -> Self {
 		Self { latest_change_set: None, kv_store, logger }
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,7 +11,7 @@
 use ldk_node::config::{Config, EsploraSyncConfig};
 use ldk_node::io::sqlite_store::SqliteStore;
 use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus};
-use ldk_node::{Builder, Event, LightningBalance, LogLevel, Node, NodeError, PendingSweepBalance};
+use ldk_node::{Builder, Event, LightningBalance, Node, NodeError, PendingSweepBalance};
 
 use lightning::ln::msgs::SocketAddress;
 use lightning::ln::{PaymentHash, PaymentPreimage};
@@ -230,8 +230,6 @@ pub(crate) fn random_config(anchor_channels: bool) -> Config {
 	let alias = random_node_alias();
 	println!("Setting random LDK node alias: {:?}", alias);
 	config.node_alias = alias;
-
-	config.log_level = LogLevel::Gossip;
 
 	config
 }

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -234,13 +234,8 @@ fn start_stop_reinit() {
 	node.sync_wallets().unwrap();
 	assert_eq!(node.list_balances().spendable_onchain_balance_sats, expected_amount.to_sat());
 
-	let log_conf = &config.logging_config;
-	match log_conf {
-		ldk_node::config::LoggingConfig::Filesystem { log_file_path, log_level: _ } => {
-			assert!(std::path::Path::new(&log_file_path).exists());
-		},
-		ldk_node::config::LoggingConfig::Custom(_) => (),
-	}
+	let log_conf = &config.logger_config;
+	assert_eq!(log_conf.formatter.include_level, true);
 
 	node.stop().unwrap();
 	assert_eq!(node.stop(), Err(NodeError::NotRunning));

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -234,8 +234,13 @@ fn start_stop_reinit() {
 	node.sync_wallets().unwrap();
 	assert_eq!(node.list_balances().spendable_onchain_balance_sats, expected_amount.to_sat());
 
-	let log_file = format!("{}/ldk_node.log", config.clone().storage_dir_path);
-	assert!(std::path::Path::new(&log_file).exists());
+	let log_conf = &config.logging_config;
+	match log_conf {
+		ldk_node::config::LoggingConfig::Filesystem { log_file_path, log_level: _ } => {
+			assert!(std::path::Path::new(&log_file_path).exists());
+		},
+		ldk_node::config::LoggingConfig::Custom(_) => (),
+	}
 
 	node.stop().unwrap();
 	assert_eq!(node.stop(), Err(NodeError::NotRunning));


### PR DESCRIPTION
## Summary
This PR builds on #393 to add a customizable logging system.

## What this PR does
- [x] Introduces a `LogWriter` interface, allowing `Writer` variants to handle log output destinations. The supported `Writer` variants can now:
    - [x] Write logs to the filesystem, 
    - [x] Optionally forward to [`log`](https://crates.io/crates/log)
    - [x] Relay logs to a custom logger.

- [x] Makes `Writer` variants configurable.
- [ ] Expose `LogWriter` to bindings (pending).
- [ ] Test logging to different destinations.

## Related Issue
- #309 