### PR TITLE
Bump `uniffi` dependency to v0.28.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ esplora-client = { version = "0.12", default-features = false, features = ["toki
 esplora-client_0_11 = { package = "esplora-client", version = "0.11", default-features = false, features = ["tokio", "async-https-rustls"] }
 electrum-client = { version = "0.23.1", default-features = true }
 libc = "0.2"
-uniffi = { version = "0.27.3", features = ["build"], optional = true }
+uniffi = { version = "0.28.3", features = ["build"], optional = true }
 serde = { version = "1.0.210", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.128", default-features = false, features = ["std"] }
 log = { version = "0.4.22", default-features = false, features = ["std"]}
@@ -117,7 +117,7 @@ lnd_grpc_rust = { version = "2.10.0", default-features = false }
 tokio = { version = "1.37", features = ["fs"] }
 
 [build-dependencies]
-uniffi = { version = "0.27.3", features = ["build"], optional = true }
+uniffi = { version = "0.28.3", features = ["build"], optional = true }
 
 [profile.release]
 panic = "abort"

--- a/bindings/uniffi-bindgen/Cargo.toml
+++ b/bindings/uniffi-bindgen/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uniffi = { version = "0.27.3", features = ["cli"] }
+uniffi = { version = "0.28.3", features = ["cli"] }


### PR DESCRIPTION
We bump our `uniffi` dependency to v0.28.3 to unlock some of the nicer features `uniffi` added since the previously-used v0.27.3. However, we can't bump it further to v0.29.3, as we have users requiring compatibility with `uniffi-bindgen-go`, which only supports v0.28.3 at the time of writing.