### PR TITLE
Add LNURL-auth support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ bdk_esplora = { version = "0.22.0", default-features = false, features = ["async
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls-ring"]}
 bdk_wallet = { version = "2.3.0", default-features = false, features = ["std", "keys-bip39"]}
 
-bitreq = { version = "0.3", default-features = false, features = ["async-https"] }
+bitreq = { version = "0.3", default-features = false, features = ["async-https", "json-using-serde"] }
 rustls = { version = "0.23", default-features = false }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 bitcoin = "0.32.7"

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -166,6 +166,8 @@ interface Node {
 	UnifiedPayment unified_payment();
 	LSPS1Liquidity lsps1_liquidity();
 	[Throws=NodeError]
+	void lnurl_auth(string lnurl);
+	[Throws=NodeError]
 	void connect(PublicKey node_id, SocketAddress address, boolean persist);
 	[Throws=NodeError]
 	void disconnect(PublicKey node_id);
@@ -364,6 +366,9 @@ enum NodeError {
 	"InvalidBlindedPaths",
 	"AsyncPaymentServicesDisabled",
 	"HrnParsingFailed",
+	"LnurlAuthFailed",
+	"LnurlAuthTimeout",
+	"InvalidLnurl",
 };
 
 dictionary NodeStatus {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -68,6 +68,7 @@ use crate::io::{
 use crate::liquidity::{
 	LSPS1ClientConfig, LSPS2ClientConfig, LSPS2ServiceConfig, LiquiditySourceBuilder,
 };
+use crate::lnurl_auth::LnurlAuth;
 use crate::logger::{log_error, LdkLogger, LogLevel, LogWriter, Logger};
 use crate::message_handler::NodeCustomMessageHandler;
 use crate::payment::asynchronous::om_mailbox::OnionMessageMailbox;
@@ -1765,6 +1766,8 @@ fn build_with_store_internal(
 		None
 	};
 
+	let lnurl_auth = Arc::new(LnurlAuth::new(xprv, Arc::clone(&logger)));
+
 	let (stop_sender, _) = tokio::sync::watch::channel(());
 	let (background_processor_stop_sender, _) = tokio::sync::watch::channel(());
 	let is_running = Arc::new(RwLock::new(false));
@@ -1810,6 +1813,7 @@ fn build_with_store_internal(
 		scorer,
 		peer_store,
 		payment_store,
+		lnurl_auth,
 		is_running,
 		node_metrics,
 		om_mailbox,

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,9 @@ pub(crate) const EXTERNAL_PATHFINDING_SCORES_SYNC_TIMEOUT_SECS: u64 = 5;
 // The timeout after which we abort a parsing/looking up an HRN resolution.
 pub(crate) const HRN_RESOLUTION_TIMEOUT_SECS: u64 = 5;
 
+// The timeout after which we abort an LNURL-auth operation.
+pub(crate) const LNURL_AUTH_TIMEOUT_SECS: u64 = 15;
+
 #[derive(Debug, Clone)]
 /// Represents the configuration of an [`Node`] instance.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,6 +131,12 @@ pub enum Error {
 	AsyncPaymentServicesDisabled,
 	/// Parsing a Human-Readable Name has failed.
 	HrnParsingFailed,
+	/// LNURL-auth authentication failed.
+	LnurlAuthFailed,
+	/// LNURL-auth authentication timed out.
+	LnurlAuthTimeout,
+	/// The provided lnurl is invalid.
+	InvalidLnurl,
 }
 
 impl fmt::Display for Error {
@@ -213,6 +219,9 @@ impl fmt::Display for Error {
 			Self::HrnParsingFailed => {
 				write!(f, "Failed to parse a human-readable name.")
 			},
+			Self::LnurlAuthFailed => write!(f, "LNURL-auth authentication failed."),
+			Self::LnurlAuthTimeout => write!(f, "LNURL-auth authentication timed out."),
+			Self::InvalidLnurl => write!(f, "The provided lnurl is invalid."),
 		}
 	}
 }

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -43,6 +43,7 @@ use vss_client::util::storable_builder::{EntropySource, StorableBuilder};
 
 use crate::entropy::NodeEntropy;
 use crate::io::utils::check_namespace_key_validity;
+use crate::lnurl_auth::LNURL_AUTH_HARDENED_CHILD_INDEX;
 
 type CustomRetryPolicy = FilteredRetryPolicy<
 	JitteredRetryPolicy<
@@ -68,7 +69,6 @@ impl_writeable_tlv_based_enum!(VssSchemaVersion,
 );
 
 const VSS_HARDENED_CHILD_INDEX: u32 = 877;
-const VSS_LNURL_AUTH_HARDENED_CHILD_INDEX: u32 = 138;
 const VSS_SCHEMA_VERSION_KEY: &str = "vss_schema_version";
 
 // We set this to a small number of threads that would still allow to make some progress if one
@@ -902,7 +902,7 @@ impl VssStoreBuilder {
 		let lnurl_auth_xprv = vss_xprv
 			.derive_priv(
 				&secp_ctx,
-				&[ChildNumber::Hardened { index: VSS_LNURL_AUTH_HARDENED_CHILD_INDEX }],
+				&[ChildNumber::Hardened { index: LNURL_AUTH_HARDENED_CHILD_INDEX }],
 			)
 			.map_err(|_| VssStoreBuildError::KeyDerivationFailed)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod graph;
 mod hex_utils;
 pub mod io;
 pub mod liquidity;
+mod lnurl_auth;
 pub mod logger;
 mod message_handler;
 pub mod payment;
@@ -124,7 +125,8 @@ pub use builder::NodeBuilder as Builder;
 use chain::ChainSource;
 use config::{
 	default_user_config, may_announce_channel, AsyncPaymentsRole, ChannelConfig, Config,
-	NODE_ANN_BCAST_INTERVAL, PEER_RECONNECTION_INTERVAL, RGS_SYNC_INTERVAL,
+	LNURL_AUTH_TIMEOUT_SECS, NODE_ANN_BCAST_INTERVAL, PEER_RECONNECTION_INTERVAL,
+	RGS_SYNC_INTERVAL,
 };
 use connection::ConnectionManager;
 pub use error::Error as NodeError;
@@ -148,6 +150,7 @@ use lightning::util::persist::KVStoreSync;
 use lightning::util::wallet_utils::Wallet as LdkWallet;
 use lightning_background_processor::process_events_async;
 use liquidity::{LSPS1Liquidity, LiquiditySource};
+use lnurl_auth::LnurlAuth;
 use logger::{log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
 use payment::asynchronous::om_mailbox::OnionMessageMailbox;
 use payment::asynchronous::static_invoice_store::StaticInvoiceStore;
@@ -220,6 +223,7 @@ pub struct Node {
 	scorer: Arc<Mutex<Scorer>>,
 	peer_store: Arc<PeerStore<Arc<Logger>>>,
 	payment_store: Arc<PaymentStore>,
+	lnurl_auth: Arc<LnurlAuth>,
 	is_running: Arc<RwLock<bool>>,
 	node_metrics: Arc<RwLock<NodeMetrics>>,
 	om_mailbox: Option<Arc<OnionMessageMailbox>>,
@@ -1003,6 +1007,26 @@ impl Node {
 			Arc::clone(&self.logger),
 			Arc::clone(&self.hrn_resolver),
 		))
+	}
+
+	/// Authenticates the user via [LNURL-auth] for the given LNURL string.
+	///
+	/// [LNURL-auth]: https://github.com/lnurl/luds/blob/luds/04.md
+	pub fn lnurl_auth(&self, lnurl: String) -> Result<(), Error> {
+		let auth = Arc::clone(&self.lnurl_auth);
+		self.runtime.block_on(async move {
+			let res = tokio::time::timeout(
+				Duration::from_secs(LNURL_AUTH_TIMEOUT_SECS),
+				auth.authenticate(&lnurl),
+			)
+			.await;
+
+			match res {
+				Ok(Ok(())) => Ok(()),
+				Ok(Err(e)) => Err(e),
+				Err(_) => Err(Error::LnurlAuthTimeout),
+			}
+		})
 	}
 
 	/// Returns a liquidity handler allowing to request channels via the [bLIP-51 / LSPS1] protocol.

--- a/src/lnurl_auth.rs
+++ b/src/lnurl_auth.rs
@@ -1,0 +1,298 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+use crate::logger::{log_debug, log_error, Logger};
+use crate::Error;
+
+use bitcoin::bip32::{ChildNumber, Xpriv};
+use bitcoin::hashes::{hex::FromHex, sha256, Hash, HashEngine, Hmac, HmacEngine};
+use bitcoin::secp256k1::{All, Message, Secp256k1, SecretKey};
+use lightning::util::logger::Logger as LdkLogger;
+
+use bitcoin::bech32;
+use bitreq::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// The BIP-32 hardened child index used for LNURL-auth key derivation as defined by LUD-05.
+pub(crate) const LNURL_AUTH_HARDENED_CHILD_INDEX: u32 = 138;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LnurlAuthResponse {
+	status: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	reason: Option<String>,
+}
+
+/// An LNURL-auth handler providing authentication with LNURL-auth compatible services.
+///
+/// LNURL-auth allows secure, privacy-preserving authentication using domain-specific keys
+/// derived from the node's master key via [LUD-05] BIP-32 key derivation. Each domain gets
+/// a unique key, ensuring privacy while allowing consistent authentication across sessions.
+///
+/// [LUD-05]: https://github.com/lnurl/luds/blob/luds/05.md
+#[derive(Clone)]
+pub struct LnurlAuth {
+	/// The xpriv at m/138', used for deriving domain-specific linking keys.
+	lnurl_auth_base_xprv: Xpriv,
+	/// The private key at m/138'/0, used as the HMAC key for derivation material.
+	hashing_key: [u8; 32],
+	client: Client,
+	secp: Secp256k1<All>,
+	logger: Arc<Logger>,
+}
+
+impl LnurlAuth {
+	pub(crate) fn new(xprv: Xpriv, logger: Arc<Logger>) -> Self {
+		let secp = Secp256k1::new();
+		let lnurl_auth_base_xprv = xprv
+			.derive_priv(&secp, &[ChildNumber::Hardened { index: LNURL_AUTH_HARDENED_CHILD_INDEX }])
+			.expect("BIP-32 derivation of m/138' should not fail");
+		let hashing_key_xprv = lnurl_auth_base_xprv
+			.derive_priv(&secp, &[ChildNumber::Normal { index: 0 }])
+			.expect("BIP-32 derivation of m/138'/0 should not fail");
+		let hashing_key = hashing_key_xprv.private_key.secret_bytes();
+		let client = Client::new(2);
+		Self { lnurl_auth_base_xprv, hashing_key, client, secp, logger }
+	}
+
+	/// Authenticates with an LNURL-auth compatible service using the provided URL.
+	///
+	/// The authentication process involves:
+	/// 1. Fetching the challenge from the service
+	/// 2. Deriving a domain-specific linking key
+	/// 3. Signing the challenge with the linking key
+	/// 4. Submitting the signed response to complete authentication
+	///
+	/// Returns `Ok(())` if authentication succeeds, or an error if the process fails.
+	pub async fn authenticate(&self, lnurl: &str) -> Result<(), Error> {
+		let (hrp, bytes) = bech32::decode(lnurl).map_err(|e| {
+			log_error!(self.logger, "Failed to decode LNURL: {e}");
+			Error::InvalidLnurl
+		})?;
+
+		if hrp.to_lowercase() != "lnurl" {
+			log_error!(self.logger, "Invalid LNURL prefix: {hrp}");
+			return Err(Error::InvalidLnurl);
+		}
+
+		let lnurl_auth_url = String::from_utf8(bytes).map_err(|e| {
+			log_error!(self.logger, "Failed to convert LNURL bytes to string: {e}");
+			Error::InvalidLnurl
+		})?;
+
+		log_debug!(self.logger, "Starting LNURL-auth process for URL: {lnurl_auth_url}");
+
+		// Parse the URL to extract domain and parameters
+		let url = bitreq::Url::parse(&lnurl_auth_url).map_err(|e| {
+			log_error!(self.logger, "Invalid LNURL-auth URL: {e}");
+			Error::InvalidLnurl
+		})?;
+
+		let domain = url.base_url();
+
+		// get query parameters for k1 and tag
+		let query_params: std::collections::HashMap<_, _> = url.query_pairs().collect();
+
+		let tag = query_params.get("tag").ok_or_else(|| {
+			log_error!(self.logger, "No tag parameter found in LNURL-auth URL");
+			Error::InvalidLnurl
+		})?;
+
+		if tag != "login" {
+			log_error!(self.logger, "Invalid tag parameter in LNURL-auth URL: {tag}");
+			return Err(Error::InvalidLnurl);
+		}
+
+		let k1 = query_params.get("k1").ok_or_else(|| {
+			log_error!(self.logger, "No k1 parameter found in LNURL-auth URL");
+			Error::InvalidLnurl
+		})?;
+
+		let k1_bytes: [u8; 32] = FromHex::from_hex(k1).map_err(|e| {
+			log_error!(self.logger, "Invalid k1 hex in challenge: {e}");
+			Error::LnurlAuthFailed
+		})?;
+
+		// Derive domain-specific linking key
+		let linking_secret_key = self.derive_linking_key(&self.secp, domain)?;
+		let linking_public_key = linking_secret_key.public_key(&self.secp);
+
+		// Sign the challenge
+		let message = Message::from_digest_slice(&k1_bytes).map_err(|e| {
+			log_error!(self.logger, "Failed to create message from k1: {e}");
+			Error::LnurlAuthFailed
+		})?;
+
+		let signature = self.secp.sign_ecdsa(&message, &linking_secret_key);
+
+		// Submit authentication response
+		let auth_url = format!("{lnurl_auth_url}&sig={signature}&key={linking_public_key}");
+
+		log_debug!(self.logger, "Submitting LNURL-auth response");
+		let request = bitreq::get(&auth_url);
+		let auth_response = self.client.send_async(request).await.map_err(|e| {
+			log_error!(self.logger, "Failed to submit LNURL-auth response: {e}");
+			Error::LnurlAuthFailed
+		})?;
+
+		let response: LnurlAuthResponse = auth_response.json().map_err(|e| {
+			log_error!(self.logger, "Failed to parse LNURL-auth response: {e}");
+			Error::LnurlAuthFailed
+		})?;
+
+		if response.status == "OK" {
+			log_debug!(self.logger, "LNURL-auth authentication successful");
+			Ok(())
+		} else {
+			let reason = response.reason.unwrap_or_else(|| "Unknown error".to_string());
+			log_error!(self.logger, "LNURL-auth authentication failed: {reason}");
+			Err(Error::LnurlAuthFailed)
+		}
+	}
+
+	fn derive_linking_key(&self, secp: &Secp256k1<All>, domain: &str) -> Result<SecretKey, Error> {
+		let path_indices = linking_key_path(&self.hashing_key, domain);
+
+		// Derive the linking key at m/138'/[idx1]/[idx2]/[idx3]/[idx4]
+		let linking_xprv =
+			self.lnurl_auth_base_xprv.derive_priv(&secp, &path_indices).map_err(|e| {
+				log_error!(self.logger, "Failed to derive linking key: {e}");
+				Error::LnurlAuthFailed
+			})?;
+
+		Ok(SecretKey::from(linking_xprv.private_key))
+	}
+}
+
+/// Computes the LUD-05 linking key path for a given domain.
+///
+/// Takes the hashing key (private key at `m/138'/0`) and a domain name, and returns the 4
+/// `ChildNumber` path components derived from `HMAC-SHA256(hashing_key, domain)`.
+fn linking_key_path(hashing_key: &[u8; 32], domain_name: &str) -> Vec<ChildNumber> {
+	let mut engine = HmacEngine::<sha256::Hash>::new(&hashing_key[..]);
+	engine.input(domain_name.as_bytes());
+	let result = Hmac::<sha256::Hash>::from_engine(engine).to_byte_array();
+	// unwrap safety: We take 4-byte chunks, so TryInto for [u8; 4] never fails.
+	result
+		.chunks_exact(4)
+		.take(4)
+		.map(|i| u32::from_be_bytes(i.try_into().unwrap()))
+		.map(ChildNumber::from)
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bitcoin::Network;
+
+	fn build_auth(seed: [u8; 32]) -> LnurlAuth {
+		let logger = Arc::new(Logger::new_log_facade());
+		let xprv = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+		LnurlAuth::new(xprv, logger)
+	}
+
+	/// Build an LnurlAuth from a base xprv that is already at m/138'.
+	fn build_auth_from_base_xprv(base_xprv: Xpriv) -> LnurlAuth {
+		let secp = Secp256k1::new();
+		let hashing_key_xprv =
+			base_xprv.derive_priv(&secp, &[ChildNumber::Normal { index: 0 }]).unwrap();
+		let hashing_key = hashing_key_xprv.private_key.secret_bytes();
+		let logger = Arc::new(Logger::new_log_facade());
+		let client = Client::new(2);
+		LnurlAuth { lnurl_auth_base_xprv: base_xprv, hashing_key, client, logger, secp }
+	}
+
+	#[test]
+	fn test_deterministic_key_derivation() {
+		let secp = Secp256k1::new();
+		let auth = build_auth([42u8; 32]);
+		let domain = "example.com";
+
+		// Keys should be identical for the same inputs
+		let key1 = auth.derive_linking_key(&secp, domain).unwrap();
+		let key2 = auth.derive_linking_key(&secp, domain).unwrap();
+		assert_eq!(key1, key2);
+
+		// Keys should be different for different domains
+		let key3 = auth.derive_linking_key(&secp, "different.com").unwrap();
+		assert_ne!(key1, key3);
+
+		// Keys should be different for different master keys
+		let different_master = build_auth([24u8; 32]);
+		let key4 = different_master.derive_linking_key(&secp, domain).unwrap();
+		assert_ne!(key1, key4);
+	}
+
+	#[test]
+	fn test_domain_isolation() {
+		let secp = Secp256k1::new();
+		let auth = build_auth([42u8; 32]);
+		let domains = ["example.com", "test.org", "service.net"];
+		let mut keys = Vec::with_capacity(domains.len());
+
+		for domain in &domains {
+			keys.push(auth.derive_linking_key(&secp, domain).unwrap());
+		}
+
+		for i in 0..keys.len() {
+			for j in 0..keys.len() {
+				if i == j {
+					continue;
+				}
+				assert_ne!(
+					keys[i], keys[j],
+					"Keys for {} and {} should be different",
+					domains[i], domains[j]
+				);
+			}
+		}
+	}
+
+	/// Test vector from LUD-05 specification.
+	/// https://github.com/lnurl/luds/blob/luds/05.md
+	#[test]
+	fn test_lud05_linking_key_path_vector() {
+		let hashing_key: [u8; 32] =
+			FromHex::from_hex("7d417a6a5e9a6a4a879aeaba11a11838764c8fa2b959c242d43dea682b3e409b")
+				.unwrap();
+		let path = linking_key_path(&hashing_key, "site.com");
+		let numbers: Vec<u32> = path.iter().map(|c| u32::from(*c)).collect();
+		assert_eq!(numbers, vec![1588488367, 2659270754, 38110259, 4136336762]);
+	}
+
+	/// Test vector matching vss-client's sign_lnurl test to ensure compatible derivation.
+	#[test]
+	fn test_sign_lnurl_vector() {
+		let secp = Secp256k1::new();
+		let parent_key_bytes: [u8; 32] =
+			FromHex::from_hex("abababababababababababababababababababababababababababababababab")
+				.unwrap();
+		let base_xprv = Xpriv::new_master(Network::Testnet, &parent_key_bytes).unwrap();
+		let auth = build_auth_from_base_xprv(base_xprv);
+
+		let domain = "example.com";
+		let k1_hex = "e2af6254a8df433264fa23f67eb8188635d15ce883e8fc020989d5f82ae6f11e";
+		let k1_bytes: [u8; 32] = FromHex::from_hex(k1_hex).unwrap();
+
+		let linking_secret_key = auth.derive_linking_key(&secp, domain).unwrap();
+		let linking_public_key = linking_secret_key.public_key(&secp);
+
+		let message = Message::from_digest_slice(&k1_bytes).unwrap();
+		let signature = secp.sign_ecdsa(&message, &linking_secret_key);
+
+		assert_eq!(
+			format!("{linking_public_key}"),
+			"02d9eb1b467517d685e3b5439082c14bb1a2c9ae672df4d9046d208c193a5846e0"
+		);
+		assert_eq!(
+			format!("{signature}"),
+			"3045022100a75df468de452e618edb8030016eb0894204655c7d93ece1be007fcf36843522022048bc2f00a0a5a30601d274b49cfaf9ef4c76176e5401d0dfb195f5d6ab8ab4c4"
+		);
+	}
+}


### PR DESCRIPTION
Implements LNURL-auth (LUD-04) specification for secure, privacy-preserving authentication with Lightning services using domain-specific key derivation.

I used LUD-05 for deriving the keys to mimic what we do for VSS auth.

I was able to auth with stacker.news with this so it works!