### PR TITLE
Allow to override fee rates for onchain payments

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -161,9 +161,19 @@ interface OnchainPayment {
 	[Throws=NodeError]
 	Address new_address();
 	[Throws=NodeError]
-	Txid send_to_address([ByRef]Address address, u64 amount_sats);
+	Txid send_to_address([ByRef]Address address, u64 amount_sats, FeeRate? fee_rate);
 	[Throws=NodeError]
-	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve);
+	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve, FeeRate? fee_rate);
+};
+
+interface FeeRate {
+	[Name=from_sat_per_kwu]
+	constructor(u64 sat_kwu);
+	[Name=from_sat_per_vb_unchecked]
+	constructor(u64 sat_vb);
+	u64 to_sat_per_kwu();
+	u64 to_sat_per_vb_floor();
+	u64 to_sat_per_vb_ceil();
 };
 
 interface UnifiedQrPayment {

--- a/src/payment/unified_qr.rs
+++ b/src/payment/unified_qr.rs
@@ -156,8 +156,11 @@ impl UnifiedQrPayment {
 			},
 		};
 
-		let txid =
-			self.onchain_payment.send_to_address(&uri_network_checked.address, amount.to_sat())?;
+		let txid = self.onchain_payment.send_to_address(
+			&uri_network_checked.address,
+			amount.to_sat(),
+			None,
+		)?;
 
 		Ok(QrPaymentResult::Onchain { txid })
 	}

--- a/src/uniffi_types.rs
+++ b/src/uniffi_types.rs
@@ -30,7 +30,7 @@ pub use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 
 pub use lightning_invoice::Bolt11Invoice;
 
-pub use bitcoin::{Address, BlockHash, Network, OutPoint, Txid};
+pub use bitcoin::{Address, BlockHash, FeeRate, Network, OutPoint, Txid};
 
 pub use bip39::Mnemonic;
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -39,7 +39,8 @@ use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
 use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, Signing};
 use bitcoin::{
-	Amount, ScriptBuf, Transaction, TxOut, Txid, WPubkeyHash, WitnessProgram, WitnessVersion,
+	Amount, FeeRate, ScriptBuf, Transaction, TxOut, Txid, WPubkeyHash, WitnessProgram,
+	WitnessVersion,
 };
 
 use std::ops::Deref;
@@ -239,9 +240,12 @@ where
 
 	pub(crate) fn send_to_address(
 		&self, address: &bitcoin::Address, send_amount: OnchainSendAmount,
+		fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
+		// Use the set fee_rate or default to fee estimation.
 		let confirmation_target = ConfirmationTarget::OnchainPayment;
-		let fee_rate = self.fee_estimator.estimate_fee_rate(confirmation_target);
+		let fee_rate =
+			fee_rate.unwrap_or_else(|| self.fee_estimator.estimate_fee_rate(confirmation_target));
 
 		let tx = {
 			let mut locked_wallet = self.inner.lock().unwrap();

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -315,11 +315,12 @@ fn onchain_spend_receive() {
 
 	assert_eq!(
 		Err(NodeError::InsufficientFunds),
-		node_a.onchain_payment().send_to_address(&addr_b, expected_node_a_balance + 1)
+		node_a.onchain_payment().send_to_address(&addr_b, expected_node_a_balance + 1, None)
 	);
 
 	let amount_to_send_sats = 1000;
-	let txid = node_b.onchain_payment().send_to_address(&addr_a, amount_to_send_sats).unwrap();
+	let txid =
+		node_b.onchain_payment().send_to_address(&addr_a, amount_to_send_sats, None).unwrap();
 	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
 	wait_for_tx(&electrsd.client, txid);
 
@@ -334,7 +335,7 @@ fn onchain_spend_receive() {
 	assert!(node_b.list_balances().spendable_onchain_balance_sats < expected_node_b_balance_upper);
 
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
-	let txid = node_a.onchain_payment().send_all_to_address(&addr_b, true).unwrap();
+	let txid = node_a.onchain_payment().send_all_to_address(&addr_b, true, None).unwrap();
 	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
 	wait_for_tx(&electrsd.client, txid);
 
@@ -350,7 +351,7 @@ fn onchain_spend_receive() {
 	assert!(node_b.list_balances().spendable_onchain_balance_sats < expected_node_b_balance_upper);
 
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
-	let txid = node_a.onchain_payment().send_all_to_address(&addr_b, false).unwrap();
+	let txid = node_a.onchain_payment().send_all_to_address(&addr_b, false, None).unwrap();
 	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
 	wait_for_tx(&electrsd.client, txid);
 


### PR DESCRIPTION
Fixes #176.

We allow to override our fee estimator in the `send_to_address` and `send_all_to_address` API methods. To this end, we implement a bindings-compatible wrapper around `bitcoin::FeeRate`.