### PR TITLE
Static invoice server

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -13,6 +13,7 @@ dictionary Config {
 	u64 probing_liquidity_limit_multiplier;
 	AnchorChannelsConfig? anchor_channels_config;
 	RouteParametersConfig? route_parameters;
+	boolean async_payment_services_enabled;
 };
 
 dictionary AnchorChannelsConfig {
@@ -209,6 +210,12 @@ interface Bolt12Payment {
 	Bolt12Invoice request_refund_payment([ByRef]Refund refund);
 	[Throws=NodeError]
 	Refund initiate_refund(u64 amount_msat, u32 expiry_secs, u64? quantity, string? payer_note);
+	[Throws=NodeError]
+	Offer receive_async();
+	[Throws=NodeError]
+	void set_paths_to_static_invoice_server(bytes paths);
+	[Throws=NodeError]
+	bytes blinded_paths_for_async_recipient(bytes recipient_id);
 };
 
 interface SpontaneousPayment {
@@ -311,6 +318,8 @@ enum NodeError {
 	"InsufficientFunds",
 	"LiquiditySourceUnavailable",
 	"LiquidityFeeTooHigh",
+	"InvalidBlindedPaths",
+	"AsyncPaymentServicesDisabled",
 };
 
 dictionary NodeStatus {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1455,7 +1455,7 @@ fn build_with_store_internal(
 		Arc::clone(&channel_manager),
 		message_router,
 		Arc::clone(&channel_manager),
-		IgnoringMessageHandler {},
+		Arc::clone(&channel_manager),
 		IgnoringMessageHandler {},
 		IgnoringMessageHandler {},
 	));

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,8 @@ pub struct Config {
 	/// **Note:** If unset, default parameters will be used, and you will be able to override the
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub route_parameters: Option<RouteParametersConfig>,
+	/// Whether to enable the static invoice service to support async payment reception for clients.
+	pub async_payment_services_enabled: bool,
 }
 
 impl Default for Config {
@@ -193,6 +195,7 @@ impl Default for Config {
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			route_parameters: None,
 			node_alias: None,
+			async_payment_services_enabled: false,
 		}
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,10 @@ pub enum Error {
 	LiquiditySourceUnavailable,
 	/// The given operation failed due to the LSP's required opening fee being too high.
 	LiquidityFeeTooHigh,
+	/// The given blinded paths are invalid.
+	InvalidBlindedPaths,
+	/// Asynchronous payment services are disabled.
+	AsyncPaymentServicesDisabled,
 }
 
 impl fmt::Display for Error {
@@ -192,6 +196,10 @@ impl fmt::Display for Error {
 			},
 			Self::LiquidityFeeTooHigh => {
 				write!(f, "The given operation failed due to the LSP's required opening fee being too high.")
+			},
+			Self::InvalidBlindedPaths => write!(f, "The given blinded paths are invalid."),
+			Self::AsyncPaymentServicesDisabled => {
+				write!(f, "Asynchronous payment services are disabled.")
 			},
 		}
 	}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -73,3 +73,8 @@ pub(crate) const BDK_WALLET_TX_GRAPH_KEY: &str = "tx_graph";
 pub(crate) const BDK_WALLET_INDEXER_PRIMARY_NAMESPACE: &str = "bdk_wallet";
 pub(crate) const BDK_WALLET_INDEXER_SECONDARY_NAMESPACE: &str = "";
 pub(crate) const BDK_WALLET_INDEXER_KEY: &str = "indexer";
+
+/// [`StaticInvoice`]s will be persisted under this key.
+///
+/// [`StaticInvoice`]: lightning::offers::static_invoice::StaticInvoice
+pub(crate) const STATIC_INVOICE_STORE_PRIMARY_NAMESPACE: &str = "static_invoices";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ use gossip::GossipSource;
 use graph::NetworkGraph;
 use io::utils::write_node_metrics;
 use liquidity::{LSPS1Liquidity, LiquiditySource};
+use payment::asynchronous::static_invoice_store::StaticInvoiceStore;
 use payment::{
 	Bolt11Payment, Bolt12Payment, OnchainPayment, PaymentDetails, SpontaneousPayment,
 	UnifiedQrPayment,
@@ -498,6 +499,12 @@ impl Node {
 			Arc::clone(&self.logger),
 		));
 
+		let static_invoice_store = if self.config.async_payment_services_enabled {
+			Some(StaticInvoiceStore::new(Arc::clone(&self.kv_store)))
+		} else {
+			None
+		};
+
 		let event_handler = Arc::new(EventHandler::new(
 			Arc::clone(&self.event_queue),
 			Arc::clone(&self.wallet),
@@ -509,6 +516,7 @@ impl Node {
 			self.liquidity_source.clone(),
 			Arc::clone(&self.payment_store),
 			Arc::clone(&self.peer_store),
+			static_invoice_store,
 			Arc::clone(&self.runtime),
 			Arc::clone(&self.logger),
 			Arc::clone(&self.config),
@@ -818,6 +826,7 @@ impl Node {
 		Bolt12Payment::new(
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.payment_store),
+			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
 			Arc::clone(&self.logger),
 		)
@@ -831,6 +840,7 @@ impl Node {
 		Arc::new(Bolt12Payment::new(
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.payment_store),
+			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
 			Arc::clone(&self.logger),
 		))

--- a/src/payment/asynchronous/mod.rs
+++ b/src/payment/asynchronous/mod.rs
@@ -1,0 +1,9 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+mod rate_limiter;
+pub(crate) mod static_invoice_store;

--- a/src/payment/asynchronous/rate_limiter.rs
+++ b/src/payment/asynchronous/rate_limiter.rs
@@ -1,0 +1,96 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+//! [`RateLimiter`] to control the rate of requests from users.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Implements a leaky-bucket style rate limiter parameterized by the max capacity of the bucket, the refill interval,
+/// and the max idle duration.
+///
+/// For every passing of the refill interval, one token is added to the bucket, up to the maximum capacity. When the
+/// bucket has remained at the maximum capacity for longer than the max idle duration, it is removed to prevent memory
+/// leakage.
+pub(crate) struct RateLimiter {
+	users: HashMap<Vec<u8>, Bucket>,
+	capacity: u32,
+	refill_interval: Duration,
+	max_idle: Duration,
+}
+
+struct Bucket {
+	tokens: u32,
+	last_refill: Instant,
+}
+
+impl RateLimiter {
+	pub(crate) fn new(capacity: u32, refill_interval: Duration, max_idle: Duration) -> Self {
+		Self { users: HashMap::new(), capacity, refill_interval, max_idle }
+	}
+
+	pub(crate) fn allow(&mut self, user_id: &[u8]) -> bool {
+		let now = Instant::now();
+
+		let entry = self.users.entry(user_id.to_vec());
+		let is_new_user = matches!(entry, std::collections::hash_map::Entry::Vacant(_));
+
+		let bucket = entry.or_insert(Bucket { tokens: self.capacity, last_refill: now });
+
+		let elapsed = now.duration_since(bucket.last_refill);
+		let tokens_to_add = (elapsed.as_secs_f64() / self.refill_interval.as_secs_f64()) as u32;
+
+		if tokens_to_add > 0 {
+			bucket.tokens = (bucket.tokens + tokens_to_add).min(self.capacity);
+			bucket.last_refill = now;
+		}
+
+		let allow = if bucket.tokens > 0 {
+			bucket.tokens -= 1;
+			true
+		} else {
+			false
+		};
+
+		// Each time a new user is added, we take the opportunity to clean up old rate limits.
+		if is_new_user {
+			self.garbage_collect(self.max_idle);
+		}
+
+		allow
+	}
+
+	fn garbage_collect(&mut self, max_idle: Duration) {
+		let now = Instant::now();
+		self.users.retain(|_, bucket| now.duration_since(bucket.last_refill) < max_idle);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::payment::asynchronous::rate_limiter::RateLimiter;
+
+	use std::time::Duration;
+
+	#[test]
+	fn rate_limiter_test() {
+		// Test
+		let mut rate_limiter =
+			RateLimiter::new(3, Duration::from_millis(100), Duration::from_secs(1));
+
+		assert!(rate_limiter.allow(b"user1"));
+		assert!(rate_limiter.allow(b"user1"));
+		assert!(rate_limiter.allow(b"user1"));
+		assert!(!rate_limiter.allow(b"user1"));
+		assert!(rate_limiter.allow(b"user2"));
+
+		std::thread::sleep(Duration::from_millis(150));
+
+		assert!(rate_limiter.allow(b"user1"));
+		assert!(rate_limiter.allow(b"user2"));
+	}
+}

--- a/src/payment/asynchronous/static_invoice_store.rs
+++ b/src/payment/asynchronous/static_invoice_store.rs
@@ -1,0 +1,277 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+//! Store implementation for [`StaticInvoice`]s.
+
+use crate::hex_utils;
+use crate::io::STATIC_INVOICE_STORE_PRIMARY_NAMESPACE;
+use crate::payment::asynchronous::rate_limiter::RateLimiter;
+use crate::types::DynStore;
+
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::Hash;
+
+use lightning::{offers::static_invoice::StaticInvoice, util::ser::Writeable};
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+pub(crate) struct StaticInvoiceStore {
+	kv_store: Arc<DynStore>,
+	request_rate_limiter: Mutex<RateLimiter>,
+	persist_rate_limiter: Mutex<RateLimiter>,
+}
+
+impl StaticInvoiceStore {
+	const RATE_LIMITER_BUCKET_CAPACITY: u32 = 5;
+	const RATE_LIMITER_REFILL_INTERVAL: Duration = Duration::from_millis(100);
+	const RATE_LIMITER_MAX_IDLE: Duration = Duration::from_secs(600);
+
+	pub(crate) fn new(kv_store: Arc<DynStore>) -> Self {
+		Self {
+			kv_store,
+			request_rate_limiter: Mutex::new(RateLimiter::new(
+				Self::RATE_LIMITER_BUCKET_CAPACITY,
+				Self::RATE_LIMITER_REFILL_INTERVAL,
+				Self::RATE_LIMITER_MAX_IDLE,
+			)),
+			persist_rate_limiter: Mutex::new(RateLimiter::new(
+				Self::RATE_LIMITER_BUCKET_CAPACITY,
+				Self::RATE_LIMITER_REFILL_INTERVAL,
+				Self::RATE_LIMITER_MAX_IDLE,
+			)),
+		}
+	}
+
+	fn check_rate_limit(
+		limiter: &Mutex<RateLimiter>, recipient_id: &[u8],
+	) -> Result<(), lightning::io::Error> {
+		let mut limiter = limiter.lock().unwrap();
+		if !limiter.allow(recipient_id) {
+			Err(lightning::io::Error::new(lightning::io::ErrorKind::Other, "Rate limit exceeded"))
+		} else {
+			Ok(())
+		}
+	}
+
+	pub(crate) async fn handle_static_invoice_requested(
+		&self, recipient_id: &[u8], invoice_slot: u16,
+	) -> Result<Option<StaticInvoice>, lightning::io::Error> {
+		Self::check_rate_limit(&self.request_rate_limiter, &recipient_id)?;
+
+		let (secondary_namespace, key) = Self::get_storage_location(invoice_slot, recipient_id);
+
+		self.kv_store
+			.read(STATIC_INVOICE_STORE_PRIMARY_NAMESPACE, &secondary_namespace, &key)
+			.and_then(|data| {
+				data.try_into().map(Some).map_err(|e| {
+					lightning::io::Error::new(
+						lightning::io::ErrorKind::InvalidData,
+						format!("Failed to parse static invoice: {:?}", e),
+					)
+				})
+			})
+			.or_else(
+				|e| {
+					if e.kind() == lightning::io::ErrorKind::NotFound {
+						Ok(None)
+					} else {
+						Err(e)
+					}
+				},
+			)
+	}
+
+	pub(crate) async fn handle_persist_static_invoice(
+		&self, invoice: StaticInvoice, invoice_slot: u16, recipient_id: Vec<u8>,
+	) -> Result<(), lightning::io::Error> {
+		Self::check_rate_limit(&self.persist_rate_limiter, &recipient_id)?;
+
+		let (secondary_namespace, key) = Self::get_storage_location(invoice_slot, &recipient_id);
+
+		let mut buf = Vec::new();
+		invoice.write(&mut buf)?;
+
+		// Static invoices will be persisted at "static_invoices/<sha256(recipient_id)>/<invoice_slot>".
+		//
+		// Example: static_invoices/039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81/00001
+		self.kv_store.write(STATIC_INVOICE_STORE_PRIMARY_NAMESPACE, &secondary_namespace, &key, buf)
+	}
+
+	fn get_storage_location(invoice_slot: u16, recipient_id: &[u8]) -> (String, String) {
+		let hash = Sha256::hash(recipient_id).to_byte_array();
+		let secondary_namespace = hex_utils::to_string(&hash);
+
+		let key = format!("{:05}", invoice_slot);
+		(secondary_namespace, key)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{sync::Arc, time::Duration};
+
+	use bitcoin::{
+		key::{Keypair, Secp256k1},
+		secp256k1::{PublicKey, SecretKey},
+	};
+	use lightning::blinded_path::{
+		message::BlindedMessagePath,
+		payment::{BlindedPayInfo, BlindedPaymentPath},
+		BlindedHop,
+	};
+	use lightning::ln::inbound_payment::ExpandedKey;
+	use lightning::offers::{
+		nonce::Nonce,
+		offer::OfferBuilder,
+		static_invoice::{StaticInvoice, StaticInvoiceBuilder},
+	};
+	use lightning::sign::EntropySource;
+	use lightning::util::test_utils::TestStore;
+	use lightning_types::features::BlindedHopFeatures;
+
+	use crate::payment::asynchronous::static_invoice_store::StaticInvoiceStore;
+	use crate::types::DynStore;
+
+	#[tokio::test]
+	async fn static_invoice_store_test() {
+		let store: Arc<DynStore> = Arc::new(TestStore::new(false));
+		let static_invoice_store = StaticInvoiceStore::new(Arc::clone(&store));
+
+		let static_invoice = invoice();
+		let recipient_id = vec![1, 1, 1];
+		assert!(static_invoice_store
+			.handle_persist_static_invoice(static_invoice.clone(), 0, recipient_id.clone())
+			.await
+			.is_ok());
+
+		let requested_invoice =
+			static_invoice_store.handle_static_invoice_requested(&recipient_id, 0).await.unwrap();
+
+		assert_eq!(requested_invoice.unwrap(), static_invoice);
+
+		assert!(static_invoice_store
+			.handle_static_invoice_requested(&recipient_id, 1)
+			.await
+			.unwrap()
+			.is_none());
+
+		assert!(static_invoice_store
+			.handle_static_invoice_requested(&[2, 2, 2], 0)
+			.await
+			.unwrap()
+			.is_none());
+	}
+
+	fn invoice() -> StaticInvoice {
+		let node_id = recipient_pubkey();
+		let payment_paths = payment_paths();
+		let now = now();
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+
+		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
+			.path(blinded_path())
+			.build()
+			.unwrap();
+
+		StaticInvoiceBuilder::for_offer_using_derived_keys(
+			&offer,
+			payment_paths.clone(),
+			vec![blinded_path()],
+			now,
+			&expanded_key,
+			nonce,
+			&secp_ctx,
+		)
+		.unwrap()
+		.build_and_sign(&secp_ctx)
+		.unwrap()
+	}
+
+	fn now() -> Duration {
+		std::time::SystemTime::now()
+			.duration_since(std::time::SystemTime::UNIX_EPOCH)
+			.expect("SystemTime::now() should come after SystemTime::UNIX_EPOCH")
+	}
+
+	fn payment_paths() -> Vec<BlindedPaymentPath> {
+		vec![
+			BlindedPaymentPath::from_blinded_path_and_payinfo(
+				pubkey(40),
+				pubkey(41),
+				vec![
+					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
+					BlindedHop { blinded_node_id: pubkey(44), encrypted_payload: vec![0; 44] },
+				],
+				BlindedPayInfo {
+					fee_base_msat: 1,
+					fee_proportional_millionths: 1_000,
+					cltv_expiry_delta: 42,
+					htlc_minimum_msat: 100,
+					htlc_maximum_msat: 1_000_000_000_000,
+					features: BlindedHopFeatures::empty(),
+				},
+			),
+			BlindedPaymentPath::from_blinded_path_and_payinfo(
+				pubkey(40),
+				pubkey(41),
+				vec![
+					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },
+					BlindedHop { blinded_node_id: pubkey(46), encrypted_payload: vec![0; 46] },
+				],
+				BlindedPayInfo {
+					fee_base_msat: 1,
+					fee_proportional_millionths: 1_000,
+					cltv_expiry_delta: 42,
+					htlc_minimum_msat: 100,
+					htlc_maximum_msat: 1_000_000_000_000,
+					features: BlindedHopFeatures::empty(),
+				},
+			),
+		]
+	}
+
+	fn blinded_path() -> BlindedMessagePath {
+		BlindedMessagePath::from_blinded_path(
+			pubkey(40),
+			pubkey(41),
+			vec![
+				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },
+				BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 44] },
+			],
+		)
+	}
+
+	fn pubkey(byte: u8) -> PublicKey {
+		let secp_ctx = Secp256k1::new();
+		PublicKey::from_secret_key(&secp_ctx, &privkey(byte))
+	}
+
+	fn privkey(byte: u8) -> SecretKey {
+		SecretKey::from_slice(&[byte; 32]).unwrap()
+	}
+
+	fn recipient_keys() -> Keypair {
+		let secp_ctx = Secp256k1::new();
+		Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[43; 32]).unwrap())
+	}
+
+	fn recipient_pubkey() -> PublicKey {
+		recipient_keys().public_key()
+	}
+
+	struct FixedEntropy;
+
+	impl EntropySource for FixedEntropy {
+		fn get_secure_random_bytes(&self) -> [u8; 32] {
+			[42; 32]
+		}
+	}
+}

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -7,6 +7,7 @@
 
 //! Objects for different types of payments.
 
+pub(crate) mod asynchronous;
 mod bolt11;
 mod bolt12;
 mod onchain;

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,7 +123,7 @@ pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMesse
 	Arc<ChannelManager>,
 	Arc<MessageRouter>,
 	Arc<ChannelManager>,
-	IgnoringMessageHandler,
+	Arc<ChannelManager>,
 	IgnoringMessageHandler,
 	IgnoringMessageHandler,
 >;


### PR DESCRIPTION
Wires up async payments functionality in ldk-node. This PR only covers the static invoice creation part. In a follow up, the full mechanism will be put in place to hold an htlc sender-side until the receiver comes online again.