### PR TITLE
Start verifying gossip data via bitcoind RPC

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1126,6 +1126,12 @@ fn build_with_store_internal(
 
 	liquidity_source.as_ref().map(|l| l.set_peer_manager(Arc::clone(&peer_manager)));
 
+	gossip_source.set_gossip_verifier(
+		Arc::clone(&chain_source),
+		Arc::clone(&peer_manager),
+		Arc::clone(&runtime),
+	);
+
 	let connection_manager =
 		Arc::new(ConnectionManager::new(Arc::clone(&peer_manager), Arc::clone(&logger)));
 

--- a/src/chain/bitcoind_rpc.rs
+++ b/src/chain/bitcoind_rpc.rs
@@ -45,6 +45,10 @@ impl BitcoindRpcClient {
 		Self { rpc_client, latest_mempool_timestamp }
 	}
 
+	pub(crate) fn rpc_client(&self) -> Arc<RpcClient> {
+		Arc::clone(&self.rpc_client)
+	}
+
 	pub(crate) async fn broadcast_transaction(&self, tx: &Transaction) -> std::io::Result<Txid> {
 		let tx_serialized = bitcoin::consensus::encode::serialize_hex(tx);
 		let tx_json = serde_json::json!(tx_serialized);

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -31,6 +31,7 @@ use lightning::util::ser::Writeable;
 
 use lightning_transaction_sync::EsploraSyncClient;
 
+use lightning_block_sync::gossip::UtxoSource;
 use lightning_block_sync::init::{synchronize_listeners, validate_best_block_header};
 use lightning_block_sync::poll::{ChainPoller, ChainTip, ValidatedBlockHeader};
 use lightning_block_sync::SpvClient;
@@ -189,6 +190,13 @@ impl ChainSource {
 			config,
 			logger,
 			node_metrics,
+		}
+	}
+
+	pub(crate) fn as_utxo_source(&self) -> Option<Arc<dyn UtxoSource>> {
+		match self {
+			Self::BitcoindRpc { bitcoind_rpc_client, .. } => Some(bitcoind_rpc_client.rpc_client()),
+			_ => None,
 		}
 	}
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@
 use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
 use crate::fee_estimator::OnchainFeeEstimator;
+use crate::gossip::RuntimeSpawner;
 use crate::logger::FilesystemLogger;
 use crate::message_handler::NodeCustomMessageHandler;
 
@@ -25,6 +26,9 @@ use lightning::sign::InMemorySigner;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::{Readable, Writeable, Writer};
 use lightning::util::sweep::OutputSweeper;
+
+use lightning_block_sync::gossip::{GossipVerifier, UtxoSource};
+
 use lightning_net_tokio::SocketDescriptor;
 
 use bitcoin::secp256k1::PublicKey;
@@ -91,7 +95,8 @@ pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<FilesystemLogger>>;
 
 pub(crate) type Graph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
 
-pub(crate) type UtxoLookup = dyn lightning::routing::utxo::UtxoLookup + Send + Sync;
+pub(crate) type UtxoLookup =
+	GossipVerifier<RuntimeSpawner, Arc<dyn UtxoSource>, Arc<FilesystemLogger>>;
 
 pub(crate) type P2PGossipSync =
 	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<FilesystemLogger>>;


### PR DESCRIPTION
~~Based on #426.~~
Closes #377.

So far, we did not verify gossip data received via the peer-to-peer network. As a small fix in the latest LDK release allows us properly set the gossip verifier, we do so, and start verifying gossip when the bitcoind RPC gossip source is set.