### PR TITLE
Avoid collision in `Bolt11Invoice::description` (main)

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -728,7 +728,7 @@ interface Bolt11Invoice {
 	u64 seconds_until_expiry();
 	boolean is_expired();
 	boolean would_expire(u64 at_time_seconds);
-	Bolt11InvoiceDescription description();
+	Bolt11InvoiceDescription invoice_description();
 	u64 min_final_cltv_expiry_delta();
 	Network network();
 	Currency currency();

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -985,7 +985,7 @@ impl Bolt11Invoice {
 	}
 
 	/// Return the description or a hash of it for longer ones
-	pub fn description(&self) -> Bolt11InvoiceDescription {
+	pub fn invoice_description(&self) -> Bolt11InvoiceDescription {
 		self.inner.description().into()
 	}
 


### PR DESCRIPTION
When exporting `Display` to bindings, Swift will add a `description` method to the respective object. Unfortunately, this collides with `Bolt11Invoice::description`, which we therefore rename to `Bolt11Invoice::invoice_description`.

Discovered by actually testing the changes in #573/#574 in Xcode.