### PR TITLE
Remove erroneous `debug_assert` when handling `PaymentForwarded`

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1289,16 +1289,10 @@ where
 				}
 
 				if let Some(liquidity_source) = self.liquidity_source.as_ref() {
-					if let Some(skimmed_fee_msat) = skimmed_fee_msat {
-						liquidity_source
-							.handle_payment_forwarded(next_channel_id, skimmed_fee_msat)
-							.await;
-					} else {
-						debug_assert!(
-							false,
-							"We expect skimmed_fee_msat to be set since LDK 0.0.122"
-						);
-					}
+					let skimmed_fee_msat = skimmed_fee_msat.unwrap_or(0);
+					liquidity_source
+						.handle_payment_forwarded(next_channel_id, skimmed_fee_msat)
+						.await;
 				}
 
 				let event = Event::PaymentForwarded {


### PR DESCRIPTION
Recent LDK changes made `skimmed_fee_msat` a required field of the LSPS service handler's `payment_forwarded` API, which seemed reasonable given that the field is available since LDK 0.0.122. However, when updating LDK Node we introduced a `debug_assert` that checked the field to be *always* set, which is wrong, as it's only set post-0.0.122 *if* there was some fee skimmed. Here we fix this oversight.