### PR TITLE
Ensure we always startup with a `rustls` `CryptoProvider`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-
 bdk_wallet = { version = "2.0.0", default-features = false, features = ["std", "keys-bip39"]}
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls = { version = "0.23", default-features = false }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 bitcoin = "0.32.4"
 bip39 = "2.0.0"


### PR DESCRIPTION
The `rustls` library recently introduced this weird behavior where they expect users to, apart from configuring the respective feature, also explictly call `CryptoProvider::install_default`. Otherwise they'd simply panic at runtime whenever the first network call requiring TLS would be made. While we already made a change upstream at `rust-electrum-client`, we also make sure here that we definitely, always, absolutley are sure that we have a `CryptoProvider` set on startup.