### PR TITLE
Accommodate minor change in `test_utils` API introduce by LDK 0.1.2

### DIFF
--- a/src/io/test_utils.rs
+++ b/src/io/test_utils.rs
@@ -80,7 +80,7 @@ pub(crate) fn do_read_write_remove_list_persist<K: KVStore + RefUnwindSafe>(kv_s
 
 // Integration-test the given KVStore implementation. Test relaying a few payments and check that
 // the persisted data is updated the appropriate number of times.
-pub(crate) fn do_test_store<K: KVStore>(store_0: &K, store_1: &K) {
+pub(crate) fn do_test_store<K: KVStore + Sync>(store_0: &K, store_1: &K) {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let mut node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let chain_mon_0 = test_utils::TestChainMonitor::new(


### PR DESCRIPTION
LDK 0.1.2 introduced a new `SyncPersist` trait that we accommodate here to fix our CI.