### PR TITLE
Account for `OutputSweeper` behavioral changes in LDK v0.1.1

### DIFF
--- a/src/balance.rs
+++ b/src/balance.rs
@@ -325,9 +325,9 @@ pub enum PendingSweepBalance {
 	},
 	/// A spending transaction has been confirmed on-chain and is awaiting threshold confirmations.
 	///
-	/// It will be considered irrevocably confirmed after reaching [`ANTI_REORG_DELAY`].
+	/// It will be pruned after reaching [`PRUNE_DELAY_BLOCKS`] confirmations.
 	///
-	/// [`ANTI_REORG_DELAY`]: lightning::chain::channelmonitor::ANTI_REORG_DELAY
+	/// [`PRUNE_DELAY_BLOCKS`]: lightning::util::sweep::PRUNE_DELAY_BLOCKS
 	AwaitingThresholdConfirmations {
 		/// The identifier of the channel this balance belongs to.
 		channel_id: Option<ChannelId>,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -935,7 +935,7 @@ pub(crate) fn do_channel_full_cycle<E: ElectrumApi>(
 		node_a.sync_wallets().unwrap();
 
 		assert!(node_b.list_balances().lightning_balances.is_empty());
-		assert!(node_b.list_balances().pending_balances_from_channel_closures.is_empty());
+		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
 
 		// Check node_a properly sees all balances and sweeps them.
 		assert_eq!(node_a.list_balances().lightning_balances.len(), 1);


### PR DESCRIPTION
Closes #455.

LDK v0.1.1 shipped slight behavioral changes to the `OutputSweeper`: spendable outputs are now tracked much longer before getting pruned. Here, we update our tests and docs to account for these changes.