### PR TITLE
Support passing preimage for spontaneous payments

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -213,6 +213,10 @@ interface SpontaneousPayment {
 	[Throws=NodeError]
 	PaymentId send_with_custom_tlvs(u64 amount_msat, PublicKey node_id, SendingParameters? sending_parameters, sequence<CustomTlvRecord> custom_tlvs);
 	[Throws=NodeError]
+	PaymentId send_with_preimage(u64 amount_msat, PublicKey node_id, PaymentPreimage preimage, SendingParameters? sending_parameters);
+	[Throws=NodeError]
+	PaymentId send_with_preimage_and_custom_tlvs(u64 amount_msat, PublicKey node_id, sequence<CustomTlvRecord> custom_tlvs, PaymentPreimage preimage, SendingParameters? sending_parameters);
+	[Throws=NodeError]
 	void send_probes(u64 amount_msat, PublicKey node_id);
 };
 

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -57,7 +57,7 @@ impl SpontaneousPayment {
 	pub fn send(
 		&self, amount_msat: u64, node_id: PublicKey, sending_parameters: Option<SendingParameters>,
 	) -> Result<PaymentId, Error> {
-		self.send_inner(amount_msat, node_id, sending_parameters, None)
+		self.send_inner(amount_msat, node_id, sending_parameters, None, None)
 	}
 
 	/// Send a spontaneous payment including a list of custom TLVs.
@@ -65,19 +65,37 @@ impl SpontaneousPayment {
 		&self, amount_msat: u64, node_id: PublicKey, sending_parameters: Option<SendingParameters>,
 		custom_tlvs: Vec<CustomTlvRecord>,
 	) -> Result<PaymentId, Error> {
-		self.send_inner(amount_msat, node_id, sending_parameters, Some(custom_tlvs))
+		self.send_inner(amount_msat, node_id, sending_parameters, Some(custom_tlvs), None)
+	}
+
+	/// Send a spontaneous payment with custom preimage
+	pub fn send_with_preimage(
+		&self, amount_msat: u64, node_id: PublicKey, preimage: PaymentPreimage,
+		sending_parameters: Option<SendingParameters>,
+	) -> Result<PaymentId, Error> {
+		self.send_inner(amount_msat, node_id, sending_parameters, None, Some(preimage))
+	}
+
+	/// Send a spontaneous payment with custom preimage including a list of custom TLVs.
+	pub fn send_with_preimage_and_custom_tlvs(
+		&self, amount_msat: u64, node_id: PublicKey, custom_tlvs: Vec<CustomTlvRecord>,
+		preimage: PaymentPreimage, sending_parameters: Option<SendingParameters>,
+	) -> Result<PaymentId, Error> {
+		self.send_inner(amount_msat, node_id, sending_parameters, Some(custom_tlvs), Some(preimage))
 	}
 
 	fn send_inner(
 		&self, amount_msat: u64, node_id: PublicKey, sending_parameters: Option<SendingParameters>,
-		custom_tlvs: Option<Vec<CustomTlvRecord>>,
+		custom_tlvs: Option<Vec<CustomTlvRecord>>, preimage: Option<PaymentPreimage>,
 	) -> Result<PaymentId, Error> {
 		let rt_lock = self.runtime.read().unwrap();
 		if rt_lock.is_none() {
 			return Err(Error::NotRunning);
 		}
 
-		let payment_preimage = PaymentPreimage(self.keys_manager.get_secure_random_bytes());
+		let payment_preimage = preimage
+			.unwrap_or_else(|| PaymentPreimage(self.keys_manager.get_secure_random_bytes()));
+
 		let payment_hash = PaymentHash::from(payment_preimage);
 		let payment_id = PaymentId(payment_hash.0);
 


### PR DESCRIPTION
This PR adds support for specifying custom preimages when sending spontaneous (keysend) payments.

## Solution
- Added `send_with_preimage()` method
- Added `send_with_preimage_and_custom_tlvs()` method for advanced use cases
- Modified internal `send_inner()` to accept optional preimage parameter and generate random preimage only when custom preimage is not provided.

An integration test is added to verify logic, and the new methods are added to the bindings.

Fixes #535 