### PR TITLE
Add onion mailbox for async recipients

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -13,7 +13,6 @@ dictionary Config {
 	u64 probing_liquidity_limit_multiplier;
 	AnchorChannelsConfig? anchor_channels_config;
 	RouteParametersConfig? route_parameters;
-	boolean async_payment_services_enabled;
 };
 
 dictionary AnchorChannelsConfig {
@@ -95,6 +94,8 @@ interface Builder {
 	void set_announcement_addresses(sequence<SocketAddress> announcement_addresses);
 	[Throws=BuildError]
 	void set_node_alias(string node_alias);
+	[Throws=BuildError]
+	void set_async_payments_role(AsyncPaymentsRole? role);
 	[Throws=BuildError]
 	Node build();
 	[Throws=BuildError]
@@ -356,6 +357,7 @@ enum BuildError {
 	"WalletSetupFailed",
 	"LoggerSetupFailed",
 	"NetworkMismatch",
+	"AsyncPaymentsConfigMismatch",
 };
 
 [Trait]
@@ -718,6 +720,11 @@ enum Currency {
 	"Regtest",
 	"Simnet",
 	"Signet",
+};
+
+enum AsyncPaymentsRole {
+	"Client",
+	"Server",
 };
 
 dictionary RouteHintHop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,8 +179,6 @@ pub struct Config {
 	/// **Note:** If unset, default parameters will be used, and you will be able to override the
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub route_parameters: Option<RouteParametersConfig>,
-	/// Whether to enable the static invoice service to support async payment reception for clients.
-	pub async_payment_services_enabled: bool,
 }
 
 impl Default for Config {
@@ -195,7 +193,6 @@ impl Default for Config {
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			route_parameters: None,
 			node_alias: None,
-			async_payment_services_enabled: false,
 		}
 	}
 }
@@ -535,6 +532,19 @@ impl From<MaxDustHTLCExposure> for LdkMaxDustHTLCExposure {
 			},
 		}
 	}
+}
+
+#[derive(Debug, Clone, Copy)]
+/// The role of the node in an asynchronous payments context.
+///
+/// See <https://github.com/lightning/bolts/pull/1149> for more information about the async payments protocol.
+pub enum AsyncPaymentsRole {
+	/// Node acts a client in an async payments context. This means that if possible, it will instruct its peers to hold
+	/// HTLCs for it, so that it can go offline.
+	Client,
+	/// Node acts as a server in an async payments context. This means that it will hold async payments HTLCs and onion
+	/// messages for its peers.
+	Server,
 }
 
 #[cfg(test)]

--- a/src/payment/asynchronous/mod.rs
+++ b/src/payment/asynchronous/mod.rs
@@ -5,5 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+pub(crate) mod om_mailbox;
 mod rate_limiter;
 pub(crate) mod static_invoice_store;

