### PR TITLE
Have `Builder::set_entropy_seed_bytes` take `[u8; 64]` for non-`uniffi`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -245,15 +245,11 @@ impl NodeBuilder {
 		self
 	}
 
-	/// Configures the [`Node`] instance to source its wallet entropy from the given 64 seed bytes.
-	pub fn set_entropy_seed_bytes(&mut self, seed_bytes: Vec<u8>) -> Result<&mut Self, BuildError> {
-		if seed_bytes.len() != WALLET_KEYS_SEED_LEN {
-			return Err(BuildError::InvalidSeedBytes);
-		}
-		let mut bytes = [0u8; WALLET_KEYS_SEED_LEN];
-		bytes.copy_from_slice(&seed_bytes);
-		self.entropy_source_config = Some(EntropySourceConfig::SeedBytes(bytes));
-		Ok(self)
+	/// Configures the [`Node`] instance to source its wallet entropy from the given
+	/// [`WALLET_KEYS_SEED_LEN`] seed bytes.
+	pub fn set_entropy_seed_bytes(&mut self, seed_bytes: [u8; WALLET_KEYS_SEED_LEN]) -> &mut Self {
+		self.entropy_source_config = Some(EntropySourceConfig::SeedBytes(seed_bytes));
+		self
 	}
 
 	/// Configures the [`Node`] instance to source its wallet entropy from a [BIP 39] mnemonic.
@@ -637,11 +633,20 @@ impl ArcedNodeBuilder {
 		self.inner.write().unwrap().set_entropy_seed_path(seed_path);
 	}
 
-	/// Configures the [`Node`] instance to source its wallet entropy from the given 64 seed bytes.
+	/// Configures the [`Node`] instance to source its wallet entropy from the given
+	/// [`WALLET_KEYS_SEED_LEN`] seed bytes.
 	///
-	/// **Note:** Panics if the length of the given `seed_bytes` differs from 64.
+	/// **Note:** Will return an error if the length of the given `seed_bytes` differs from
+	/// [`WALLET_KEYS_SEED_LEN`].
 	pub fn set_entropy_seed_bytes(&self, seed_bytes: Vec<u8>) -> Result<(), BuildError> {
-		self.inner.write().unwrap().set_entropy_seed_bytes(seed_bytes).map(|_| ())
+		if seed_bytes.len() != WALLET_KEYS_SEED_LEN {
+			return Err(BuildError::InvalidSeedBytes);
+		}
+		let mut bytes = [0u8; WALLET_KEYS_SEED_LEN];
+		bytes.copy_from_slice(&seed_bytes);
+
+		self.inner.write().unwrap().set_entropy_seed_bytes(bytes);
+		Ok(())
 	}
 
 	/// Configures the [`Node`] instance to source its wallet entropy from a [BIP 39] mnemonic.

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,8 +78,8 @@ pub(crate) const TX_BROADCAST_TIMEOUT_SECS: u64 = 5;
 // The timeout after which we abort a RGS sync operation.
 pub(crate) const RGS_SYNC_TIMEOUT_SECS: u64 = 5;
 
-// The length in bytes of our wallets' keys seed.
-pub(crate) const WALLET_KEYS_SEED_LEN: usize = 64;
+/// The length in bytes of our wallets' keys seed.
+pub const WALLET_KEYS_SEED_LEN: usize = 64;
 
 #[derive(Debug, Clone)]
 /// Represents the configuration of an [`Node`] instance.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -338,7 +338,16 @@ pub(crate) fn setup_node(
 	}
 
 	if let Some(seed) = seed_bytes {
-		builder.set_entropy_seed_bytes(seed).unwrap();
+		#[cfg(feature = "uniffi")]
+		{
+			builder.set_entropy_seed_bytes(seed).unwrap();
+		}
+		#[cfg(not(feature = "uniffi"))]
+		{
+			let mut bytes = [0u8; 64];
+			bytes.copy_from_slice(&seed);
+			builder.set_entropy_seed_bytes(bytes);
+		}
 	}
 
 	let test_sync_store = Arc::new(TestSyncStore::new(config.node_config.storage_dir_path.into()));


### PR DESCRIPTION
Closes #489.

Historically, we aligned `uniffi` and non-`uniffi` APIs as much as possible (mostly because there are no rendered docs available for the latter). As the APIs have diverged a bit by now anyways, we here have `Builder::set_entropy_seed_bytes` take a `[u8; 64]`, which makes for a better API in Rust.