### PR TITLE
feat: add onchain address validation for network-specific addresses

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use bdk_chain::local_chain::CannotConnectError as BdkChainConnectionError;
 use bdk_chain::tx_graph::CalculateFeeError as BdkChainCalculateFeeError;
 use bdk_wallet::error::CreateTxError as BdkCreateTxError;
 use bdk_wallet::signer::SignerError as BdkSignerError;
+use bitcoin::Network;
 
 use std::fmt;
 
@@ -120,6 +121,13 @@ pub enum Error {
 	LiquiditySourceUnavailable,
 	/// The given operation failed due to the LSP's required opening fee being too high.
 	LiquidityFeeTooHigh,
+	/// The given address is invalid.
+	InvalidAddressFormat,
+	///Address belongs to the wrong network
+	InvalidNetworkAddress {
+		/// The expected network.
+        expected: Network
+    },
 }
 
 impl fmt::Display for Error {
@@ -193,6 +201,8 @@ impl fmt::Display for Error {
 			Self::LiquidityFeeTooHigh => {
 				write!(f, "The given operation failed due to the LSP's required opening fee being too high.")
 			},
+			Self::InvalidAddressFormat => write!(f, "The given address is invalid."),
+			Self::InvalidNetworkAddress { expected } => write!(f, "The given address is invalid. Expected network: {:?}", expected),
 		}
 	}
 }

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -13,8 +13,10 @@ use crate::logger::{log_info, LdkLogger, Logger};
 use crate::types::{ChannelManager, Wallet};
 use crate::wallet::OnchainSendAmount;
 
-use bitcoin::{Address, Txid};
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::{Address, Network, Txid};
 
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 #[cfg(not(feature = "uniffi"))]
@@ -80,12 +82,33 @@ impl OnchainPayment {
 			return Err(Error::NotRunning);
 		}
 
+		let validated_address = self.parse_and_validate_address(self.config.network, &address.to_string())?;
+
 		let cur_anchor_reserve_sats =
 			crate::total_anchor_channels_reserve_sats(&self.channel_manager, &self.config);
 		let send_amount =
 			OnchainSendAmount::ExactRetainingReserve { amount_sats, cur_anchor_reserve_sats };
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+		self.wallet.send_to_address(&validated_address, send_amount, fee_rate_opt)
+	}
+
+	/// Validates a Bitcoin address is properly formatted and matches the expected network.
+	///
+	/// Returns `Ok(Address)` if valid, or:
+	/// - `InvalidAddressFormat` if malformed
+	/// - `InvalidNetworkAddress` if valid but wrong network
+	///
+	/// # Example
+	/// ```
+	/// let address = "tb1q..."; // Testnet address
+	/// parse_and_validate_address(Network::Testnet, address)?;
+	pub fn parse_and_validate_address(&self, network: Network, address: &str) -> Result<Address, Error> {
+		Address::<NetworkUnchecked>::from_str(address)
+        .map_err(|_| Error::InvalidAddressFormat)?
+        .require_network(network)
+        .map_err(|_| Error::InvalidNetworkAddress {
+			expected: network,
+		})
 	}
 
 	/// Send an on-chain payment to the given address, draining the available funds.

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -32,9 +32,12 @@ use bitcoincore_rpc::RpcApi;
 
 use bitcoin::hashes::Hash;
 use bitcoin::Amount;
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::Address;
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
 use log::LevelFilter;
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 #[test]
@@ -294,6 +297,9 @@ fn onchain_send_receive() {
 
 	let addr_a = node_a.onchain_payment().new_address().unwrap();
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
+	let static_address = "tb1q0d40e5rta4fty63z64gztf8c3v20cvet6v2jdh";
+	let unchecked_address = Address::<NetworkUnchecked>::from_str(static_address).unwrap();
+	let addr_c = unchecked_address.assume_checked();
 
 	let premine_amount_sat = 1_100_000;
 	premine_and_distribute_funds(
@@ -356,6 +362,13 @@ fn onchain_send_receive() {
 	assert_eq!(
 		Err(NodeError::InsufficientFunds),
 		node_a.onchain_payment().send_to_address(&addr_b, expected_node_a_balance + 1, None)
+	);
+
+	assert_eq!(
+		Err(NodeError::InvalidNetworkAddress {
+			expected: node_a.config().network,
+		}),
+		node_a.onchain_payment().send_to_address(&addr_c, expected_node_a_balance + 1, None)
 	);
 
 	let amount_to_send_sats = 54321;


### PR DESCRIPTION
Addresses need to be validated against the target network before use to ensure correctness
and prevent potential loss of funds.

This commit introduces a function to validate addresses based on the target network:
- Implements a function to validate addresses based on the network.
- Adds unit tests to verify the correctness of the validation logic.

This change enhances the robustness of address handling and mitigates risks associated with invalid or mismatched addresses.

Fixes https://github.com/lightningdevkit/ldk-node/issues/386