--- a/src/payment/asynchronous/om_mailbox.rs
+++ b/src/payment/asynchronous/om_mailbox.rs
@@ -1,0 +1,99 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::msgs::OnionMessage;
+
+pub(crate) struct OnionMessageMailbox {
+	map: Mutex<HashMap<PublicKey, VecDeque<OnionMessage>>>,
+}
+
+impl OnionMessageMailbox {
+	const MAX_MESSAGES_PER_PEER: usize = 30;
+	const MAX_PEERS: usize = 300;
+
+	pub fn new() -> Self {
+		Self { map: Mutex::new(HashMap::with_capacity(Self::MAX_PEERS)) }
+	}
+
+	pub(crate) fn onion_message_intercepted(&self, peer_node_id: PublicKey, message: OnionMessage) {
+		let mut map = self.map.lock().unwrap();
+
+		let queue = map.entry(peer_node_id).or_insert_with(VecDeque::new);
+		if queue.len() >= Self::MAX_MESSAGES_PER_PEER {
+			queue.pop_front();
+		}
+		queue.push_back(message);
+
+		// Enforce a peers limit. If exceeded, evict the peer with the longest queue.
+		if map.len() > Self::MAX_PEERS {
+			let peer_to_remove =
+				map.iter().max_by_key(|(_, queue)| queue.len()).map(|(peer, _)| *peer).unwrap();
+
+			map.remove(&peer_to_remove);
+		}
+	}
+
+	pub(crate) fn onion_message_peer_connected(
+		&self, peer_node_id: PublicKey,
+	) -> Vec<OnionMessage> {
+		let mut map = self.map.lock().unwrap();
+
+		if let Some(queue) = map.remove(&peer_node_id) {
+			queue.into()
+		} else {
+			Vec::new()
+		}
+	}
+
+	#[cfg(test)]
+	pub(crate) fn is_empty(&self) -> bool {
+		let map = self.map.lock().unwrap();
+		map.is_empty()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bitcoin::key::Secp256k1;
+	use bitcoin::secp256k1::{PublicKey, SecretKey};
+	use lightning::onion_message;
+
+	use crate::payment::asynchronous::om_mailbox::OnionMessageMailbox;
+
+	#[test]
+	fn onion_message_mailbox() {
+		let mailbox = OnionMessageMailbox::new();
+
+		let secp = Secp256k1::new();
+		let sk_bytes = [12; 32];
+		let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+		let peer_node_id = PublicKey::from_secret_key(&secp, &sk);
+
+		let blinding_sk = SecretKey::from_slice(&[13; 32]).unwrap();
+		let blinding_point = PublicKey::from_secret_key(&secp, &blinding_sk);
+
+		let message_sk = SecretKey::from_slice(&[13; 32]).unwrap();
+		let message_point = PublicKey::from_secret_key(&secp, &message_sk);
+
+		let message = lightning::ln::msgs::OnionMessage {
+			blinding_point,
+			onion_routing_packet: onion_message::packet::Packet {
+				version: 0,
+				public_key: message_point,
+				hop_data: vec![1, 2, 3],
+				hmac: [0; 32],
+			},
+		};
+		mailbox.onion_message_intercepted(peer_node_id, message.clone());
+
+		let messages = mailbox.onion_message_peer_connected(peer_node_id);
+		assert_eq!(messages.len(), 1);
+		assert_eq!(messages[0], message);
+
+		assert!(mailbox.is_empty());
+
+		let messages = mailbox.onion_message_peer_connected(peer_node_id);
+		assert_eq!(messages.len(), 0);
+	}
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod logging;
 
 use logging::TestLogWriter;
 
-use ldk_node::config::{Config, ElectrumSyncConfig, EsploraSyncConfig};
+use ldk_node::config::{AsyncPaymentsRole, Config, ElectrumSyncConfig, EsploraSyncConfig};
 use ldk_node::io::sqlite_store::SqliteStore;
 use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus};
 use ldk_node::{
@@ -311,6 +311,13 @@ pub(crate) fn setup_two_nodes(
 pub(crate) fn setup_node(
 	chain_source: &TestChainSource, config: TestConfig, seed_bytes: Option<Vec<u8>>,
 ) -> TestNode {
+	setup_node_for_async_payments(chain_source, config, seed_bytes, None)
+}
+
+pub(crate) fn setup_node_for_async_payments(
+	chain_source: &TestChainSource, config: TestConfig, seed_bytes: Option<Vec<u8>>,
+	async_payments_role: Option<AsyncPaymentsRole>,
+) -> TestNode {
 	setup_builder!(builder, config.node_config);
 	match chain_source {
 		TestChainSource::Esplora(electrsd) => {
@@ -374,6 +381,8 @@ pub(crate) fn setup_node(
 			builder.set_entropy_seed_bytes(bytes);
 		}
 	}
+
+	builder.set_async_payments_role(async_payments_role).unwrap();
 
 	let test_sync_store = Arc::new(TestSyncStore::new(config.node_config.storage_dir_path.into()));
 	let node = builder.build_with_store(test_sync_store).unwrap();


### PR DESCRIPTION
Adds functionality for LSPs to hold onion messages for their clients until they come back online.

Depends on https://github.com/lightningdevkit/rust-lightning/pull/4046
