### PR TITLE
Have the mock log facade not always print to `stdout`

### DIFF
--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -48,7 +48,6 @@ impl LogFacadeLog for MockLogFacadeLogger {
 			record.line().unwrap(),
 			record.args()
 		);
-		println!("{message}");
 		self.logs.lock().unwrap().push(message);
 	}
 


### PR DESCRIPTION
In #463 we introduced a mock logger that implements the `log` facade in tests. Previously, it defaulted to always print `TRACE`-level logs to `stdout`. This however can be very spammy (especially since it includes TRACE-level logs of `electrum_client` now).

Here, we make printing the log lines optional by `cfg`-gating it.

(cc @enigbe)