### PR TITLE
Add support for sending to human-readable names (BIP 353)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ panic = 'abort'     # Abort on panic
 default = []
 
 [dependencies]
-lightning = { version = "0.1.0", features = ["std"] }
+lightning = { version = "0.1.0", features = ["std", "dnssec"] }
 lightning-types = { version = "0.2.0" }
 lightning-invoice = { version = "0.33.0", features = ["std"] }
 lightning-net-tokio = { version = "0.1.0" }

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -302,6 +302,7 @@ enum NodeError {
 	"InsufficientFunds",
 	"LiquiditySourceUnavailable",
 	"LiquidityFeeTooHigh",
+	"HrnParsingFailed",
 };
 
 dictionary NodeStatus {
@@ -405,6 +406,7 @@ interface PaymentKind {
 	Bolt12Offer(PaymentHash? hash, PaymentPreimage? preimage, PaymentSecret? secret, OfferId offer_id, UntrustedString? payer_note, u64? quantity);
 	Bolt12Refund(PaymentHash? hash, PaymentPreimage? preimage, PaymentSecret? secret, UntrustedString? payer_note, u64? quantity);
 	Spontaneous(PaymentHash hash, PaymentPreimage? preimage);
+	HrnBolt12Offer(HumanReadableName hrn);
 };
 
 [Enum]
@@ -763,3 +765,6 @@ typedef string OrderId;
 
 [Custom]
 typedef string DateTime;
+
+[Custom]
+typedef string HumanReadableName;

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,8 @@ pub enum Error {
 	LiquiditySourceUnavailable,
 	/// The given operation failed due to the LSP's required opening fee being too high.
 	LiquidityFeeTooHigh,
+	/// Parsing a Human-Readable Name has failed
+	HrnParsingFailed,
 }
 
 impl fmt::Display for Error {
@@ -192,6 +194,9 @@ impl fmt::Display for Error {
 			},
 			Self::LiquidityFeeTooHigh => {
 				write!(f, "The given operation failed due to the LSP's required opening fee being too high.")
+			},
+			Self::HrnParsingFailed => {
+				write!(f, "Failed to parse a human-readable name.")
 			},
 		}
 	}

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -22,6 +22,8 @@ use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::offer::{Amount, Offer, Quantity};
 use lightning::offers::parse::Bolt12SemanticError;
 use lightning::offers::refund::Refund;
+use lightning::onion_message::dns_resolution::HumanReadableName;
+use lightning::onion_message::messenger::Destination;
 use lightning::util::string::UntrustedString;
 
 use rand::RngCore;
@@ -252,6 +254,72 @@ impl Bolt12Payment {
 						Err(Error::PaymentSendingFailed)
 					},
 				}
+			},
+		}
+	}
+
+	/// Send a payment to an offer resolved from a human-readable name [BIP 353].
+	///
+	/// Paying to human-readable names makes it more intuitive to make payments for offers
+	/// as users can simply send payments to HRNs such as `user@example.com`.
+	///
+	/// This can be used to pay so-called "zero-amount" offers, i.e., an offer that leaves the
+	/// amount paid to be determined by the user.
+	///
+	/// `dns_resolvers` should be a list of node Destinations that are configured for dns resolution (as outlined in bLIP 32).
+	/// These nodes can be found by running a search through the `NetworkGraph` to find nodes that announce the
+	/// `dns_resolver` feature flag.
+	pub fn send_to_human_readable_name(
+		&self, name: &str, amount_msat: u64, dns_resolvers: Vec<Destination>,
+	) -> Result<PaymentId, Error> {
+		let rt_lock = self.runtime.read().unwrap();
+		if rt_lock.is_none() {
+			return Err(Error::NotRunning);
+		}
+
+		let hrn = HumanReadableName::from_encoded(&name).map_err(|_| Error::HrnParsingFailed)?;
+
+		let mut random_bytes = [0u8; 32];
+		rand::thread_rng().fill_bytes(&mut random_bytes);
+		let payment_id = PaymentId(random_bytes);
+		let retry_strategy = Retry::Timeout(LDK_PAYMENT_RETRY_TIMEOUT);
+		let max_total_routing_fee_msat = None;
+
+		match self.channel_manager.pay_for_offer_from_human_readable_name(
+			hrn.clone(),
+			amount_msat,
+			payment_id,
+			retry_strategy,
+			max_total_routing_fee_msat,
+			dns_resolvers,
+		) {
+			Ok(()) => {
+				log_info!(self.logger, "Initiated sending {} msats to {}", amount_msat, name);
+				let kind = PaymentKind::HrnBolt12Offer { hrn };
+				let payment = PaymentDetails::new(
+					payment_id,
+					kind,
+					Some(amount_msat),
+					None,
+					PaymentDirection::Outbound,
+					PaymentStatus::Pending,
+				);
+				self.payment_store.insert(payment)?;
+				Ok(payment_id)
+			},
+			Err(()) => {
+				log_error!(self.logger, "Failed to send payment to {}", name);
+				let kind = PaymentKind::HrnBolt12Offer { hrn };
+				let payment = PaymentDetails::new(
+					payment_id,
+					kind,
+					Some(amount_msat),
+					None,
+					PaymentDirection::Outbound,
+					PaymentStatus::Pending,
+				);
+				self.payment_store.insert(payment)?;
+				Err(Error::PaymentSendingFailed)
 			},
 		}
 	}

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -16,6 +16,7 @@ use crate::Error;
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::msgs::DecodeError;
 use lightning::offers::offer::OfferId;
