### PR TITLE
Switch to use Rust VSS server in CI

### DIFF
--- a/.github/workflows/vss-integration.yml
+++ b/.github/workflows/vss-integration.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: YOU_MUST_CHANGE_THIS_PASSWORD
+          POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -36,54 +36,13 @@ jobs:
           repository: lightningdevkit/vss-server
           path: vss-server
 
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: '17'
-
-      - name: Start Tomcat
+      - name: Build and Deploy VSS Server
         run: |
-          docker run -d --network=host --name tomcat tomcat:latest
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: release-candidate
-
-      - name: Create database table
-        run: |
-          psql -h localhost -U postgres -d postgres -f ./vss-server/java/app/src/main/java/org/vss/impl/postgres/sql/v0_create_vss_db.sql
-        env:
-          PGPASSWORD: YOU_MUST_CHANGE_THIS_PASSWORD
-
-      - name: Build and Deploy VSS
-        run: |
-          # Print Info
-          java -version
-          gradle --version
-          
-          GRADLE_VERSION=$(gradle --version | awk '/^Gradle/ {print $2}' | head -1)
-          if [ -z "$GRADLE_VERSION" ]; then
-            echo "Error: Failed to extract Gradle version." >&2
-            exit 1
-          fi
-          echo "Extracted Gradle Version: $GRADLE_VERSION"
-
-          cd vss-server/java
-          gradle wrapper --gradle-version $GRADLE_VERSION
-          ./gradlew --version
-          ./gradlew build
-
-          docker cp app/build/libs/vss-1.0.war tomcat:/usr/local/tomcat/webapps/vss.war
-          cd ../
-      - name: Run VSS Integration tests against vss-instance.
+          cd vss-server/rust
+          cargo run server/vss-server-config.toml&
+      - name: Run VSS Integration tests
         run: |
           cd ldk-node
           export TEST_VSS_BASE_URL="http://localhost:8080/vss"
           RUSTFLAGS="--cfg vss_test" cargo build --verbose --color always
           RUSTFLAGS="--cfg vss_test" cargo test --test integration_tests_vss
-
-      - name: Cleanup
-        run: |
-          docker stop tomcat && docker rm tomcat


### PR DESCRIPTION
Since we just deprecated the Java version of the VSS server, we here switch our CI over to use the Rust version.