### PR TITLE
Bump `electrsd` to 0.36.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,11 +116,11 @@ proptest = "1.0.0"
 regex = "1.5.6"
 
 [target.'cfg(not(no_download))'.dev-dependencies]
-electrsd = { version = "0.35.0", default-features = false, features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }
+electrsd = { version = "0.36.1", default-features = false, features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }
 
 [target.'cfg(no_download)'.dev-dependencies]
-electrsd = { version = "0.35.0", default-features = false, features = ["legacy"] }
-corepc-node = { version = "0.8.0", default-features = false, features = ["27_2"] }
+electrsd = { version = "0.36.1", default-features = false, features = ["legacy"] }
+corepc-node = { version = "0.10.0", default-features = false, features = ["27_2"] }
 
 [target.'cfg(cln_test)'.dev-dependencies]
 clightningrpc = { version = "0.3.0-beta.8", default-features = false }


### PR DESCRIPTION
We bump our `electrsd` dependency to the latest version, fixing CI.