### PR TITLE
Fix: add retry logic to Esplora requests to handle connection issues

### DIFF
--- a/bindings/python/src/ldk_node/test_ldk_node.py
+++ b/bindings/python/src/ldk_node/test_ldk_node.py
@@ -50,27 +50,43 @@ def mine_and_wait(esplora_endpoint, blocks):
 
 def wait_for_block(esplora_endpoint, block_hash):
     url = esplora_endpoint + "/block/" + block_hash + "/status"
-    esplora_picked_up_block = False
-    while not esplora_picked_up_block:
-        res = requests.get(url)
+    attempts = 0
+    max_attempts = 30
+
+    while attempts < max_attempts:
         try:
+            res = requests.get(url, timeout=10)
             json = res.json()
-            esplora_picked_up_block = json['in_best_chain']
-        except:
-            pass
-        time.sleep(1)
+            if json.get('in_best_chain'):
+                return
+
+        except Exception as e:
+            print(f"Error: {e}")
+
+        attempts += 1
+        time.sleep(0.5)
+
+    raise Exception(f"Failed to confirm block {block_hash} after {max_attempts} attempts")
 
 def wait_for_tx(esplora_endpoint, txid):
     url = esplora_endpoint + "/tx/" + txid
-    esplora_picked_up_tx = False
-    while not esplora_picked_up_tx:
-        res = requests.get(url)
+    attempts = 0
+    max_attempts = 30
+
+    while attempts < max_attempts:
         try:
+            res = requests.get(url, timeout=10)
             json = res.json()
-            esplora_picked_up_tx = json['txid'] == txid
-        except:
-            pass
-        time.sleep(1)
+            if json.get('txid') == txid:
+                return
+
+        except Exception as e:
+            print(f"Error: {e}")
+
+        attempts += 1
+        time.sleep(0.5)
+
+    raise Exception(f"Failed to confirm transaction {txid} after {max_attempts} attempts")
 
 def send_to_address(address, amount_sats):
     amount_btc = amount_sats/100000000.0


### PR DESCRIPTION
# Fix Esplora connection issues in Python tests

## Description
This PR addresses the intermittent CI failures in Python tests where connection to the Esplora server was being reset ("Connection reset by peer" errors).

## Changes
- Added retry logic with timeouts to the Python test functions that communicate with Esplora
- Added proper exception handling to continue retrying after connection errors
- Used a shorter sleep interval (0.5s) to match the more successful Kotlin implementation
- Added helpful error messages and maximum retry limits for better debugging

These changes will make our CI pipeline more stable and reduce false negative test failures.