### PR TITLE
Refactor unified_qr.rs to use bitcoin-payment-instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ log = { version = "0.4.22", default-features = false, features = ["std"]}
 
 vss-client = { package = "vss-client-ng", version = "0.4" }
 prost = { version = "0.11.6", default-features = false}
+#bitcoin-payment-instructions = { version = "0.6" }
+bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", branch = "2025-12-ldk-node-base" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -149,7 +149,7 @@ interface Node {
 	Bolt12Payment bolt12_payment();
 	SpontaneousPayment spontaneous_payment();
 	OnchainPayment onchain_payment();
-	UnifiedQrPayment unified_qr_payment();
+	UnifiedPayment unified_payment();
 	LSPS1Liquidity lsps1_liquidity();
 	[Throws=NodeError]
 	void connect(PublicKey node_id, SocketAddress address, boolean persist);
@@ -275,11 +275,11 @@ interface FeeRate {
 	u64 to_sat_per_vb_ceil();
 };
 
-interface UnifiedQrPayment {
+interface UnifiedPayment {
 	[Throws=NodeError]
 	string receive(u64 amount_sats, [ByRef]string message, u32 expiry_sec);
-	[Throws=NodeError]
-	QrPaymentResult send([ByRef]string uri_str, RouteParametersConfig? route_parameters);
+	[Throws=NodeError, Async]
+	UnifiedPaymentResult send([ByRef]string uri_str, u64? amount_msat, RouteParametersConfig? route_parameters);
 };
 
 interface LSPS1Liquidity {
@@ -347,6 +347,7 @@ enum NodeError {
 	"LiquidityFeeTooHigh",
 	"InvalidBlindedPaths",
 	"AsyncPaymentServicesDisabled",
+	"HrnParsingFailed",
 };
 
 dictionary NodeStatus {
@@ -456,7 +457,7 @@ interface PaymentKind {
 };
 
 [Enum]
-interface QrPaymentResult {
+interface UnifiedPaymentResult {
 	Onchain(Txid txid);
 	Bolt11(PaymentId payment_id);
 	Bolt12(PaymentId payment_id);
@@ -807,6 +808,13 @@ interface Offer {
 	sequence<u8>? metadata();
 	u64? absolute_expiry_seconds();
 	PublicKey? issuer_signing_pubkey();
+};
+
+interface HumanReadableName {
+	[Throws=NodeError, Name=from_encoded]
+	constructor([ByRef] string encoded);
+	string user();
+	string domain();
 };
 
 [Traits=(Debug, Display, Eq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -129,6 +129,8 @@ pub enum Error {
 	InvalidBlindedPaths,
 	/// Asynchronous payment services are disabled.
 	AsyncPaymentServicesDisabled,
+	/// Parsing a Human-Readable Name has failed.
+	HrnParsingFailed,
 }
 
 impl fmt::Display for Error {
@@ -207,6 +209,9 @@ impl fmt::Display for Error {
 			Self::InvalidBlindedPaths => write!(f, "The given blinded paths are invalid."),
 			Self::AsyncPaymentServicesDisabled => {
 				write!(f, "Asynchronous payment services are disabled.")
+			},
+			Self::HrnParsingFailed => {
+				write!(f, "Failed to parse a human-readable name.")
 			},
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,14 +152,15 @@ use payment::asynchronous::om_mailbox::OnionMessageMailbox;
 use payment::asynchronous::static_invoice_store::StaticInvoiceStore;
 use payment::{
 	Bolt11Payment, Bolt12Payment, OnchainPayment, PaymentDetails, SpontaneousPayment,
-	UnifiedQrPayment,
+	UnifiedPayment,
 };
 use peer_store::{PeerInfo, PeerStore};
 use rand::Rng;
 use runtime::Runtime;
 use types::{
 	Broadcaster, BumpTransactionEventHandler, ChainMonitor, ChannelManager, DynStore, Graph,
-	KeysManager, OnionMessenger, PaymentStore, PeerManager, Router, Scorer, Sweeper, Wallet,
+	HRNResolver, KeysManager, OnionMessenger, PaymentStore, PeerManager, Router, Scorer, Sweeper,
+	Wallet,
 };
 pub use types::{ChannelDetails, CustomTlvRecord, PeerDetails, SyncAndAsyncKVStore, UserChannelId};
 pub use {
@@ -206,6 +207,7 @@ pub struct Node {
 	node_metrics: Arc<RwLock<NodeMetrics>>,
 	om_mailbox: Option<Arc<OnionMessageMailbox>>,
 	async_payments_role: Option<AsyncPaymentsRole>,
+	hrn_resolver: Arc<HRNResolver>,
 }
 
 impl Node {
@@ -945,34 +947,42 @@ impl Node {
 	/// Returns a payment handler allowing to create [BIP 21] URIs with an on-chain, [BOLT 11],
 	/// and [BOLT 12] payment options.
 	///
+	/// This handler allows you to send payments to these URIs as well as [BIP 353] HRNs.
+	///
 	/// [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 	/// [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
 	/// [BIP 21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+	/// [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
 	#[cfg(not(feature = "uniffi"))]
-	pub fn unified_qr_payment(&self) -> UnifiedQrPayment {
-		UnifiedQrPayment::new(
+	pub fn unified_payment(&self) -> UnifiedPayment {
+		UnifiedPayment::new(
 			self.onchain_payment().into(),
 			self.bolt11_payment().into(),
 			self.bolt12_payment().into(),
 			Arc::clone(&self.config),
 			Arc::clone(&self.logger),
+			Arc::clone(&self.hrn_resolver),
 		)
 	}
 
 	/// Returns a payment handler allowing to create [BIP 21] URIs with an on-chain, [BOLT 11],
 	/// and [BOLT 12] payment options.
 	///
+	/// This handler allows you to send payments to these URIs as well as [BIP 353] HRNs.
+	///
 	/// [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
 	/// [BOLT 12]: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
 	/// [BIP 21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+	/// [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
 	#[cfg(feature = "uniffi")]
-	pub fn unified_qr_payment(&self) -> Arc<UnifiedQrPayment> {
-		Arc::new(UnifiedQrPayment::new(
+	pub fn unified_payment(&self) -> Arc<UnifiedPayment> {
+		Arc::new(UnifiedPayment::new(
 			self.onchain_payment(),
 			self.bolt11_payment(),
 			self.bolt12_payment(),
 			Arc::clone(&self.config),
 			Arc::clone(&self.logger),
+			Arc::clone(&self.hrn_resolver),
 		))
 	}
 

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -13,7 +13,7 @@ mod bolt12;
 mod onchain;
 mod spontaneous;
 pub(crate) mod store;
-mod unified_qr;
+mod unified;
 
 pub use bolt11::Bolt11Payment;
 pub use bolt12::Bolt12Payment;
@@ -22,4 +22,4 @@ pub use spontaneous::SpontaneousPayment;
 pub use store::{
 	ConfirmationStatus, LSPFeeLimits, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
 };
-pub use unified_qr::{QrPaymentResult, UnifiedQrPayment};
+pub use unified::{UnifiedPayment, UnifiedPaymentResult};

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,8 @@ use lightning_block_sync::gossip::GossipVerifier;
 use lightning_liquidity::utils::time::DefaultTimeProvider;
 use lightning_net_tokio::SocketDescriptor;
 
+use bitcoin_payment_instructions::onion_message_resolver::LDKOnionMessageDNSSECHrnResolver;
+
 use crate::chain::bitcoind::UtxoSourceClient;
 use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
@@ -276,9 +278,11 @@ pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMesse
 	Arc<MessageRouter>,
 	Arc<ChannelManager>,
 	Arc<ChannelManager>,
-	IgnoringMessageHandler,
+	Arc<HRNResolver>,
 	IgnoringMessageHandler,
 >;
+
+pub(crate) type HRNResolver = LDKOnionMessageDNSSECHrnResolver<Arc<Graph>, Arc<Logger>>;
 
 pub(crate) type MessageRouter = lightning::onion_message::messenger::DefaultMessageRouter<
 	Arc<Graph>,

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -29,7 +29,7 @@ use ldk_node::config::{AsyncPaymentsRole, EsploraSyncConfig};
 use ldk_node::liquidity::LSPS2ServiceConfig;
 use ldk_node::payment::{
 	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
-	QrPaymentResult,
+	UnifiedPaymentResult,
 };
 use ldk_node::{Builder, Event, NodeError};
 use lightning::ln::channelmanager::PaymentId;
@@ -1545,15 +1545,15 @@ async fn generate_bip21_uri() {
 
 	// Test 1: Verify URI generation (on-chain + BOLT11) works
 	// even before any channels are opened. This checks the graceful fallback behavior.
-	let initial_uqr_payment = node_b
-		.unified_qr_payment()
+	let initial_uni_payment = node_b
+		.unified_payment()
 		.receive(expected_amount_sats, "asdf", expiry_sec)
 		.expect("Failed to generate URI");
-	println!("Initial URI (no channels): {}", initial_uqr_payment);
+	println!("Initial URI (no channels): {}", initial_uni_payment);
 
-	assert!(initial_uqr_payment.contains("bitcoin:"));
-	assert!(initial_uqr_payment.contains("lightning="));
-	assert!(!initial_uqr_payment.contains("lno=")); // BOLT12 requires channels
+	assert!(initial_uni_payment.contains("bitcoin:"));
+	assert!(initial_uni_payment.contains("lightning="));
+	assert!(!initial_uni_payment.contains("lno=")); // BOLT12 requires channels
 
 	premine_and_distribute_funds(
 		&bitcoind.client,
@@ -1574,19 +1574,19 @@ async fn generate_bip21_uri() {
 	expect_channel_ready_event!(node_b, node_a.node_id());
 
 	// Test 2: Verify URI generation (on-chain + BOLT11 + BOLT12) works after channels are established.
-	let uqr_payment = node_b
-		.unified_qr_payment()
+	let uni_payment = node_b
+		.unified_payment()
 		.receive(expected_amount_sats, "asdf", expiry_sec)
 		.expect("Failed to generate URI");
 
-	println!("Generated URI: {}", uqr_payment);
-	assert!(uqr_payment.contains("bitcoin:"));
-	assert!(uqr_payment.contains("lightning="));
-	assert!(uqr_payment.contains("lno="));
+	println!("Generated URI: {}", uni_payment);
+	assert!(uni_payment.contains("bitcoin:"));
+	assert!(uni_payment.contains("lightning="));
+	assert!(uni_payment.contains("lno="));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn unified_qr_send_receive() {
+async fn unified_send_receive_bip21_uri() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let chain_source = TestChainSource::Esplora(&electrsd);
 
@@ -1624,38 +1624,39 @@ async fn unified_qr_send_receive() {
 	let expected_amount_sats = 100_000;
 	let expiry_sec = 4_000;
 
-	let uqr_payment = node_b.unified_qr_payment().receive(expected_amount_sats, "asdf", expiry_sec);
-	let uri_str = uqr_payment.clone().unwrap();
-	let offer_payment_id: PaymentId = match node_a.unified_qr_payment().send(&uri_str, None) {
-		Ok(QrPaymentResult::Bolt12 { payment_id }) => {
-			println!("\nBolt12 payment sent successfully with PaymentID: {:?}", payment_id);
-			payment_id
-		},
-		Ok(QrPaymentResult::Bolt11 { payment_id: _ }) => {
-			panic!("Expected Bolt12 payment but got Bolt11");
-		},
-		Ok(QrPaymentResult::Onchain { txid: _ }) => {
-			panic!("Expected Bolt12 payment but get On-chain transaction");
-		},
-		Err(e) => {
-			panic!("Expected Bolt12 payment but got error: {:?}", e);
-		},
-	};
+	let uni_payment = node_b.unified_payment().receive(expected_amount_sats, "asdf", expiry_sec);
+	let uri_str = uni_payment.clone().unwrap();
+	let offer_payment_id: PaymentId =
+		match node_a.unified_payment().send(&uri_str, None, None).await {
+			Ok(UnifiedPaymentResult::Bolt12 { payment_id }) => {
+				println!("\nBolt12 payment sent successfully with PaymentID: {:?}", payment_id);
+				payment_id
+			},
+			Ok(UnifiedPaymentResult::Bolt11 { payment_id: _ }) => {
+				panic!("Expected Bolt12 payment but got Bolt11");
+			},
+			Ok(UnifiedPaymentResult::Onchain { txid: _ }) => {
+				panic!("Expected Bolt12 payment but got On-chain transaction");
+			},
+			Err(e) => {
+				panic!("Expected Bolt12 payment but got error: {:?}", e);
+			},
+		};
 
 	expect_payment_successful_event!(node_a, Some(offer_payment_id), None);
 
 	// Cut off the BOLT12 part to fallback to BOLT11.
 	let uri_str_without_offer = uri_str.split("&lno=").next().unwrap();
 	let invoice_payment_id: PaymentId =
-		match node_a.unified_qr_payment().send(uri_str_without_offer, None) {
-			Ok(QrPaymentResult::Bolt12 { payment_id: _ }) => {
+		match node_a.unified_payment().send(uri_str_without_offer, None, None).await {
+			Ok(UnifiedPaymentResult::Bolt12 { payment_id: _ }) => {
 				panic!("Expected Bolt11 payment but got Bolt12");
 			},
-			Ok(QrPaymentResult::Bolt11 { payment_id }) => {
+			Ok(UnifiedPaymentResult::Bolt11 { payment_id }) => {
 				println!("\nBolt11 payment sent successfully with PaymentID: {:?}", payment_id);
 				payment_id
 			},
-			Ok(QrPaymentResult::Onchain { txid: _ }) => {
+			Ok(UnifiedPaymentResult::Onchain { txid: _ }) => {
 				panic!("Expected Bolt11 payment but got on-chain transaction");
 			},
 			Err(e) => {
@@ -1665,19 +1666,19 @@ async fn unified_qr_send_receive() {
 	expect_payment_successful_event!(node_a, Some(invoice_payment_id), None);
 
 	let expect_onchain_amount_sats = 800_000;
-	let onchain_uqr_payment =
-		node_b.unified_qr_payment().receive(expect_onchain_amount_sats, "asdf", 4_000).unwrap();
+	let onchain_uni_payment =
+		node_b.unified_payment().receive(expect_onchain_amount_sats, "asdf", 4_000).unwrap();
 
 	// Cut off any lightning part to fallback to on-chain only.
-	let uri_str_without_lightning = onchain_uqr_payment.split("&lightning=").next().unwrap();
-	let txid = match node_a.unified_qr_payment().send(&uri_str_without_lightning, None) {
-		Ok(QrPaymentResult::Bolt12 { payment_id: _ }) => {
+	let uri_str_without_lightning = onchain_uni_payment.split("&lightning=").next().unwrap();
+	let txid = match node_a.unified_payment().send(&uri_str_without_lightning, None, None).await {
+		Ok(UnifiedPaymentResult::Bolt12 { payment_id: _ }) => {
 			panic!("Expected on-chain payment but got Bolt12")
 		},
-		Ok(QrPaymentResult::Bolt11 { payment_id: _ }) => {
+		Ok(UnifiedPaymentResult::Bolt11 { payment_id: _ }) => {
 			panic!("Expected on-chain payment but got Bolt11");
 		},
-		Ok(QrPaymentResult::Onchain { txid }) => {
+		Ok(UnifiedPaymentResult::Onchain { txid }) => {
 			println!("\nOn-chain transaction successful with Txid: {}", txid);
 			txid
 		},


### PR DESCRIPTION
_This PR is a continuation of #607 which was closed mistakenly when the `develop` base branch was deleted._

This PR introduces a `unified.rs` module (which is a refactor of the `unified_qr.rs` module) - this refactor allows us to use this module as a single API for sending payments to `BIP 21/321 URIs` as well as `BIP 353 HRNs`, creating a simpler interface for users.

https://github.com/rust-bitcoin/bitcoin-payment-instructions is used to parse `BIP 21/321 URIs` as well as the `BIP 353 HRNs`.

Changes

- The `unified_qr.rs` module has been renamed to `unified.rs`.
- The `UnifiedQrPayment` struct has been renamed to `UnifiedPayment`.
- The `QRPaymentResult` enum has been renamed to `UnifiedPaymentResult`.
- The `send` method in `unified.rs` now supports sending to both `BIP 21/321 URIs` as well as `BIP 353 HRNs`.
- The integration tests for the module have been updated accordingly.

This PR closes https://github.com/lightningdevkit/ldk-node/issues/521 and #435 