### PR TITLE
Multi node console log

### DIFF
--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -1,5 +1,4 @@
 use chrono::Utc;
-#[cfg(not(feature = "uniffi"))]
 use ldk_node::logger::LogRecord;
 use ldk_node::logger::{LogLevel, LogWriter};
 #[cfg(not(feature = "uniffi"))]
@@ -142,4 +141,30 @@ pub(crate) fn validate_log_entry(entry: &String) {
 	let msg_start_index = path_and_msg.find(']').unwrap() + 1;
 	let msg = &path_and_msg[msg_start_index..];
 	assert!(!msg.is_empty());
+}
+
+pub(crate) struct MultiNodeLogger {
+	node_id: String,
+}
+
+impl MultiNodeLogger {
+	pub(crate) fn new(node_id: String) -> Self {
+		Self { node_id }
+	}
+}
+
+impl LogWriter for MultiNodeLogger {
+	fn log(&self, record: LogRecord) {
+		let log = format!(
+			"[{}] {} {:<5} [{}:{}] {}\n",
+			self.node_id,
+			Utc::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+			record.level.to_string(),
+			record.module_path,
+			record.line,
+			record.args
+		);
+
+		print!("{}", log);
+	}
 }

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -12,6 +12,7 @@ use common::{
 	expect_channel_pending_event, expect_channel_ready_event, expect_event,
 	expect_payment_claimable_event, expect_payment_received_event, expect_payment_successful_event,
 	generate_blocks_and_wait,
+	logging::MultiNodeLogger,
 	logging::{init_log_logger, validate_log_entry, TestLogWriter},
 	open_channel, premine_and_distribute_funds, premine_blocks, prepare_rbf, random_config,
 	random_listening_addresses, setup_bitcoind_and_electrsd, setup_builder, setup_node,
@@ -1135,17 +1136,27 @@ fn static_invoice_server() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let chain_source = TestChainSource::Esplora(&electrsd);
 
-	let config_sender = random_config(true);
+	let mut config_sender = random_config(true);
+	config_sender.log_writer =
+		TestLogWriter::Custom(Arc::new(MultiNodeLogger::new("sender      ".to_string())));
 	let node_sender = setup_node(&chain_source, config_sender, None);
 
-	let config_sender_lsp = random_config(true);
+	let mut config_sender_lsp = random_config(true);
+	config_sender_lsp.log_writer =
+		TestLogWriter::Custom(Arc::new(MultiNodeLogger::new("sender_lsp  ".to_string())));
 	let node_sender_lsp = setup_node(&chain_source, config_sender_lsp, None);
 
 	let mut config_receiver_lsp = random_config(true);
 	config_receiver_lsp.node_config.async_payment_services_enabled = true;
+	config_receiver_lsp.log_writer =
+		TestLogWriter::Custom(Arc::new(MultiNodeLogger::new("receiver_lsp".to_string())));
+
 	let node_receiver_lsp = setup_node(&chain_source, config_receiver_lsp, None);
 
-	let config_receiver = random_config(true);
+	let mut config_receiver = random_config(true);
+	config_receiver.log_writer =
+		TestLogWriter::Custom(Arc::new(MultiNodeLogger::new("receiver    ".to_string())));
+
 	let node_receiver = setup_node(&chain_source, config_receiver, None);
 
 	let address_sender = node_sender.onchain_payment().new_address().unwrap();


### PR DESCRIPTION
Multiple test debug runs with the temporary log files isn't a great dev experience. This PR replaces file logging with console logging with a node identifier prefix to keep the nodes apart.