### PR TITLE
Implement CPFP fee bumping for unconfirmed transactions

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -231,6 +231,8 @@ interface OnchainPayment {
 	Txid send_to_address([ByRef]Address address, u64 amount_sats, FeeRate? fee_rate);
 	[Throws=NodeError]
 	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve, FeeRate? fee_rate);
+	[Throws=NodeError]
+	Txid bump_fee_cpfp(PaymentId payment_id);
 };
 
 interface FeeRate {

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -14,6 +14,7 @@ use crate::types::{ChannelManager, Wallet};
 use crate::wallet::OnchainSendAmount;
 
 use bitcoin::{Address, Txid};
+use lightning::ln::channelmanager::PaymentId;
 
 use std::sync::{Arc, RwLock};
 
@@ -119,5 +120,32 @@ impl OnchainPayment {
 
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
 		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+	}
+
+	/// Bumps the fee of a given UTXO using Child-Pays-For-Parent (CPFP) by creating a new transaction.
+	///
+	/// This method creates a new transaction that spends the specified UTXO with a higher fee rate,
+	/// effectively increasing the priority of both the new transaction and the parent transaction
+	/// it depends on. This is useful when a transaction is stuck in the mempool due to insufficient
+	/// fees and you want to accelerate its confirmation.
+	///
+	/// CPFP works by creating a child transaction that spends one or more outputs from the parent
+	/// transaction. Miners will consider the combined fees of both transactions when deciding
+	/// which transactions to include in a block.
+	///
+	/// # Parameters
+	/// * `payment_id` - The identifier of the payment whose UTXO should be fee-bumped
+	///
+	/// # Returns
+	/// * `Ok(Txid)` - The transaction ID of the newly created CPFP transaction on success
+	/// * `Err(Error)` - If the payment cannot be found, the UTXO is not suitable for CPFP,
+	///   or if there's an error creating the transaction
+	///
+	/// # Note
+	/// CPFP is specifically designed to work with unconfirmed UTXOs. The child transaction
+	/// can spend outputs from unconfirmed parent transactions, allowing miners to consider
+	/// the combined fees of both transactions when building a block.
+	pub fn bump_fee_cpfp(&self, payment_id: PaymentId) -> Result<Txid, Error> {
+		self.wallet.bump_fee_cpfp(payment_id)
 	}
 }

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -33,9 +33,9 @@ use lightning::util::persist::KVStore;
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
 use lightning_types::payment::{PaymentHash, PaymentPreimage};
 
-use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;
+use bitcoin::{address::NetworkUnchecked, Txid};
 use bitcoin::{Address, Amount, ScriptBuf};
 use log::LevelFilter;
 
@@ -1698,4 +1698,106 @@ async fn drop_in_async_context() {
 	let config = random_config(true);
 	let node = setup_node(&chain_source, config, Some(seed_bytes));
 	node.stop().unwrap();
+}
+
+#[test]
+fn test_fee_bump_cpfp() {
+	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
+	let chain_source = TestChainSource::Esplora(&electrsd);
+	let (node_a, node_b) = setup_two_nodes(&chain_source, false, true, false);
+
+	// Fund both nodes
+	let addr_a = node_a.onchain_payment().new_address().unwrap();
+	let addr_b = node_b.onchain_payment().new_address().unwrap();
+
+	let premine_amount_sat = 500_000;
+	premine_and_distribute_funds(
+		&bitcoind.client,
+		&electrsd.client,
+		vec![addr_a.clone(), addr_b.clone()],
+		Amount::from_sat(premine_amount_sat),
+	);
+
+	node_a.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
+
+	// Send a transaction from node_b to node_a that we'll later bump
+	let amount_to_send_sats = 100_000;
+	let txid =
+		node_b.onchain_payment().send_to_address(&addr_a, amount_to_send_sats, None).unwrap();
+	wait_for_tx(&electrsd.client, txid);
+	node_a.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
+
+	let payment_id = PaymentId(txid.to_byte_array());
+	let original_payment = node_b.payment(&payment_id).unwrap();
+	let original_fee = original_payment.fee_paid_msat.unwrap();
+
+	// Non-existent payment id
+	let fake_txid =
+		Txid::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
+	let invalid_payment_id = PaymentId(fake_txid.to_byte_array());
+	assert_eq!(
+		Err(NodeError::InvalidPaymentId),
+		node_b.onchain_payment().bump_fee_cpfp(invalid_payment_id)
+	);
+
+	// Bump an outbound payment
+	assert_eq!(
+		Err(NodeError::InvalidPaymentId),
+		node_b.onchain_payment().bump_fee_cpfp(payment_id)
+	);
+
+	// Successful fee bump via CPFP
+	let new_txid = node_a.onchain_payment().bump_fee_cpfp(payment_id).unwrap();
+	wait_for_tx(&electrsd.client, new_txid);
+
+	// Sleep to allow for transaction propagation
+	std::thread::sleep(std::time::Duration::from_secs(5));
+
+	node_a.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
+
+	let new_payment_id = PaymentId(new_txid.to_byte_array());
+	let new_payment = node_a.payment(&new_payment_id).unwrap();
+
+	// Verify payment properties
+	assert_eq!(new_payment.amount_msat, Some(amount_to_send_sats * 1000));
+	assert_eq!(new_payment.direction, PaymentDirection::Outbound);
+	assert_eq!(new_payment.status, PaymentStatus::Pending);
+
+	// // Verify fee increased
+	assert!(
+		new_payment.fee_paid_msat > Some(original_fee),
+		"Fee should increase after RBF bump. Original: {}, New: {}",
+		original_fee,
+		new_payment.fee_paid_msat.unwrap()
+	);
+
+	// Confirm the transaction and try to bump again (should fail)
+	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6);
+	node_a.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
+
+	assert_eq!(
+		Err(NodeError::InvalidPaymentId),
+		node_a.onchain_payment().bump_fee_cpfp(payment_id)
+	);
+
+	// Verify final payment is confirmed
+	let final_payment = node_b.payment(&payment_id).unwrap();
+	assert_eq!(final_payment.status, PaymentStatus::Succeeded);
+	match final_payment.kind {
+		PaymentKind::Onchain { status, .. } => {
+			assert!(matches!(status, ConfirmationStatus::Confirmed { .. }));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
+
+	// Verify node A received the funds correctly
+	let node_a_received_payment =
+		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { txid, .. }));
+	assert_eq!(node_a_received_payment.len(), 1);
+	assert_eq!(node_a_received_payment[0].amount_msat, Some(amount_to_send_sats * 1000));
+	assert_eq!(node_a_received_payment[0].status, PaymentStatus::Succeeded);
 }


### PR DESCRIPTION
Add `Child-Pays-For-Parent` functionality to allow users to accelerate pending unconfirmed transactions by creating higher-fee child spends. This provides an alternative to Replace-by-Fee bumping when direct transaction replacement is not available or desired.

- Creates new transactions spending from unconfirmed UTXOs with increased fees
- Specifically designed for accelerating stuck unconfirmed transactions
- Miners consider combined fees of parent and child transactions
- Maintains payment tracking and wallet state consistency
- Includes integration tests covering various CPFP scenarios
- Provides clear error handling for unsuitable or confirmed UTXOs

The feature is accessible via `bump_fee_cpfp(payment_id)` method.