### PR TITLE
Bump MSRV to rustc 1.85

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
         toolchain: [
           stable,
           beta,
-          1.75.0, # Our MSRV
+          1.85.0, # Our MSRV
           ]
         include:
           - toolchain: stable
@@ -29,7 +29,7 @@ jobs:
             platform: macos-latest
           - toolchain: stable
             platform: windows-latest
-          - toolchain: 1.75.0
+          - toolchain: 1.85.0
             msrv: true
     runs-on: ${{ matrix.platform }}
     steps:
@@ -42,11 +42,6 @@ jobs:
       - name: Check formatting on Rust ${{ matrix.toolchain }}
         if: matrix.check-fmt
         run: rustup component add rustfmt && cargo fmt --all -- --check
-      - name: Pin packages to allow for MSRV
-        if: matrix.msrv
-        run: |
-          cargo update -p home --precise "0.5.9" --verbose # home v0.5.11 requires rustc 1.81 or newer
-          cargo update -p idna_adapter --precise "1.1.0" --verbose # idna_adapter 1.2 switched to ICU4X, requiring 1.81 and newer
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
@@ -79,7 +74,7 @@ jobs:
         if: matrix.build-uniffi
         run: cargo build --features uniffi --verbose --color always
       - name: Build documentation on Rust ${{ matrix.toolchain }}
-        if: "matrix.platform != 'windows-latest' || matrix.toolchain != '1.75.0'"
+        if: "matrix.platform != 'windows-latest' || matrix.toolchain != '1.85.0'"
         run: |
           cargo doc --release --verbose --color always
           cargo doc --document-private-items --verbose --color always

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ LDK Node currently comes with a decidedly opinionated set of design choices:
 LDK Node itself is written in [Rust][rust] and may therefore be natively added as a library dependency to any `std` Rust program. However, beyond its Rust API it also offers language bindings for [Swift][swift], [Kotlin][kotlin], and [Python][python] based on the [UniFFI](https://github.com/mozilla/uniffi-rs/). Moreover, [Flutter bindings][flutter_bindings] are also available.
 
 ## MSRV
-The Minimum Supported Rust Version (MSRV) is currently 1.75.0.
+The Minimum Supported Rust Version (MSRV) is currently 1.85.0.
 
 [api_docs]: https://docs.rs/ldk-node/*/ldk_node/
 [api_docs_node]: https://docs.rs/ldk-node/*/ldk_node/struct.Node.html


### PR DESCRIPTION
We generally align our MSRV with Debian's stable channel. Debian 13 'Trixie' was just released, shipping rustc 1.85. We therefore bump our MSRV on the `main` branch here.