### PR TITLE
 Default to fallbacks for huge bogus values in fee estimation conversion

### DIFF
--- a/src/fee_estimator.rs
+++ b/src/fee_estimator.rs
@@ -144,7 +144,10 @@ pub(crate) fn apply_post_estimation_adjustments(
 		ConfirmationTarget::Lightning(
 			LdkConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee,
 		) => {
-			let slightly_less_than_background = estimated_rate.to_sat_per_kwu() - 250;
+			let slightly_less_than_background = estimated_rate
+				.to_sat_per_kwu()
+				.saturating_sub(250)
+				.max(FEERATE_FLOOR_SATS_PER_KW as u64);
 			FeeRate::from_sat_per_kwu(slightly_less_than_background)
 		},
 		_ => estimated_rate,


### PR DESCRIPTION
~~Based on #426.~~

Previously, we would cast `FeeRate::to_sat_per_kwu` to `u32`, which however might result in `u32::max_value` being used if our fee estimation source delivers huge bogus data. Here, we make sure to use the fallback rate if we would do so otherwise.

We also make sure our post-estimation adjustments could never underflow. 

Both of these changes aren't super critical but make the code a bit more robust.