### PR TITLE
Fix amount calculation and track paid fees in `PaymentKind::Onchain`

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -412,6 +412,7 @@ dictionary PaymentDetails {
 	PaymentId id;
 	PaymentKind kind;
 	u64? amount_msat;
+	u64? fee_paid_msat;
 	PaymentDirection direction;
 	PaymentStatus status;
 	u64 latest_update_timestamp;

--- a/src/event.rs
+++ b/src/event.rs
@@ -725,6 +725,7 @@ where
 							payment_id,
 							kind,
 							Some(amount_msat),
+							None,
 							PaymentDirection::Inbound,
 							PaymentStatus::Pending,
 						);
@@ -765,6 +766,7 @@ where
 							payment_id,
 							kind,
 							Some(amount_msat),
+							None,
 							PaymentDirection::Inbound,
 							PaymentStatus::Pending,
 						);
@@ -931,6 +933,7 @@ where
 				let update = PaymentDetailsUpdate {
 					hash: Some(Some(payment_hash)),
 					preimage: Some(Some(payment_preimage)),
+					fee_paid_msat: Some(fee_paid_msat),
 					status: Some(PaymentStatus::Succeeded),
 					..PaymentDetailsUpdate::new(payment_id)
 				};

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -160,6 +160,7 @@ impl Bolt11Payment {
 					payment_id,
 					kind,
 					invoice.amount_milli_satoshis(),
+					None,
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
@@ -182,6 +183,7 @@ impl Bolt11Payment {
 							payment_id,
 							kind,
 							invoice.amount_milli_satoshis(),
+							None,
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
@@ -293,6 +295,7 @@ impl Bolt11Payment {
 					payment_id,
 					kind,
 					Some(amount_msat),
+					None,
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
@@ -315,6 +318,7 @@ impl Bolt11Payment {
 							payment_id,
 							kind,
 							Some(amount_msat),
+							None,
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
@@ -531,6 +535,7 @@ impl Bolt11Payment {
 			id,
 			kind,
 			amount_msat,
+			None,
 			PaymentDirection::Inbound,
 			PaymentStatus::Pending,
 		);
@@ -666,6 +671,7 @@ impl Bolt11Payment {
 			id,
 			kind,
 			amount_msat,
+			None,
 			PaymentDirection::Inbound,
 			PaymentStatus::Pending,
 		);

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -113,6 +113,7 @@ impl Bolt12Payment {
 					payment_id,
 					kind,
 					Some(offer_amount_msat),
+					None,
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
@@ -137,6 +138,7 @@ impl Bolt12Payment {
 							payment_id,
 							kind,
 							Some(offer_amount_msat),
+							None,
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
@@ -217,6 +219,7 @@ impl Bolt12Payment {
 					payment_id,
 					kind,
 					Some(amount_msat),
+					None,
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
@@ -241,6 +244,7 @@ impl Bolt12Payment {
 							payment_id,
 							kind,
 							Some(amount_msat),
+							None,
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
@@ -338,6 +342,7 @@ impl Bolt12Payment {
 			payment_id,
 			kind,
 			Some(refund.amount_msats()),
+			None,
 			PaymentDirection::Inbound,
 			PaymentStatus::Pending,
 		);
@@ -402,6 +407,7 @@ impl Bolt12Payment {
 			payment_id,
 			kind,
 			Some(amount_msat),
+			None,
 			PaymentDirection::Outbound,
 			PaymentStatus::Pending,
 		);

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -140,6 +140,7 @@ impl SpontaneousPayment {
 					payment_id,
 					kind,
 					Some(amount_msat),
+					None,
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
@@ -161,6 +162,7 @@ impl SpontaneousPayment {
 							payment_id,
 							kind,
 							Some(amount_msat),
+							None,
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -103,6 +103,10 @@ macro_rules! expect_payment_received_event {
 			ref e @ Event::PaymentReceived { payment_id, amount_msat, .. } => {
 				println!("{} got event {:?}", $node.node_id(), e);
 				assert_eq!(amount_msat, $amount_msat);
+				let payment = $node.payment(&payment_id.unwrap()).unwrap();
+				if !matches!(payment.kind, PaymentKind::Onchain { .. }) {
+					assert_eq!(payment.fee_paid_msat, None);
+				}
 				$node.event_handled();
 				payment_id
 			},
@@ -148,6 +152,8 @@ macro_rules! expect_payment_successful_event {
 				if let Some(fee_msat) = $fee_paid_msat {
 					assert_eq!(fee_paid_msat, fee_msat);
 				}
+				let payment = $node.payment(&$payment_id.unwrap()).unwrap();
+				assert_eq!(payment.fee_paid_msat, fee_paid_msat);
 				assert_eq!(payment_id, $payment_id);
 				$node.event_handled();
 			},

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -26,6 +26,7 @@ use lightning::util::persist::KVStore;
 
 use bitcoincore_rpc::RpcApi;
 
+use bitcoin::hashes::Hash;
 use bitcoin::Amount;
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
 
@@ -281,7 +282,7 @@ fn start_stop_reinit() {
 }
 
 #[test]
-fn onchain_spend_receive() {
+fn onchain_send_receive() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let chain_source = TestChainSource::Esplora(&electrsd);
 	let (node_a, node_b) = setup_two_nodes(&chain_source, false, true, false);
@@ -352,12 +353,37 @@ fn onchain_spend_receive() {
 		node_a.onchain_payment().send_to_address(&addr_b, expected_node_a_balance + 1, None)
 	);
 
-	let amount_to_send_sats = 1000;
+	let amount_to_send_sats = 54321;
 	let txid =
 		node_b.onchain_payment().send_to_address(&addr_a, amount_to_send_sats, None).unwrap();
-	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
 	wait_for_tx(&electrsd.client, txid);
+	node_a.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
 
+	let payment_id = PaymentId(txid.to_byte_array());
+	let payment_a = node_a.payment(&payment_id).unwrap();
+	assert_eq!(payment_a.status, PaymentStatus::Pending);
+	match payment_a.kind {
+		PaymentKind::Onchain { status, .. } => {
+			assert!(matches!(status, ConfirmationStatus::Unconfirmed));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
+	assert!(payment_a.fee_paid_msat > Some(0));
+	let payment_b = node_b.payment(&payment_id).unwrap();
+	assert_eq!(payment_b.status, PaymentStatus::Pending);
+	match payment_a.kind {
+		PaymentKind::Onchain { status, .. } => {
+			assert!(matches!(status, ConfirmationStatus::Unconfirmed));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
+	assert!(payment_b.fee_paid_msat > Some(0));
+	assert_eq!(payment_a.amount_msat, Some(amount_to_send_sats * 1000));
+	assert_eq!(payment_a.amount_msat, payment_b.amount_msat);
+	assert_eq!(payment_a.fee_paid_msat, payment_b.fee_paid_msat);
+
+	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
 	node_a.sync_wallets().unwrap();
 	node_b.sync_wallets().unwrap();
 
@@ -374,6 +400,24 @@ fn onchain_spend_receive() {
 	let node_b_payments =
 		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_b_payments.len(), 3);
+
+	let payment_a = node_a.payment(&payment_id).unwrap();
+	match payment_a.kind {
+		PaymentKind::Onchain { txid: _txid, status } => {
+			assert_eq!(_txid, txid);
+			assert!(matches!(status, ConfirmationStatus::Confirmed { .. }));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
+
+	let payment_b = node_a.payment(&payment_id).unwrap();
+	match payment_b.kind {
+		PaymentKind::Onchain { txid: _txid, status } => {
+			assert_eq!(_txid, txid);
+			assert!(matches!(status, ConfirmationStatus::Confirmed { .. }));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
 
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
 	let txid = node_a.onchain_payment().send_all_to_address(&addr_b, true, None).unwrap();


### PR DESCRIPTION
We recently started tracking onchain payments in the store. It turns out the calculated amount was slightly off as in the outbound case it would include the paid fees. Here, we fix this minor bug and start tracking the fees separately.