### PR TITLE
Allow disabling wallet background syncing

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -19,10 +19,14 @@ dictionary AnchorChannelsConfig {
 	u64 per_channel_reserve_sats;
 };
 
-dictionary EsploraSyncConfig {
+dictionary BackgroundSyncConfig {
 	u64 onchain_wallet_sync_interval_secs;
 	u64 lightning_wallet_sync_interval_secs;
 	u64 fee_rate_cache_update_interval_secs;
+};
+
+dictionary EsploraSyncConfig {
+	BackgroundSyncConfig? background_sync_config;
 };
 
 dictionary LSPS2ServiceConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,7 +282,7 @@ pub(crate) fn default_user_config(config: &Config) -> UserConfig {
 	user_config
 }
 
-/// Options related to syncing the Lightning and on-chain wallets via an Esplora backend.
+/// Options related to background syncing the Lightning and on-chain wallets.
 ///
 /// ### Defaults
 ///
@@ -292,28 +292,51 @@ pub(crate) fn default_user_config(config: &Config) -> UserConfig {
 /// | `lightning_wallet_sync_interval_secs`  | 30                 |
 /// | `fee_rate_cache_update_interval_secs`  | 600                |
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct EsploraSyncConfig {
+pub struct BackgroundSyncConfig {
 	/// The time in-between background sync attempts of the onchain wallet, in seconds.
 	///
-	/// **Note:** A minimum of 10 seconds is always enforced.
+	/// **Note:** A minimum of 10 seconds is enforced when background syncing is enabled.
 	pub onchain_wallet_sync_interval_secs: u64,
+
 	/// The time in-between background sync attempts of the LDK wallet, in seconds.
 	///
-	/// **Note:** A minimum of 10 seconds is always enforced.
+	/// **Note:** A minimum of 10 seconds is enforced when background syncing is enabled.
 	pub lightning_wallet_sync_interval_secs: u64,
+
 	/// The time in-between background update attempts to our fee rate cache, in seconds.
 	///
-	/// **Note:** A minimum of 10 seconds is always enforced.
+	/// **Note:** A minimum of 10 seconds is enforced when background syncing is enabled.
 	pub fee_rate_cache_update_interval_secs: u64,
 }
 
-impl Default for EsploraSyncConfig {
+impl Default for BackgroundSyncConfig {
 	fn default() -> Self {
 		Self {
 			onchain_wallet_sync_interval_secs: DEFAULT_BDK_WALLET_SYNC_INTERVAL_SECS,
 			lightning_wallet_sync_interval_secs: DEFAULT_LDK_WALLET_SYNC_INTERVAL_SECS,
 			fee_rate_cache_update_interval_secs: DEFAULT_FEE_RATE_CACHE_UPDATE_INTERVAL_SECS,
 		}
+	}
+}
+
+/// Configuration for syncing with an Esplora backend.
+///
+/// Background syncing is enabled by default, using the default values specified in
+/// [`BackgroundSyncConfig`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EsploraSyncConfig {
+	/// Background sync configuration.
+	///
+	/// If set to `None`, background syncing will be disabled. Users will need to manually
+	/// sync via `Node::sync_wallets` for the wallets and fee rate updates.
+	///
+	/// [`Node::sync_wallets`]: crate::Node::sync_wallets
+	pub background_sync_config: Option<BackgroundSyncConfig>,
+}
+
+impl Default for EsploraSyncConfig {
+	fn default() -> Self {
+		Self { background_sync_config: Some(BackgroundSyncConfig::default()) }
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,14 +1219,13 @@ impl Node {
 	/// Manually sync the LDK and BDK wallets with the current chain state and update the fee rate
 	/// cache.
 	///
-	/// **Note:** The wallets are regularly synced in the background, which is configurable via the
-	/// respective config object, e.g., via
-	/// [`EsploraSyncConfig::onchain_wallet_sync_interval_secs`] and
-	/// [`EsploraSyncConfig::lightning_wallet_sync_interval_secs`]. Therefore, using this blocking
-	/// sync method is almost always redundant and should be avoided where possible.
+	/// **Note:** The wallets are regularly synced in the background if background syncing is enabled
+	/// via [`EsploraSyncConfig::background_sync_config`]. Therefore, using this blocking sync method
+	/// is almost always redundant when background syncing is enabled and should be avoided where possible.
+	/// However, if background syncing is disabled (i.e., `background_sync_config` is set to `None`),
+	/// this method must be called manually to keep wallets in sync with the chain state.
 	///
-	/// [`EsploraSyncConfig::onchain_wallet_sync_interval_secs`]: crate::config::EsploraSyncConfig::onchain_wallet_sync_interval_secs
-	/// [`EsploraSyncConfig::lightning_wallet_sync_interval_secs`]: crate::config::EsploraSyncConfig::lightning_wallet_sync_interval_secs
+	/// [`EsploraSyncConfig::background_sync_config`]: crate::config::EsploraSyncConfig::background_sync_config
 	pub fn sync_wallets(&self) -> Result<(), Error> {
 		let rt_lock = self.runtime.read().unwrap();
 		if rt_lock.is_none() {

--- a/src/uniffi_types.rs
+++ b/src/uniffi_types.rs
@@ -11,7 +11,8 @@
 // Make sure to add any re-exported items that need to be used in uniffi below.
 
 pub use crate::config::{
-	default_config, AnchorChannelsConfig, EsploraSyncConfig, MaxDustHTLCExposure,
+	default_config, AnchorChannelsConfig, BackgroundSyncConfig, EsploraSyncConfig,
+	MaxDustHTLCExposure,
 };
 pub use crate::graph::{ChannelInfo, ChannelUpdateInfo, NodeAnnouncementInfo, NodeInfo};
 pub use crate::liquidity::{LSPS1OrderStatus, LSPS2ServiceConfig, OnchainPaymentInfo, PaymentInfo};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -310,9 +310,7 @@ pub(crate) fn setup_node(
 	match chain_source {
 		TestChainSource::Esplora(electrsd) => {
 			let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
-			let mut sync_config = EsploraSyncConfig::default();
-			sync_config.onchain_wallet_sync_interval_secs = 100000;
-			sync_config.lightning_wallet_sync_interval_secs = 100000;
+			let sync_config = EsploraSyncConfig { background_sync_config: None };
 			builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
 		},
 		TestChainSource::BitcoindRpc(bitcoind) => {

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -127,9 +127,7 @@ fn multi_hop_sending() {
 	let mut nodes = Vec::new();
 	for _ in 0..5 {
 		let config = random_config(true);
-		let mut sync_config = EsploraSyncConfig::default();
-		sync_config.onchain_wallet_sync_interval_secs = 100000;
-		sync_config.lightning_wallet_sync_interval_secs = 100000;
+		let sync_config = EsploraSyncConfig { background_sync_config: None };
 		setup_builder!(builder, config.node_config);
 		builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
 		let node = builder.build().unwrap();
@@ -227,9 +225,7 @@ fn start_stop_reinit() {
 	let test_sync_store: Arc<dyn KVStore + Sync + Send> =
 		Arc::new(TestSyncStore::new(config.node_config.storage_dir_path.clone().into()));
 
-	let mut sync_config = EsploraSyncConfig::default();
-	sync_config.onchain_wallet_sync_interval_secs = 100000;
-	sync_config.lightning_wallet_sync_interval_secs = 100000;
+	let sync_config = EsploraSyncConfig { background_sync_config: None };
 	setup_builder!(builder, config.node_config);
 	builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
 
@@ -1048,9 +1044,7 @@ fn lsps2_client_service_integration() {
 
 	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
 
-	let mut sync_config = EsploraSyncConfig::default();
-	sync_config.onchain_wallet_sync_interval_secs = 100000;
-	sync_config.lightning_wallet_sync_interval_secs = 100000;
+	let sync_config = EsploraSyncConfig { background_sync_config: None };
 
 	// Setup three nodes: service, client, and payer
 	let channel_opening_fee_ppm = 10_000;


### PR DESCRIPTION
Allow disabling background wallet synchronization

Closes #310.

Changes:
- Implements BackgroundSyncConfig to allow disabling background wallet syncs
- Allows users to explicitly disable background wallet synchronization
- Sets intervals to minimum threshold if specified value is below it

Breaking Change:
Existing implementations may need updates to accommodate the new configuration structure.

Implementation Notes:
The BackgroundSyncConfig may be reused for other backend implementations.

Context:
Some users have setups where they need to rely exclusively on manual syncing via `sync_wallets()`. Previously, they had to set intervals to `u64::MAX` as a workaround to effectively disable background syncing. This implementation provides a cleaner, more explicit approach for controlling sync behavior when manual syncing is preferred.
