### PR TITLE
Try to log status code for `reqwest`'s `Request` error kind

### DIFF
--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -144,12 +144,22 @@ impl EsploraChainSource {
 						},
 						Err(e) => match *e {
 							esplora_client::Error::Reqwest(he) => {
-								log_error!(
-									self.logger,
-									"{} of on-chain wallet failed due to HTTP connection error: {}",
-									if incremental_sync { "Incremental sync" } else { "Sync" },
-									he
-								);
+								if let Some(status_code) = he.status() {
+									log_error!(
+										self.logger,
+										"{} of on-chain wallet failed due to HTTP {} error: {}",
+										if incremental_sync { "Incremental sync" } else { "Sync" },
+										status_code,
+										he,
+									);
+								} else {
+									log_error!(
+										self.logger,
+										"{} of on-chain wallet failed due to HTTP error: {}",
+										if incremental_sync { "Incremental sync" } else { "Sync" },
+										he,
+									);
+								}
 								Err(Error::WalletOperationFailed)
 							},
 							_ => {


### PR DESCRIPTION
We attempt to log a status code when `reqwest` returns a `Request` error kind. It might not be the case that the status code would always/ever be set for this error kind.