### PR TITLE
Re-format all imports

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,3 +10,5 @@ match_block_trailing_comma = true
 # UNSTABLE: format_macro_matchers = true
 # UNSTABLE: format_strings = true
 # UNSTABLE: group_imports = "StdExternalCrate"
+# UNSTABLE: reorder_imports = true
+# UNSTABLE: imports_granularity = "Module"

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -5,16 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use lightning::chain::channelmonitor::Balance as LdkBalance;
-use lightning::chain::channelmonitor::BalanceSource;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::{Amount, BlockHash, Txid};
+use lightning::chain::channelmonitor::{Balance as LdkBalance, BalanceSource};
 use lightning::ln::types::ChannelId;
 use lightning::sign::SpendableOutputDescriptor;
 use lightning::util::sweep::{OutputSpendStatus, TrackedSpendableOutput};
-
 use lightning_types::payment::{PaymentHash, PaymentPreimage};
-
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::{Amount, BlockHash, Txid};
 
 /// Details of the known available balances returned by [`Node::list_balances`].
 ///

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -5,8 +5,25 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use super::{periodically_archive_fully_resolved_monitors, WalletSyncStatus};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use bdk_chain::bdk_core::spk_client::{
+	FullScanRequest as BdkFullScanRequest, FullScanResponse as BdkFullScanResponse,
+	SyncRequest as BdkSyncRequest, SyncResponse as BdkSyncResponse,
+};
+use bdk_electrum::BdkElectrumClient;
+use bdk_wallet::{KeychainKind as BdkKeyChainKind, Update as BdkUpdate};
+use bitcoin::{FeeRate, Network, Script, ScriptBuf, Transaction, Txid};
+use electrum_client::{
+	Batch, Client as ElectrumClient, ConfigBuilder as ElectrumConfigBuilder, ElectrumApi,
+};
+use lightning::chain::{Confirm, Filter, WatchedOutput};
+use lightning::util::ser::Writeable;
+use lightning_transaction_sync::ElectrumSyncClient;
+
+use super::{periodically_archive_fully_resolved_monitors, WalletSyncStatus};
 use crate::config::{
 	Config, ElectrumSyncConfig, BDK_CLIENT_STOP_GAP, BDK_WALLET_SYNC_TIMEOUT_SECS,
 	FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS, LDK_WALLET_SYNC_TIMEOUT_SECS, TX_BROADCAST_TIMEOUT_SECS,
@@ -21,29 +38,6 @@ use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkLogger, Logger
 use crate::runtime::Runtime;
 use crate::types::{ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::NodeMetrics;
-
-use lightning::chain::{Confirm, Filter, WatchedOutput};
-use lightning::util::ser::Writeable;
-use lightning_transaction_sync::ElectrumSyncClient;
-
-use bdk_chain::bdk_core::spk_client::FullScanRequest as BdkFullScanRequest;
-use bdk_chain::bdk_core::spk_client::FullScanResponse as BdkFullScanResponse;
-use bdk_chain::bdk_core::spk_client::SyncRequest as BdkSyncRequest;
-use bdk_chain::bdk_core::spk_client::SyncResponse as BdkSyncResponse;
-use bdk_wallet::KeychainKind as BdkKeyChainKind;
-use bdk_wallet::Update as BdkUpdate;
-
-use bdk_electrum::BdkElectrumClient;
-
-use electrum_client::Client as ElectrumClient;
-use electrum_client::ConfigBuilder as ElectrumConfigBuilder;
-use electrum_client::{Batch, ElectrumApi};
-
-use bitcoin::{FeeRate, Network, Script, ScriptBuf, Transaction, Txid};
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const BDK_ELECTRUM_CLIENT_BATCH_SIZE: usize = 5;
 const ELECTRUM_CLIENT_NUM_RETRIES: u8 = 3;

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -5,8 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use super::{periodically_archive_fully_resolved_monitors, WalletSyncStatus};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use bdk_esplora::EsploraAsyncExt;
+use bitcoin::{FeeRate, Network, Script, Transaction, Txid};
+use esplora_client::AsyncClient as EsploraAsyncClient;
+use lightning::chain::{Confirm, Filter, WatchedOutput};
+use lightning::util::ser::Writeable;
+use lightning_transaction_sync::EsploraSyncClient;
+
+use super::{periodically_archive_fully_resolved_monitors, WalletSyncStatus};
 use crate::config::{
 	Config, EsploraSyncConfig, BDK_CLIENT_CONCURRENCY, BDK_CLIENT_STOP_GAP,
 	BDK_WALLET_SYNC_TIMEOUT_SECS, DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS,
@@ -20,21 +30,6 @@ use crate::io::utils::write_node_metrics;
 use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkLogger, Logger};
 use crate::types::{ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
-
-use lightning::chain::{Confirm, Filter, WatchedOutput};
-use lightning::util::ser::Writeable;
-
-use lightning_transaction_sync::EsploraSyncClient;
-
-use bdk_esplora::EsploraAsyncExt;
-
-use esplora_client::AsyncClient as EsploraAsyncClient;
-
-use bitcoin::{FeeRate, Network, Script, Transaction, Txid};
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 pub(super) struct EsploraChainSource {
 	pub(super) sync_config: EsploraSyncConfig,

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -9,6 +9,14 @@ mod bitcoind;
 mod electrum;
 mod esplora;
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use bitcoin::{Script, Txid};
+use lightning::chain::Filter;
+use lightning_block_sync::gossip::UtxoSource;
+
 use crate::chain::bitcoind::BitcoindChainSource;
 use crate::chain::electrum::ElectrumChainSource;
 use crate::chain::esplora::EsploraChainSource;
@@ -22,16 +30,6 @@ use crate::logger::{log_debug, log_info, log_trace, LdkLogger, Logger};
 use crate::runtime::Runtime;
 use crate::types::{Broadcaster, ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
-
-use lightning::chain::Filter;
-
-use lightning_block_sync::gossip::UtxoSource;
-
-use bitcoin::{Script, Txid};
-
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 pub(crate) enum WalletSyncStatus {
 	Completed,

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,20 +7,19 @@
 
 //! Objects for configuring the node.
 
-use crate::logger::LogLevel;
-
-use lightning::ln::msgs::SocketAddress;
-use lightning::routing::gossip::NodeAlias;
-use lightning::routing::router::RouteParametersConfig;
-use lightning::util::config::ChannelConfig as LdkChannelConfig;
-use lightning::util::config::MaxDustHTLCExposure as LdkMaxDustHTLCExposure;
-use lightning::util::config::UserConfig;
+use std::fmt;
+use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
+use lightning::ln::msgs::SocketAddress;
+use lightning::routing::gossip::NodeAlias;
+use lightning::routing::router::RouteParametersConfig;
+use lightning::util::config::{
+	ChannelConfig as LdkChannelConfig, MaxDustHTLCExposure as LdkMaxDustHTLCExposure, UserConfig,
+};
 
-use std::fmt;
-use std::time::Duration;
+use crate::logger::LogLevel;
 
 // Config defaults
 const DEFAULT_NETWORK: Network = Network::Bitcoin;
@@ -551,11 +550,7 @@ pub enum AsyncPaymentsRole {
 mod tests {
 	use std::str::FromStr;
 
-	use super::may_announce_channel;
-	use super::AnnounceError;
-	use super::Config;
-	use super::NodeAlias;
-	use super::SocketAddress;
+	use super::{may_announce_channel, AnnounceError, Config, NodeAlias, SocketAddress};
 
 	#[test]
 	fn node_announce_channel() {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,19 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use crate::logger::{log_error, log_info, LdkLogger};
-use crate::types::PeerManager;
-use crate::Error;
-
-use lightning::ln::msgs::SocketAddress;
-
-use bitcoin::secp256k1::PublicKey;
-
 use std::collections::hash_map::{self, HashMap};
 use std::net::ToSocketAddrs;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::msgs::SocketAddress;
+
+use crate::logger::{log_error, log_info, LdkLogger};
+use crate::types::PeerManager;
+use crate::Error;
 
 pub(crate) struct ConnectionManager<L: Deref + Clone + Sync + Send>
 where

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -5,16 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use crate::logger::{log_error, LdkLogger};
-use crate::types::DynStore;
-use crate::Error;
+use std::collections::{hash_map, HashMap};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use lightning::util::ser::{Readable, Writeable};
 
-use std::collections::hash_map;
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use crate::logger::{log_error, LdkLogger};
+use crate::types::DynStore;
+use crate::Error;
 
 pub(crate) trait StorableObject: Clone + Readable + Writeable {
 	type Id: StorableObjectId;
@@ -164,9 +163,8 @@ mod tests {
 	use lightning::impl_writeable_tlv_based;
 	use lightning::util::test_utils::{TestLogger, TestStore};
 
-	use crate::hex_utils;
-
 	use super::*;
+	use crate::hex_utils;
 
 	#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 	struct TestObjectId {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,13 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::fmt;
+
 use bdk_chain::bitcoin::psbt::ExtractTxError as BdkExtractTxError;
 use bdk_chain::local_chain::CannotConnectError as BdkChainConnectionError;
 use bdk_chain::tx_graph::CalculateFeeError as BdkChainCalculateFeeError;
 use bdk_wallet::error::CreateTxError as BdkCreateTxError;
 use bdk_wallet::signer::SignerError as BdkSignerError;
-
-use std::fmt;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// An error that possibly needs to be handled by the user.

--- a/src/fee_estimator.rs
+++ b/src/fee_estimator.rs
@@ -5,14 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use lightning::chain::chaininterface::ConfirmationTarget as LdkConfirmationTarget;
-use lightning::chain::chaininterface::FeeEstimator as LdkFeeEstimator;
-use lightning::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
-
-use bitcoin::FeeRate;
-
 use std::collections::HashMap;
 use std::sync::RwLock;
+
+use bitcoin::FeeRate;
+use lightning::chain::chaininterface::{
+	ConfirmationTarget as LdkConfirmationTarget, FeeEstimator as LdkFeeEstimator,
+	FEERATE_FLOOR_SATS_PER_KW,
+};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub(crate) enum ConfirmationTarget {

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -5,21 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use lightning::util::native_async::FutureSpawner;
+use lightning_block_sync::gossip::GossipVerifier;
+
 use crate::chain::ChainSource;
 use crate::config::RGS_SYNC_TIMEOUT_SECS;
 use crate::logger::{log_trace, LdkLogger, Logger};
 use crate::runtime::Runtime;
 use crate::types::{GossipSync, Graph, P2PGossipSync, PeerManager, RapidGossipSync, UtxoLookup};
 use crate::Error;
-
-use lightning_block_sync::gossip::GossipVerifier;
-
-use lightning::util::native_async::FutureSpawner;
-
-use std::future::Future;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
 
 pub(crate) enum GossipSource {
 	P2PNetwork {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,19 +7,17 @@
 
 //! Objects for querying the network graph.
 
-use crate::types::Graph;
-
-use lightning::routing::gossip::NodeId;
+use std::sync::Arc;
 
 #[cfg(feature = "uniffi")]
 use lightning::ln::msgs::SocketAddress;
+use lightning::routing::gossip::NodeId;
 #[cfg(feature = "uniffi")]
 use lightning::routing::gossip::RoutingFees;
-
 #[cfg(not(feature = "uniffi"))]
 use lightning::routing::gossip::{ChannelInfo, NodeInfo};
 
-use std::sync::Arc;
+use crate::types::Graph;
 
 /// Represents the network as nodes and channels between them.
 pub struct NetworkGraph {

--- a/src/io/sqlite_store/migrations.rs
+++ b/src/io/sqlite_store/migrations.rs
@@ -5,9 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use rusqlite::Connection;
-
 use lightning::io;
+use rusqlite::Connection;
 
 pub(super) fn migrate_schema(
 	connection: &mut Connection, kv_table_name: &str, from_version: u16, to_version: u16,
@@ -75,14 +74,13 @@ pub(super) fn migrate_schema(
 
 #[cfg(test)]
 mod tests {
-	use crate::io::sqlite_store::SqliteStore;
-	use crate::io::test_utils::{do_read_write_remove_list_persist, random_storage_path};
+	use std::fs;
 
 	use lightning::util::persist::KVStoreSync;
-
 	use rusqlite::{named_params, Connection};
 
-	use std::fs;
+	use crate::io::sqlite_store::SqliteStore;
+	use crate::io::test_utils::{do_read_write_remove_list_persist, random_storage_path};
 
 	#[test]
 	fn rwrl_post_schema_1_migration() {

--- a/src/io/sqlite_store/mod.rs
+++ b/src/io/sqlite_store/mod.rs
@@ -6,18 +6,16 @@
 // accordance with one or both of these licenses.
 
 //! Objects related to [`SqliteStore`] live here.
-use crate::io::utils::check_namespace_key_validity;
-
-use lightning::io;
-use lightning::util::persist::KVStoreSync;
-
-use lightning_types::string::PrintableString;
-
-use rusqlite::{named_params, Connection};
-
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+use lightning::io;
+use lightning::util::persist::KVStoreSync;
+use lightning_types::string::PrintableString;
+use rusqlite::{named_params, Connection};
+
+use crate::io::utils::check_namespace_key_validity;
 
 mod migrations;
 

--- a/src/io/test_utils.rs
+++ b/src/io/test_utils.rs
@@ -5,21 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::panic::RefUnwindSafe;
+use std::path::PathBuf;
+
+use lightning::events::ClosureReason;
 use lightning::ln::functional_test_utils::{
 	connect_block, create_announced_chan_between_nodes, create_chanmon_cfgs, create_dummy_block,
 	create_network, create_node_cfgs, create_node_chanmgrs, send_payment,
 };
 use lightning::util::persist::{read_channel_monitors, KVStoreSync, KVSTORE_NAMESPACE_KEY_MAX_LEN};
-
-use lightning::events::ClosureReason;
 use lightning::util::test_utils;
 use lightning::{check_added_monitors, check_closed_broadcast, check_closed_event};
-
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-
-use std::panic::RefUnwindSafe;
-use std::path::PathBuf;
 
 pub(crate) fn random_storage_path() -> PathBuf {
 	let mut temp_path = std::env::temp_dir();

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -5,18 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use crate::io::utils::check_namespace_key_validity;
-use crate::runtime::Runtime;
+#[cfg(test)]
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
+use std::time::Duration;
 
 use bitcoin::hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use lightning::io::{self, Error, ErrorKind};
 use lightning::util::persist::KVStoreSync;
 use prost::Message;
 use rand::RngCore;
-#[cfg(test)]
-use std::panic::RefUnwindSafe;
-use std::sync::Arc;
-use std::time::Duration;
 use vss_client::client::VssClient;
 use vss_client::error::VssError;
 use vss_client::headers::VssHeaderProvider;
@@ -30,6 +28,9 @@ use vss_client::util::retry::{
 	MaxAttemptsRetryPolicy, MaxTotalDelayRetryPolicy, RetryPolicy,
 };
 use vss_client::util::storable_builder::{EntropySource, StorableBuilder};
+
+use crate::io::utils::check_namespace_key_validity;
+use crate::runtime::Runtime;
 
 type CustomRetryPolicy = FilteredRetryPolicy<
 	JitteredRetryPolicy<
@@ -256,13 +257,15 @@ impl RefUnwindSafe for VssStore {}
 #[cfg(test)]
 #[cfg(vss_test)]
 mod tests {
-	use super::*;
-	use crate::io::test_utils::do_read_write_remove_list_persist;
+	use std::collections::HashMap;
+
 	use rand::distributions::Alphanumeric;
 	use rand::{thread_rng, Rng, RngCore};
-	use std::collections::HashMap;
 	use tokio::runtime;
 	use vss_client::headers::FixedHeaders;
+
+	use super::*;
+	use crate::io::test_utils::do_read_write_remove_list_persist;
 
 	#[test]
 	fn vss_read_write_remove_list_persist() {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -7,21 +7,18 @@
 
 //! Logging-related objects.
 
-pub(crate) use lightning::util::logger::{Logger as LdkLogger, Record as LdkRecord};
-pub(crate) use lightning::{log_bytes, log_debug, log_error, log_info, log_trace};
-
-pub use lightning::util::logger::Level as LogLevel;
-
-use chrono::Utc;
-use log::Level as LogFacadeLevel;
-use log::Record as LogFacadeRecord;
-
 #[cfg(not(feature = "uniffi"))]
 use core::fmt;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
+
+use chrono::Utc;
+pub use lightning::util::logger::Level as LogLevel;
+pub(crate) use lightning::util::logger::{Logger as LdkLogger, Record as LdkRecord};
+pub(crate) use lightning::{log_bytes, log_debug, log_error, log_info, log_trace};
+use log::{Level as LogFacadeLevel, Record as LogFacadeRecord};
 
 /// A unit of logging output with metadata to enable filtering `module_path`,
 /// `file`, and `line` to inform on log's source.

--- a/src/message_handler.rs
+++ b/src/message_handler.rs
@@ -5,21 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use crate::liquidity::LiquiditySource;
+use std::ops::Deref;
+use std::sync::Arc;
 
+use bitcoin::secp256k1::PublicKey;
 use lightning::ln::peer_handler::CustomMessageHandler;
 use lightning::ln::wire::CustomMessageReader;
 use lightning::util::logger::Logger;
 use lightning::util::ser::LengthLimitedRead;
-
+use lightning_liquidity::lsps0::ser::RawLSPSMessage;
 use lightning_types::features::{InitFeatures, NodeFeatures};
 
-use lightning_liquidity::lsps0::ser::RawLSPSMessage;
-
-use bitcoin::secp256k1::PublicKey;
-
-use std::ops::Deref;
-use std::sync::Arc;
+use crate::liquidity::LiquiditySource;
 
 pub(crate) enum NodeCustomMessageHandler<L: Deref>
 where

--- a/src/payment/asynchronous/rate_limiter.rs
+++ b/src/payment/asynchronous/rate_limiter.rs
@@ -72,9 +72,9 @@ impl RateLimiter {
 
 #[cfg(test)]
 mod tests {
-	use crate::payment::asynchronous::rate_limiter::RateLimiter;
-
 	use std::time::Duration;
+
+	use crate::payment::asynchronous::rate_limiter::RateLimiter;
 
 	#[test]
 	fn rate_limiter_test() {

--- a/src/payment/asynchronous/static_invoice_store.rs
+++ b/src/payment/asynchronous/static_invoice_store.rs
@@ -7,20 +7,20 @@
 
 //! Store implementation for [`StaticInvoice`]s.
 
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::Hash;
+use lightning::blinded_path::message::BlindedMessagePath;
+use lightning::impl_writeable_tlv_based;
+use lightning::offers::static_invoice::StaticInvoice;
+use lightning::util::ser::{Readable, Writeable};
+
 use crate::hex_utils;
 use crate::io::STATIC_INVOICE_STORE_PRIMARY_NAMESPACE;
 use crate::payment::asynchronous::rate_limiter::RateLimiter;
 use crate::types::DynStore;
-
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::Hash;
-
-use lightning::blinded_path::message::BlindedMessagePath;
-use lightning::impl_writeable_tlv_based;
-use lightning::{offers::static_invoice::StaticInvoice, util::ser::Readable, util::ser::Writeable};
-
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 struct PersistedStaticInvoice {
 	invoice: StaticInvoice,
@@ -133,23 +133,18 @@ impl StaticInvoiceStore {
 
 #[cfg(test)]
 mod tests {
-	use std::{sync::Arc, time::Duration};
+	use std::sync::Arc;
+	use std::time::Duration;
 
-	use bitcoin::{
-		key::{Keypair, Secp256k1},
-		secp256k1::{PublicKey, SecretKey},
-	};
-	use lightning::blinded_path::{
-		message::BlindedMessagePath,
-		payment::{BlindedPayInfo, BlindedPaymentPath},
-		BlindedHop,
-	};
+	use bitcoin::key::{Keypair, Secp256k1};
+	use bitcoin::secp256k1::{PublicKey, SecretKey};
+	use lightning::blinded_path::message::BlindedMessagePath;
+	use lightning::blinded_path::payment::{BlindedPayInfo, BlindedPaymentPath};
+	use lightning::blinded_path::BlindedHop;
 	use lightning::ln::inbound_payment::ExpandedKey;
-	use lightning::offers::{
-		nonce::Nonce,
-		offer::OfferBuilder,
-		static_invoice::{StaticInvoice, StaticInvoiceBuilder},
-	};
+	use lightning::offers::nonce::Nonce;
+	use lightning::offers::offer::OfferBuilder;
+	use lightning::offers::static_invoice::{StaticInvoice, StaticInvoiceBuilder};
 	use lightning::sign::EntropySource;
 	use lightning::util::test_utils::TestStore;
 	use lightning_types::features::BlindedHopFeatures;

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -9,6 +9,19 @@
 //!
 //! [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 
+use std::sync::{Arc, RwLock};
+
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::Hash;
+use lightning::ln::channelmanager::{
+	Bolt11InvoiceParameters, Bolt11PaymentError, PaymentId, Retry, RetryableSendFailure,
+};
+use lightning::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
+use lightning_invoice::{
+	Bolt11Invoice as LdkBolt11Invoice, Bolt11InvoiceDescription as LdkBolt11InvoiceDescription,
+};
+use lightning_types::payment::{PaymentHash, PaymentPreimage};
+
 use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::connection::ConnectionManager;
 use crate::data_store::DataStoreUpdateResult;
@@ -23,21 +36,6 @@ use crate::payment::store::{
 use crate::peer_store::{PeerInfo, PeerStore};
 use crate::runtime::Runtime;
 use crate::types::{ChannelManager, PaymentStore};
-
-use lightning::ln::channelmanager::{
-	Bolt11InvoiceParameters, Bolt11PaymentError, PaymentId, Retry, RetryableSendFailure,
-};
-use lightning::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
-
-use lightning_types::payment::{PaymentHash, PaymentPreimage};
-
-use lightning_invoice::Bolt11Invoice as LdkBolt11Invoice;
-use lightning_invoice::Bolt11InvoiceDescription as LdkBolt11InvoiceDescription;
-
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::Hash;
-
-use std::sync::{Arc, RwLock};
 
 #[cfg(not(feature = "uniffi"))]
 type Bolt11Invoice = LdkBolt11Invoice;

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -9,28 +9,26 @@
 //!
 //! [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
 
-use crate::config::{AsyncPaymentsRole, LDK_PAYMENT_RETRY_TIMEOUT};
-use crate::error::Error;
-use crate::ffi::{maybe_deref, maybe_wrap};
-use crate::logger::{log_error, log_info, LdkLogger, Logger};
-use crate::payment::store::{PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus};
-use crate::types::{ChannelManager, PaymentStore};
+use std::num::NonZeroU64;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use lightning::blinded_path::message::BlindedMessagePath;
 use lightning::ln::channelmanager::{OptionalOfferPaymentParams, PaymentId, Retry};
 use lightning::offers::offer::{Amount, Offer as LdkOffer, Quantity};
 use lightning::offers::parse::Bolt12SemanticError;
 use lightning::routing::router::RouteParametersConfig;
-
 #[cfg(feature = "uniffi")]
 use lightning::util::ser::{Readable, Writeable};
 use lightning_types::string::UntrustedString;
-
 use rand::RngCore;
 
-use std::num::NonZeroU64;
-use std::sync::{Arc, RwLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use crate::config::{AsyncPaymentsRole, LDK_PAYMENT_RETRY_TIMEOUT};
+use crate::error::Error;
+use crate::ffi::{maybe_deref, maybe_wrap};
+use crate::logger::{log_error, log_info, LdkLogger, Logger};
+use crate::payment::store::{PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus};
+use crate::types::{ChannelManager, PaymentStore};
 
 #[cfg(not(feature = "uniffi"))]
 type Bolt12Invoice = lightning::offers::invoice::Bolt12Invoice;

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -7,15 +7,15 @@
 
 //! Holds a payment handler allowing to send and receive on-chain payments.
 
+use std::sync::{Arc, RwLock};
+
+use bitcoin::{Address, Txid};
+
 use crate::config::Config;
 use crate::error::Error;
 use crate::logger::{log_info, LdkLogger, Logger};
 use crate::types::{ChannelManager, Wallet};
 use crate::wallet::OnchainSendAmount;
-
-use bitcoin::{Address, Txid};
-
-use std::sync::{Arc, RwLock};
 
 #[cfg(not(feature = "uniffi"))]
 type FeeRate = bitcoin::FeeRate;

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -7,21 +7,19 @@
 
 //! Holds a payment handler allowing to send spontaneous ("keysend") payments.
 
+use std::sync::{Arc, RwLock};
+
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::channelmanager::{PaymentId, RecipientOnionFields, Retry, RetryableSendFailure};
+use lightning::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
+use lightning::sign::EntropySource;
+use lightning_types::payment::{PaymentHash, PaymentPreimage};
+
 use crate::config::{Config, LDK_PAYMENT_RETRY_TIMEOUT};
 use crate::error::Error;
 use crate::logger::{log_error, log_info, LdkLogger, Logger};
 use crate::payment::store::{PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus};
 use crate::types::{ChannelManager, CustomTlvRecord, KeysManager, PaymentStore};
-
-use lightning::ln::channelmanager::{PaymentId, RecipientOnionFields, Retry, RetryableSendFailure};
-use lightning::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
-use lightning::sign::EntropySource;
-
-use lightning_types::payment::{PaymentHash, PaymentPreimage};
-
-use bitcoin::secp256k1::PublicKey;
-
-use std::sync::{Arc, RwLock};
 
 // The default `final_cltv_expiry_delta` we apply when not set.
 const LDK_DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 144;

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bitcoin::{BlockHash, Txid};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::msgs::DecodeError;
 use lightning::offers::offer::OfferId;
@@ -13,13 +16,8 @@ use lightning::{
 	_init_and_read_len_prefixed_tlv_fields, impl_writeable_tlv_based,
 	impl_writeable_tlv_based_enum, write_tlv_fields,
 };
-
 use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning_types::string::UntrustedString;
-
-use bitcoin::{BlockHash, Txid};
-
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::data_store::{StorableObject, StorableObjectId, StorableObjectUpdate};
 use crate::hex_utils;
@@ -607,9 +605,10 @@ impl StorableObjectUpdate<PaymentDetails> for PaymentDetailsUpdate {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use bitcoin::io::Cursor;
 	use lightning::util::ser::Readable;
+
+	use super::*;
 
 	/// We refactored `PaymentDetails` to hold a payment id and moved some required fields into
 	/// `PaymentKind`. Here, we keep the old layout available in order test de/ser compatibility.

--- a/src/payment/unified_qr.rs
+++ b/src/payment/unified_qr.rs
@@ -11,23 +11,22 @@
 //! [BIP 21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
 //! [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 //! [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
-use crate::error::Error;
-use crate::ffi::maybe_wrap;
-use crate::logger::{log_error, LdkLogger, Logger};
-use crate::payment::{Bolt11Payment, Bolt12Payment, OnchainPayment};
-use crate::Config;
-
-use lightning::ln::channelmanager::PaymentId;
-use lightning::offers::offer::Offer;
-use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
+use std::sync::Arc;
+use std::vec::IntoIter;
 
 use bip21::de::ParamKind;
 use bip21::{DeserializationError, DeserializeParams, Param, SerializeParams};
 use bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bitcoin::{Amount, Txid};
+use lightning::ln::channelmanager::PaymentId;
+use lightning::offers::offer::Offer;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 
-use std::sync::Arc;
-use std::vec::IntoIter;
+use crate::error::Error;
+use crate::ffi::maybe_wrap;
+use crate::logger::{log_error, LdkLogger, Logger};
+use crate::payment::{Bolt11Payment, Bolt12Payment, OnchainPayment};
+use crate::Config;
 
 type Uri<'a> = bip21::Uri<'a, NetworkChecked, Extras>;
 
@@ -303,10 +302,12 @@ impl DeserializationError for Extras {
 
 #[cfg(test)]
 mod tests {
+	use std::str::FromStr;
+
+	use bitcoin::{Address, Network};
+
 	use super::*;
 	use crate::payment::unified_qr::Extras;
-	use bitcoin::{Address, Network};
-	use std::str::FromStr;
 
 	#[test]
 	fn parse_uri() {

--- a/src/peer_store.rs
+++ b/src/peer_store.rs
@@ -5,6 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::{Arc, RwLock};
+
+use bitcoin::secp256k1::PublicKey;
+use lightning::impl_writeable_tlv_based;
+use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
+
 use crate::io::{
 	PEER_INFO_PERSISTENCE_KEY, PEER_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
 	PEER_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -12,15 +20,6 @@ use crate::io::{
 use crate::logger::{log_error, LdkLogger};
 use crate::types::DynStore;
 use crate::{Error, SocketAddress};
-
-use lightning::impl_writeable_tlv_based;
-use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
-
-use bitcoin::secp256k1::PublicKey;
-
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::sync::{Arc, RwLock};
 
 pub struct PeerStore<L: Deref>
 where
@@ -149,11 +148,12 @@ impl_writeable_tlv_based!(PeerInfo, {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use lightning::util::test_utils::{TestLogger, TestStore};
-
 	use std::str::FromStr;
 	use std::sync::Arc;
+
+	use lightning::util::test_utils::{TestLogger, TestStore};
+
+	use super::*;
 
 	#[test]
 	fn peer_info_persistence() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,16 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::task::{JoinHandle, JoinSet};
+
 use crate::config::{
 	BACKGROUND_TASK_SHUTDOWN_TIMEOUT_SECS, LDK_EVENT_HANDLER_SHUTDOWN_TIMEOUT_SECS,
 };
 use crate::logger::{log_debug, log_error, log_trace, LdkLogger, Logger};
-
-use tokio::task::{JoinHandle, JoinSet};
-
-use std::future::Future;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 pub(crate) struct Runtime {
 	mode: RuntimeMode,

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -5,16 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use crate::logger::{log_error, LdkLogger};
-
-use lightning::chain::chaininterface::BroadcasterInterface;
+use std::ops::Deref;
 
 use bitcoin::Transaction;
+use lightning::chain::chaininterface::BroadcasterInterface;
+use tokio::sync::{mpsc, Mutex, MutexGuard};
 
-use tokio::sync::mpsc;
-use tokio::sync::{Mutex, MutexGuard};
-
-use std::ops::Deref;
+use crate::logger::{log_error, LdkLogger};
 
 const BCAST_PACKAGE_QUEUE_SIZE: usize = 50;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,27 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::sync::{Arc, Mutex};
+
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::OutPoint;
+use lightning::chain::chainmonitor;
+use lightning::impl_writeable_tlv_based;
+use lightning::ln::channel_state::ChannelDetails as LdkChannelDetails;
+use lightning::ln::msgs::{RoutingMessageHandler, SocketAddress};
+use lightning::ln::peer_handler::IgnoringMessageHandler;
+use lightning::ln::types::ChannelId;
+use lightning::routing::gossip;
+use lightning::routing::router::DefaultRouter;
+use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
+use lightning::sign::InMemorySigner;
+use lightning::util::persist::{KVStoreSync, KVStoreSyncWrapper};
+use lightning::util::ser::{Readable, Writeable, Writer};
+use lightning::util::sweep::OutputSweeper;
+use lightning_block_sync::gossip::{GossipVerifier, UtxoSource};
+use lightning_liquidity::utils::time::DefaultTimeProvider;
+use lightning_net_tokio::SocketDescriptor;
+
 use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
 use crate::data_store::DataStore;
@@ -13,33 +34,6 @@ use crate::gossip::RuntimeSpawner;
 use crate::logger::Logger;
 use crate::message_handler::NodeCustomMessageHandler;
 use crate::payment::PaymentDetails;
-
-use lightning::chain::chainmonitor;
-use lightning::impl_writeable_tlv_based;
-use lightning::ln::channel_state::ChannelDetails as LdkChannelDetails;
-use lightning::ln::msgs::RoutingMessageHandler;
-use lightning::ln::msgs::SocketAddress;
-use lightning::ln::peer_handler::IgnoringMessageHandler;
-use lightning::ln::types::ChannelId;
-use lightning::routing::gossip;
-use lightning::routing::router::DefaultRouter;
-use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
-use lightning::sign::InMemorySigner;
-use lightning::util::persist::KVStoreSync;
-use lightning::util::persist::KVStoreSyncWrapper;
-use lightning::util::ser::{Readable, Writeable, Writer};
-
-use lightning::util::sweep::OutputSweeper;
-use lightning_block_sync::gossip::{GossipVerifier, UtxoSource};
-
-use lightning_net_tokio::SocketDescriptor;
-
-use lightning_liquidity::utils::time::DefaultTimeProvider;
-
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::OutPoint;
-
-use std::sync::{Arc, Mutex};
 
 pub(crate) type DynStore = dyn KVStoreSync + Sync + Send;
 

--- a/src/wallet/persist.rs
+++ b/src/wallet/persist.rs
@@ -5,6 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::sync::Arc;
+
+use bdk_chain::Merge;
+use bdk_wallet::{ChangeSet, WalletPersister};
+
 use crate::io::utils::{
 	read_bdk_wallet_change_set, write_bdk_wallet_change_descriptor, write_bdk_wallet_descriptor,
 	write_bdk_wallet_indexer, write_bdk_wallet_local_chain, write_bdk_wallet_network,
@@ -12,11 +17,6 @@ use crate::io::utils::{
 };
 use crate::logger::{log_error, LdkLogger, Logger};
 use crate::types::DynStore;
-
-use bdk_chain::Merge;
-use bdk_wallet::{ChangeSet, WalletPersister};
-
-use std::sync::Arc;
 pub(crate) struct KVStoreWalletPersister {
 	latest_change_set: Option<ChangeSet>,
 	kv_store: Arc<DynStore>,

--- a/src/wallet/ser.rs
+++ b/src/wallet/ser.rs
@@ -5,26 +5,23 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use lightning::ln::msgs::DecodeError;
-use lightning::util::ser::{BigSize, Readable, RequiredWrapper, Writeable, Writer};
-use lightning::{decode_tlv_stream, encode_tlv_stream, read_tlv_fields, write_tlv_fields};
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+use std::sync::Arc;
 
 use bdk_chain::bdk_core::{BlockId, ConfirmationBlockTime};
 use bdk_chain::indexer::keychain_txout::ChangeSet as BdkIndexerChangeSet;
 use bdk_chain::local_chain::ChangeSet as BdkLocalChainChangeSet;
 use bdk_chain::tx_graph::ChangeSet as BdkTxGraphChangeSet;
 use bdk_chain::DescriptorId;
-
 use bdk_wallet::descriptor::Descriptor;
 use bdk_wallet::keys::DescriptorPublicKey;
-
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::p2p::Magic;
 use bitcoin::{BlockHash, Network, OutPoint, Transaction, TxOut, Txid};
-
-use std::collections::{BTreeMap, BTreeSet};
-use std::str::FromStr;
-use std::sync::Arc;
+use lightning::ln::msgs::DecodeError;
+use lightning::util::ser::{BigSize, Readable, RequiredWrapper, Writeable, Writer};
+use lightning::{decode_tlv_stream, encode_tlv_stream, read_tlv_fields, write_tlv_fields};
 
 const CHANGESET_SERIALIZATION_VERSION: u8 = 1;
 

--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -1,10 +1,10 @@
+use std::sync::{Arc, Mutex};
+
 use chrono::Utc;
-use ldk_node::logger::LogRecord;
-use ldk_node::logger::{LogLevel, LogWriter};
+use ldk_node::logger::{LogLevel, LogRecord, LogWriter};
 #[cfg(not(feature = "uniffi"))]
 use log::Record as LogFacadeRecord;
 use log::{Level as LogFacadeLevel, LevelFilter as LogFacadeLevelFilter, Log as LogFacadeLog};
-use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
 pub(crate) enum TestLogWriter {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,45 +10,38 @@
 
 pub(crate) mod logging;
 
-use logging::TestLogWriter;
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::Hash;
+use bitcoin::{
+	Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, Txid, Witness,
+};
+use electrsd::corepc_node::{Client as BitcoindClient, Node as BitcoinD};
+use electrsd::{corepc_node, ElectrsD};
+use electrum_client::ElectrumApi;
 use ldk_node::config::{AsyncPaymentsRole, Config, ElectrumSyncConfig, EsploraSyncConfig};
 use ldk_node::io::sqlite_store::SqliteStore;
 use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus};
 use ldk_node::{
 	Builder, CustomTlvRecord, Event, LightningBalance, Node, NodeError, PendingSweepBalance,
 };
-
 use lightning::ln::msgs::SocketAddress;
 use lightning::routing::gossip::NodeAlias;
 use lightning::util::persist::KVStoreSync;
 use lightning::util::test_utils::TestStore;
-
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
-use lightning_types::payment::{PaymentHash, PaymentPreimage};
-
 use lightning_persister::fs_store::FilesystemStore;
-
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::{hex::FromHex, Hash};
-use bitcoin::{
-	Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, Txid, Witness,
-};
-
-use electrsd::corepc_node::Client as BitcoindClient;
-use electrsd::corepc_node::Node as BitcoinD;
-use electrsd::{corepc_node, ElectrsD};
-use electrum_client::ElectrumApi;
-
+use lightning_types::payment::{PaymentHash, PaymentPreimage};
+use logging::TestLogWriter;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde_json::{json, Value};
-
-use std::collections::{HashMap, HashSet};
-use std::env;
-use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 macro_rules! expect_event {
 	($node: expr, $event_type: ident) => {{

--- a/tests/integration_tests_cln.rs
+++ b/tests/integration_tests_cln.rs
@@ -9,26 +9,21 @@
 
 mod common;
 
+use std::default::Default;
+use std::str::FromStr;
+
+use clightningrpc::lightningrpc::LightningRPC;
+use clightningrpc::responses::NetworkAddress;
+use electrsd::corepc_client::client_sync::Auth;
+use electrsd::corepc_node::Client as BitcoindClient;
+use electrum_client::Client as ElectrumClient;
 use ldk_node::bitcoin::secp256k1::PublicKey;
 use ldk_node::bitcoin::Amount;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::{Builder, Event};
-use lightning_invoice::{Bolt11InvoiceDescription, Description};
-
-use clightningrpc::lightningrpc::LightningRPC;
-use clightningrpc::responses::NetworkAddress;
-
-use electrsd::corepc_client::client_sync::Auth;
-use electrsd::corepc_node::Client as BitcoindClient;
-
-use electrum_client::Client as ElectrumClient;
-use lightning_invoice::Bolt11Invoice;
-
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-
-use std::default::Default;
-use std::str::FromStr;
 
 #[test]
 fn test_cln() {

--- a/tests/integration_tests_lnd.rs
+++ b/tests/integration_tests_lnd.rs
@@ -2,29 +2,25 @@
 
 mod common;
 
+use std::default::Default;
+use std::str::FromStr;
+
+use bitcoin::hex::DisplayHex;
+use electrsd::corepc_client::client_sync::Auth;
+use electrsd::corepc_node::Client as BitcoindClient;
+use electrum_client::Client as ElectrumClient;
 use ldk_node::bitcoin::secp256k1::PublicKey;
 use ldk_node::bitcoin::Amount;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::{Builder, Event};
-
+use lightning_invoice::{Bolt11InvoiceDescription, Description};
+use lnd_grpc_rust::lnrpc::invoice::InvoiceState::Settled as LndInvoiceStateSettled;
 use lnd_grpc_rust::lnrpc::{
-	invoice::InvoiceState::Settled as LndInvoiceStateSettled, GetInfoRequest as LndGetInfoRequest,
-	GetInfoResponse as LndGetInfoResponse, Invoice as LndInvoice,
-	ListInvoiceRequest as LndListInvoiceRequest, QueryRoutesRequest as LndQueryRoutesRequest,
-	Route as LndRoute, SendRequest as LndSendRequest,
+	GetInfoRequest as LndGetInfoRequest, GetInfoResponse as LndGetInfoResponse,
+	Invoice as LndInvoice, ListInvoiceRequest as LndListInvoiceRequest,
+	QueryRoutesRequest as LndQueryRoutesRequest, Route as LndRoute, SendRequest as LndSendRequest,
 };
 use lnd_grpc_rust::{connect, LndClient};
-
-use electrsd::corepc_client::client_sync::Auth;
-use electrsd::corepc_node::Client as BitcoindClient;
-
-use electrum_client::Client as ElectrumClient;
-use lightning_invoice::{Bolt11InvoiceDescription, Description};
-
-use bitcoin::hex::DisplayHex;
-
-use std::default::Default;
-use std::str::FromStr;
 use tokio::fs;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -7,19 +7,24 @@
 
 mod common;
 
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::hashes::sha256::Hash as Sha256Hash;
+use bitcoin::hashes::Hash;
+use bitcoin::{Address, Amount, ScriptBuf};
+use common::logging::{init_log_logger, validate_log_entry, MultiNodeLogger, TestLogWriter};
 use common::{
 	bump_fee_and_broadcast, distribute_funds_unconfirmed, do_channel_full_cycle,
 	expect_channel_pending_event, expect_channel_ready_event, expect_event,
 	expect_payment_claimable_event, expect_payment_received_event, expect_payment_successful_event,
-	generate_blocks_and_wait,
-	logging::MultiNodeLogger,
-	logging::{init_log_logger, validate_log_entry, TestLogWriter},
-	open_channel, open_channel_push_amt, premine_and_distribute_funds, premine_blocks, prepare_rbf,
-	random_config, random_listening_addresses, setup_bitcoind_and_electrsd, setup_builder,
-	setup_node, setup_node_for_async_payments, setup_two_nodes, wait_for_tx, TestChainSource,
-	TestSyncStore,
+	generate_blocks_and_wait, open_channel, open_channel_push_amt, premine_and_distribute_funds,
+	premine_blocks, prepare_rbf, random_config, random_listening_addresses,
+	setup_bitcoind_and_electrsd, setup_builder, setup_node, setup_node_for_async_payments,
+	setup_two_nodes, wait_for_tx, TestChainSource, TestSyncStore,
 };
-
 use ldk_node::config::{AsyncPaymentsRole, EsploraSyncConfig};
 use ldk_node::liquidity::LSPS2ServiceConfig;
 use ldk_node::payment::{
@@ -27,24 +32,13 @@ use ldk_node::payment::{
 	QrPaymentResult,
 };
 use ldk_node::{Builder, Event, NodeError};
-
 use lightning::ln::channelmanager::PaymentId;
 use lightning::routing::gossip::{NodeAlias, NodeId};
 use lightning::routing::router::RouteParametersConfig;
 use lightning::util::persist::KVStoreSync;
-
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
 use lightning_types::payment::{PaymentHash, PaymentPreimage};
-
-use bitcoin::address::NetworkUnchecked;
-use bitcoin::hashes::sha256::Hash as Sha256Hash;
-use bitcoin::hashes::Hash;
-use bitcoin::{Address, Amount, ScriptBuf};
 use log::LevelFilter;
-
-use std::collections::HashSet;
-use std::str::FromStr;
-use std::sync::Arc;
 
 #[test]
 fn channel_full_cycle() {

--- a/tests/integration_tests_vss.rs
+++ b/tests/integration_tests_vss.rs
@@ -9,8 +9,9 @@
 
 mod common;
 
-use ldk_node::Builder;
 use std::collections::HashMap;
+
+use ldk_node::Builder;
 
 #[test]
 fn channel_full_cycle_with_vss_store() {

--- a/tests/reorg_test.rs
+++ b/tests/reorg_test.rs
@@ -1,9 +1,11 @@
 mod common;
+use std::collections::HashMap;
+
 use bitcoin::Amount;
 use ldk_node::payment::{PaymentDirection, PaymentKind};
 use ldk_node::{Event, LightningBalance, PendingSweepBalance};
-use proptest::{prelude::prop, proptest};
-use std::collections::HashMap;
+use proptest::prelude::prop;
+use proptest::proptest;
 
 use crate::common::{
 	expect_event, generate_blocks_and_wait, invalidate_blocks, open_channel,


### PR DESCRIPTION
Nightly `rustfmt` allows to auto-group imports on the module level. While we're not quite convinced to switch to the nightly channel for this yet (mostly because not all contributors would have the right nightly version installed on their machines), we here make use of `cargo +nightly fmt` with some addtional import grouping options as a one-off. This cleans up our imports for the whole crate and gets us to a consistent state everywhere.

To reproduce, run `cargo +nightly fmt` with the following lines in `rustfmt.toml` enabled:

```
group_imports = "StdExternalCrate"
reorder_imports = true
imports_granularity = "Module"
```