### PR TITLE
Use `crate::runtime::Runtime` for `VssStore`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -694,10 +694,7 @@ impl NodeBuilder {
 		let vss_seed_bytes: [u8; 32] = vss_xprv.private_key.secret_bytes();
 
 		let vss_store =
-			VssStore::new(vss_url, store_id, vss_seed_bytes, header_provider).map_err(|e| {
-				log_error!(logger, "Failed to setup VssStore: {}", e);
-				BuildError::KVStoreSetupFailed
-			})?;
+			VssStore::new(vss_url, store_id, vss_seed_bytes, header_provider, Arc::clone(&runtime));
 		build_with_store_internal(
 			config,
 			self.chain_data_source_config.as_ref(),


### PR DESCRIPTION
.. which should give us cleaner reuse/handling of outer runtime contexts, cleanup on `Drop`, etc.