### PR TITLE
Introduce `Runtime` object allowng to detect outer runtime context

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -64,7 +64,7 @@ dictionary LogRecord {
 
 [Trait, WithForeign]
 interface LogWriter {
-    void log(LogRecord record);
+	void log(LogRecord record);
 };
 
 interface Builder {
@@ -161,8 +161,8 @@ interface Node {
 
 [Enum]
 interface Bolt11InvoiceDescription {
-  Hash(string hash);
-  Direct(string description);
+	Hash(string hash);
+	Direct(string description);
 };
 
 interface Bolt11Payment {
@@ -335,6 +335,7 @@ enum BuildError {
 	"InvalidListeningAddresses",
 	"InvalidAnnouncementAddresses",
 	"InvalidNodeAlias",
+	"RuntimeSetupFailed",
 	"ReadFailed",
 	"WriteFailed",
 	"StoragePathAccessFailed",

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -19,6 +19,7 @@ use crate::config::{
 use crate::fee_estimator::OnchainFeeEstimator;
 use crate::io::utils::write_node_metrics;
 use crate::logger::{log_debug, log_info, log_trace, LdkLogger, Logger};
+use crate::runtime::Runtime;
 use crate::types::{Broadcaster, ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
 
@@ -185,7 +186,7 @@ impl ChainSource {
 		Self { kind, tx_broadcaster, logger }
 	}
 
-	pub(crate) fn start(&self, runtime: Arc<tokio::runtime::Runtime>) -> Result<(), Error> {
+	pub(crate) fn start(&self, runtime: Arc<Runtime>) -> Result<(), Error> {
 		match &self.kind {
 			ChainSourceKind::Electrum(electrum_chain_source) => {
 				electrum_chain_source.start(runtime)?

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -7,7 +7,8 @@
 
 use crate::chain::ChainSource;
 use crate::config::RGS_SYNC_TIMEOUT_SECS;
-use crate::logger::{log_error, log_trace, LdkLogger, Logger};
+use crate::logger::{log_trace, LdkLogger, Logger};
+use crate::runtime::Runtime;
 use crate::types::{GossipSync, Graph, P2PGossipSync, PeerManager, RapidGossipSync, UtxoLookup};
 use crate::Error;
 
@@ -15,13 +16,12 @@ use lightning_block_sync::gossip::{FutureSpawner, GossipVerifier};
 
 use std::future::Future;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 pub(crate) enum GossipSource {
 	P2PNetwork {
 		gossip_sync: Arc<P2PGossipSync>,
-		logger: Arc<Logger>,
 	},
 	RapidGossipSync {
 		gossip_sync: Arc<RapidGossipSync>,
@@ -38,7 +38,7 @@ impl GossipSource {
 			None::<Arc<UtxoLookup>>,
 			Arc::clone(&logger),
 		));
-		Self::P2PNetwork { gossip_sync, logger }
+		Self::P2PNetwork { gossip_sync }
 	}
 
 	pub fn new_rgs(
@@ -63,12 +63,12 @@ impl GossipSource {
 
 	pub(crate) fn set_gossip_verifier(
 		&self, chain_source: Arc<ChainSource>, peer_manager: Arc<PeerManager>,
-		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
+		runtime: Arc<Runtime>,
 	) {
 		match self {
-			Self::P2PNetwork { gossip_sync, logger } => {
+			Self::P2PNetwork { gossip_sync } => {
 				if let Some(utxo_source) = chain_source.as_utxo_source() {
-					let spawner = RuntimeSpawner::new(Arc::clone(&runtime), Arc::clone(&logger));
+					let spawner = RuntimeSpawner::new(Arc::clone(&runtime));
 					let gossip_verifier = Arc::new(GossipVerifier::new(
 						utxo_source,
 						spawner,
@@ -133,28 +133,17 @@ impl GossipSource {
 }
 
 pub(crate) struct RuntimeSpawner {
-	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
-	logger: Arc<Logger>,
+	runtime: Arc<Runtime>,
 }
 
 impl RuntimeSpawner {
-	pub(crate) fn new(
-		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>, logger: Arc<Logger>,
-	) -> Self {
-		Self { runtime, logger }
+	pub(crate) fn new(runtime: Arc<Runtime>) -> Self {
+		Self { runtime }
 	}
 }
 
 impl FutureSpawner for RuntimeSpawner {
 	fn spawn<T: Future<Output = ()> + Send + 'static>(&self, future: T) {
-		let rt_lock = self.runtime.read().unwrap();
-		if rt_lock.is_none() {
-			log_error!(self.logger, "Tried spawing a future while the runtime wasn't available. This should never happen.");
-			debug_assert!(false, "Tried spawing a future while the runtime wasn't available. This should never happen.");
-			return;
-		}
-
-		let runtime = rt_lock.as_ref().unwrap();
-		runtime.spawn(future);
+		self.runtime.spawn(future);
 	}
 }

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -41,19 +41,19 @@ macro_rules! maybe_map_fee_rate_opt {
 ///
 /// [`Node::onchain_payment`]: crate::Node::onchain_payment
 pub struct OnchainPayment {
-	runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>,
 	wallet: Arc<Wallet>,
 	channel_manager: Arc<ChannelManager>,
 	config: Arc<Config>,
+	is_running: Arc<RwLock<bool>>,
 	logger: Arc<Logger>,
 }
 
 impl OnchainPayment {
 	pub(crate) fn new(
-		runtime: Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>>, wallet: Arc<Wallet>,
-		channel_manager: Arc<ChannelManager>, config: Arc<Config>, logger: Arc<Logger>,
+		wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>, config: Arc<Config>,
+		is_running: Arc<RwLock<bool>>, logger: Arc<Logger>,
 	) -> Self {
-		Self { runtime, wallet, channel_manager, config, logger }
+		Self { wallet, channel_manager, config, is_running, logger }
 	}
 
 	/// Retrieve a new on-chain/funding address.
@@ -75,8 +75,7 @@ impl OnchainPayment {
 	pub fn send_to_address(
 		&self, address: &bitcoin::Address, amount_sats: u64, fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
-		let rt_lock = self.runtime.read().unwrap();
-		if rt_lock.is_none() {
+		if !*self.is_running.read().unwrap() {
 			return Err(Error::NotRunning);
 		}
 
@@ -106,8 +105,7 @@ impl OnchainPayment {
 	pub fn send_all_to_address(
 		&self, address: &bitcoin::Address, retain_reserves: bool, fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
-		let rt_lock = self.runtime.read().unwrap();
-		if rt_lock.is_none() {
+		if !*self.is_running.read().unwrap() {
 			return Err(Error::NotRunning);
 		}
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,72 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+use tokio::task::JoinHandle;
+
+use std::future::Future;
+
+pub(crate) struct Runtime {
+	mode: RuntimeMode,
+}
+
+impl Runtime {
+	pub fn new() -> Result<Self, std::io::Error> {
+		let mode = match tokio::runtime::Handle::try_current() {
+			Ok(handle) => RuntimeMode::Handle(handle),
+			Err(_) => {
+				let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
+				RuntimeMode::Owned(rt)
+			},
+		};
+		Ok(Self { mode })
+	}
+
+	pub fn with_handle(handle: tokio::runtime::Handle) -> Self {
+		let mode = RuntimeMode::Handle(handle);
+		Self { mode }
+	}
+
+	pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+	where
+		F: Future + Send + 'static,
+		F::Output: Send + 'static,
+	{
+		let handle = self.handle();
+		handle.spawn(future)
+	}
+
+	pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
+	where
+		F: FnOnce() -> R + Send + 'static,
+		R: Send + 'static,
+	{
+		let handle = self.handle();
+		handle.spawn_blocking(func)
+	}
+
+	pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+		// While we generally decided not to overthink via which call graph users would enter our
+		// runtime context, we'd still try to reuse whatever current context would be present
+		// during `block_on`, as this is the context `block_in_place` would operate on. So we try
+		// to detect the outer context here, and otherwise use whatever was set during
+		// initialization.
+		let handle = tokio::runtime::Handle::try_current().unwrap_or(self.handle().clone());
+		tokio::task::block_in_place(move || handle.block_on(future))
+	}
+
+	pub fn handle(&self) -> &tokio::runtime::Handle {
+		match &self.mode {
+			RuntimeMode::Owned(rt) => rt.handle(),
+			RuntimeMode::Handle(handle) => handle,
+		}
+	}
+}
+
+enum RuntimeMode {
+	Owned(tokio::runtime::Runtime),
+	Handle(tokio::runtime::Handle),
+}


### PR DESCRIPTION
Closes #491 

Instead of holding an `Arc<RwLock<Option<Arc<tokio::runtime::Runtime>>>`
and dealing with stuff like `tokio::task::block_in_place` at all
callsites, we introduce a `Runtime` object that takes care of the state
transitions, and allows to detect and reuse an outer runtime context.

We also adjust the `with_runtime` API to take a `tokio::runtime::Handle`
rather than an `Arc<Runtime>`.

~~We then also go ahead an reuse said `Runtime` object for `VssStore`.~~

(cc @andrei-21)