### PR TITLE
Update `Cargo.toml` post v0.5.0-rc.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldk-node"
-version = "0.5.0+git"
+version = "0.5.0-rc.1"
 authors = ["Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We just uploaded v0.5.0-rc.1 to crates.io: https://crates.io/crates/ldk-node/0.5.0-rc.1

Here, we simply adjust our `Cargo.toml` accordingly to match the latest Rust release.