### PR TITLE
Pin `idna_adapter` to fix MSRV CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
         if: matrix.msrv
         run: |
           cargo update -p home --precise "0.5.9" --verbose # home v0.5.11 requires rustc 1.81 or newer
+          cargo update -p idna_adapter --precise "1.1.0" --verbose # idna_adapter 1.2 switched to ICU4X, requiring 1.81 and newer
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"


### PR DESCRIPTION
Starting with v1.2, the `idna_adapter` crate switched to use `icu4x`, which requires a rust version of 1.81, conflicting with our MSRV.

Here, we hence pin `idna_adapter` to v1.1 in our MSRV CI.