### PR TITLE
Set log target to module path

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -153,6 +153,7 @@ impl LogWriter for Writer {
 				#[cfg(not(feature = "uniffi"))]
 				log::logger().log(
 					&builder
+						.target(record.module_path)
 						.module_path(Some(record.module_path))
 						.line(Some(record.line))
 						.args(format_args!("{}", record.args))
@@ -161,6 +162,7 @@ impl LogWriter for Writer {
 				#[cfg(feature = "uniffi")]
 				log::logger().log(
 					&builder
+						.target(&record.module_path)
 						.module_path(Some(&record.module_path))
 						.line(Some(record.line))
 						.args(format_args!("{}", record.args))


### PR DESCRIPTION
The `log!()` macro defaults to using the module path as the log target when no target is specified.
Explicitly setting the log target to the module path enables better integration with other logging crates,
such as `env_logger`, allowing them to filter logs by target (e.g., via `env_logger::Builder::parse_filters()`).