### PR TITLE
Export trait impls in FFI (backport for `release/0.6`)

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -715,6 +715,7 @@ dictionary RouteHintHop {
 	RoutingFees fees;
 };
 
+[Traits=(Debug, Display, Eq)]
 interface Bolt11Invoice {
 	[Throws=NodeError, Name=from_str]
 	constructor([ByRef] string invoice_str);

--- a/src/payment/unified_qr.rs
+++ b/src/payment/unified_qr.rs
@@ -186,6 +186,7 @@ impl UnifiedQrPayment {
 /// [BIP 21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
 /// [`PaymentId`]: lightning::ln::channelmanager::PaymentId
 /// [`Txid`]: bitcoin::hash_types::Txid
+#[derive(Debug)]
 pub enum QrPaymentResult {
 	/// An on-chain payment.
 	Onchain {

--- a/src/uniffi_types.rs
+++ b/src/uniffi_types.rs
@@ -467,7 +467,7 @@ impl From<lightning::routing::router::RouteHintHop> for RouteHintHop {
 /// Represents a syntactically and semantically correct lightning BOLT11 invoice.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Bolt11Invoice {
-	pub inner: LdkBolt11Invoice,
+	pub(crate) inner: LdkBolt11Invoice,
 }
 
 impl Bolt11Invoice {


### PR DESCRIPTION
Previously, we moved from a `String` representation to a 'full' `Bolt11Invoice` type. However, we forgot to expose the `Display` implementation in the FFI, leaving now way to retrieve the invoice string.

Here, we fix this oversight, and also make a few related changes.


This is a backport of #573 towards `release/0.6`.