### PR TITLE
Adds `InboundChannelsConfig` configuration

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -13,11 +13,17 @@ dictionary Config {
 	u64 probing_liquidity_limit_multiplier;
 	AnchorChannelsConfig? anchor_channels_config;
 	SendingParameters? sending_parameters;
+	InboundChannelsConfig inbound_channels_config;
 };
 
 dictionary AnchorChannelsConfig {
 	sequence<PublicKey> trusted_peers_no_reserve;
 	u64 per_channel_reserve_sats;
+};
+
+dictionary InboundChannelsConfig {
+	boolean reject_announced_channel_requests;
+	u64? minimum_channel_size;
 };
 
 dictionary BackgroundSyncConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,11 +101,12 @@ pub const WALLET_KEYS_SEED_LEN: usize = 64;
 /// | `trusted_peers_0conf`                  | []                 |
 /// | `probing_liquidity_limit_multiplier`   | 3                  |
 /// | `log_level`                            | Debug              |
-/// | `anchor_channels_config`               | Some(..)           |
+/// | `anchor_channels_config`                | Some(..)           |
 /// | `sending_parameters`                   | None               |
+/// | `inbound_channels_config` .             | ::Default          |
 ///
-/// See [`AnchorChannelsConfig`] and [`SendingParameters`] for more information regarding their
-/// respective default values.
+/// See [`AnchorChannelsConfig`], [`InboundChannelsConfig`] and [`SendingParameters`]
+/// for more information regarding their respective default values.
 ///
 /// [`Node`]: crate::Node
 pub struct Config {
@@ -167,6 +168,11 @@ pub struct Config {
 	/// **Note:** If unset, default parameters will be used, and you will be able to override the
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub sending_parameters: Option<SendingParameters>,
+	/// Configuration options for inbound channels requests.
+	///
+	/// These options can be used to customize the behavior whenever a channel is requested by a
+	/// remote peer.
+	pub inbound_channels_config: InboundChannelsConfig,
 }
 
 impl Default for Config {
@@ -181,7 +187,41 @@ impl Default for Config {
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			sending_parameters: None,
 			node_alias: None,
+			inbound_channels_config: InboundChannelsConfig::default(),
 		}
+	}
+}
+
+/// Configuration options for inbound channels requests.
+///
+/// These options can be used to customize the behavior whenever a channel is requested by a
+/// remote peer.
+///
+/// ### Defaults
+///
+/// | Parameter                           | Value  |
+/// |-------------------------------------|--------|
+/// | `reject_announced_channel_requests` | false  |
+/// | `minimum_channel_size` 			  | None   |
+///
+
+#[derive(Debug, Clone)]
+pub struct InboundChannelsConfig {
+	/// Boolean flag indicating whether to reject announced channel requests.
+	///
+	/// If `true`, the node will reject any inbound channel requests with announced channel
+	/// requests.
+	pub reject_announced_channel_requests: bool,
+	/// Optional minimum channel size in satoshis.
+	///
+	/// If set, the node will reject any inbound channel requests with a channel size smaller than
+	/// the specified value.
+	pub minimum_channel_size: Option<u64>,
+}
+
+impl Default for InboundChannelsConfig {
+	fn default() -> Self {
+		Self { reject_announced_channel_requests: false, minimum_channel_size: None }
 	}
 }
 

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -12,7 +12,7 @@
 
 pub use crate::config::{
 	default_config, AnchorChannelsConfig, BackgroundSyncConfig, ElectrumSyncConfig,
-	EsploraSyncConfig, MaxDustHTLCExposure,
+	EsploraSyncConfig, InboundChannelsConfig, MaxDustHTLCExposure,
 };
 pub use crate::graph::{ChannelInfo, ChannelUpdateInfo, NodeAnnouncementInfo, NodeInfo};
 pub use crate::liquidity::{LSPS1OrderStatus, LSPS2ServiceConfig, OnchainPaymentInfo, PaymentInfo};


### PR DESCRIPTION
Fixes partially #502 

## Context

When running a personal or business node would like to control how peers request channels either blocking all possible channels, announced channels or some channels given a minimum.

This is useful as operator to take care of how liquidity moves. Even more, if we acquired a channel LSP for specific reasons and don't want that liquidity to move.

Other example is when running a operative node (i.e, exchange / wallet) don't want to be full of tiny channels that could affect route finding.

## Solution

Added a `InboundChannelsConfig` configuration on `config.rs` with two parameters to reject channels or set a minimum channel size. In case that node runner wants to block all possible channels, it would mean to set the `minimum_channel_size` to a greater number.

## Questions
I was thinking that better approach is to have a "channels_config" and inside would have inbound (or policy / limits) and also de Anchors channel config.