+use lightning::onion_message::dns_resolution::HumanReadableName;
 use lightning::util::ser::{Readable, Writeable};
 use lightning::util::string::UntrustedString;
 use lightning::{
@@ -436,6 +437,16 @@ pub enum PaymentKind {
 		/// The pre-image used by the payment.
 		preimage: Option<PaymentPreimage>,
 	},
+	/// A payment to a [BOLT 12] 'offer' resolved from a [HumanReadableName] as outlined in [BIP 353] and [bLIP 32].
+	///
+	/// [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
+	/// [HumanReadableName]: crate::lightning::onion_message::dns_resolution::HumanReadableName
+	/// [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
+	/// [bLIP 32]: https://github.com/lightning/blips/blob/master/blip-0032.md
+	HrnBolt12Offer {
+		/// The human-readable name used to initiate the payment.
+		hrn: HumanReadableName,
+	},
 }
 
 impl_writeable_tlv_based_enum!(PaymentKind,
@@ -473,6 +484,9 @@ impl_writeable_tlv_based_enum!(PaymentKind,
 		(2, preimage, option),
 		(3, quantity, option),
 		(4, secret, option),
+	},
+	(12, HrnBolt12Offer) => {
+		(0, hrn, required),
 	}
 );
 

--- a/src/uniffi_types.rs
+++ b/src/uniffi_types.rs
@@ -35,6 +35,7 @@ pub use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 
 pub use lightning_invoice::{Bolt11Invoice, Description};
 
+pub use lightning::onion_message::dns_resolution::HumanReadableName;
 pub use lightning_liquidity::lsps1::msgs::ChannelInfo as ChannelOrderInfo;
 pub use lightning_liquidity::lsps1::msgs::{
 	Bolt11PaymentInfo, OrderId, OrderParameters, PaymentState,
@@ -426,6 +427,18 @@ impl UniffiCustomTypeConverter for DateTime {
 
 	fn from_custom(obj: Self) -> Self::Builtin {
 		obj.to_rfc3339()
+	}
+}
+
+impl UniffiCustomTypeConverter for HumanReadableName {
+	type Builtin = String;
+
+	fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+		HumanReadableName::from_encoded(&val).map_err(|_| Error::HrnParsingFailed.into())
+	}
+
+	fn from_custom(obj: Self) -> Self::Builtin {
+		format!("{}@{}", obj.user(), obj.domain())
 	}
 }
 


### PR DESCRIPTION
This PR is a first step to add support for human-readable names as outlined in BIP 353 and implemented in LDK 0.1.

Refs #435 

## Changes

1.  A `send_to_human_readable_name` function was added under `Bolt12Payment`.
2.  A `HrnBolt12Offer` PaymentKind variant was added.
3. A `HrnParsingFailed` Error variant was added.
4. These new enum variants were added to the uniffi bindings.

I plan to follow up with a PR for #436 and another PR that will add HRN sending for on-chain payments.