### PR TITLE
Enhance onchain transaction management

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -277,6 +277,8 @@ interface OnchainPayment {
 	Txid send_to_address([ByRef]Address address, u64 amount_sats, FeeRate? fee_rate);
 	[Throws=NodeError]
 	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve, FeeRate? fee_rate);
+	[Throws=NodeError]
+	Txid bump_fee_rbf(PaymentId payment_id, FeeRate? fee_rate);
 };
 
 interface FeeRate {

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -10,6 +10,7 @@
 use std::sync::{Arc, RwLock};
 
 use bitcoin::{Address, Txid};
+use lightning::ln::channelmanager::PaymentId;
 
 use crate::config::Config;
 use crate::error::Error;
@@ -119,5 +120,21 @@ impl OnchainPayment {
 
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
 		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+	}
+
+	/// Attempt to bump the fee of an unconfirmed transaction using Replace-by-Fee (RBF).
+	///
+	/// This creates a new transaction that replaces the original one, increasing the fee by the
+	/// specified increment to improve its chances of confirmation.
+	///
+	/// The new transaction will have the same outputs as the original but with a
+	/// higher fee, resulting in faster confirmation potential.
+	///
+	/// Returns the [`Txid`] of the new replacement transaction if successful.
+	pub fn bump_fee_rbf(
+		&self, payment_id: PaymentId, fee_rate: Option<FeeRate>,
+	) -> Result<Txid, Error> {
+		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
+		self.wallet.bump_fee_rbf(payment_id, fee_rate_opt)
 	}
 }

--- a/src/payment/pending_payment_store.rs
+++ b/src/payment/pending_payment_store.rs
@@ -84,10 +84,11 @@ impl StorableObjectUpdate<PendingPaymentDetails> for PendingPaymentDetailsUpdate
 
 impl From<&PendingPaymentDetails> for PendingPaymentDetailsUpdate {
 	fn from(value: &PendingPaymentDetails) -> Self {
-		Self {
-			id: value.id(),
-			payment_update: Some(value.details.to_update()),
-			conflicting_txids: Some(value.conflicting_txids.clone()),
-		}
+		let conflicting_txids = if value.conflicting_txids.is_empty() {
+			None
+		} else {
+			Some(value.conflicting_txids.clone())
+		};
+		Self { id: value.id(), payment_update: Some(value.details.to_update()), conflicting_txids }
 	}
 }


### PR DESCRIPTION
This PR enhances on-chain transaction management:

1. **Rebroadcast/bumping of on-chain wallet transactions**

2. **Handle RBF'd Pending payments**

### Changes

- Added background job for rebroadcasting unconfirmed onchain transactions with max attempt limit
- Implemented RBF (Replace-by-Fee) functionality allowing users to bump fees on outbound unconfirmed transactions

### Related Issues

- Fixes https://github.com/lightningdevkit/ldk-node/issues/367