### PR TITLE
Add support for configurable BIP39 mnemonic word counts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rustls = { version = "0.23", default-features = false }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 bitcoin = "0.32.7"
-bip39 = "2.0.0"
+bip39 = { version = "2.0.0", features = ["rand"] }
 bip21 = { version = "0.5", features = ["std"], default-features = false }
 
 base64 = { version = "0.22.1", default-features = false, features = ["std"] }

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -1,5 +1,5 @@
 namespace ldk_node {
-	Mnemonic generate_entropy_mnemonic();
+	Mnemonic generate_entropy_mnemonic(WordCount? word_count);
 	Config default_config();
 };
 
@@ -44,6 +44,14 @@ dictionary LSPS2ServiceConfig {
 	u32 max_client_to_self_delay;
 	u64 min_payment_size_msat;
 	u64 max_payment_size_msat;
+};
+
+enum WordCount {
+	"Words12",
+	"Words15",
+	"Words18",
+	"Words21",
+	"Words24",
 };
 
 enum LogLevel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ use types::{
 };
 pub use types::{
 	ChannelDetails, CustomTlvRecord, DynStore, PeerDetails, SyncAndAsyncKVStore, UserChannelId,
+	WordCount,
 };
 pub use {
 	bip39, bitcoin, lightning, lightning_invoice, lightning_liquidity, lightning_types, tokio,

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,6 +36,34 @@ use crate::logger::Logger;
 use crate::message_handler::NodeCustomMessageHandler;
 use crate::payment::PaymentDetails;
 
+/// Supported BIP39 mnemonic word counts for entropy generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WordCount {
+	/// 12-word mnemonic (128-bit entropy)
+	Words12,
+	/// 15-word mnemonic (160-bit entropy)
+	Words15,
+	/// 18-word mnemonic (192-bit entropy)
+	Words18,
+	/// 21-word mnemonic (224-bit entropy)
+	Words21,
+	/// 24-word mnemonic (256-bit entropy)
+	Words24,
+}
+
+impl WordCount {
+	/// Returns the word count as a usize value.
+	pub fn word_count(&self) -> usize {
+		match self {
+			WordCount::Words12 => 12,
+			WordCount::Words15 => 15,
+			WordCount::Words18 => 18,
+			WordCount::Words21 => 21,
+			WordCount::Words24 => 24,
+		}
+	}
+}
+
 /// A supertrait that requires that a type implements both [`KVStore`] and [`KVStoreSync`] at the
 /// same time.
 pub trait SyncAndAsyncKVStore: KVStore + KVStoreSync {}


### PR DESCRIPTION
## Summary

This PR introduces support for generating BIP39 mnemonics with configurable word counts - **12, 15, 18, 21, or 24 words**.  
The `word_count` parameter is optional and defaults to **24 words (256-bit entropy)**.

## Motivation

Different use cases benefit from different mnemonic lengths:
- **12 words:** Simplified UX and easier memorization for users *(default in Bitkit)*  
- Supporting configurable lengths increases flexibility for downstream applications integrating with this library.

## Changes

- Added `WordCount` enum (`Words12`, `Words15`, `Words18`, `Words21`, `Words24`)
- Updated `generate_entropy_mnemonic()` to accept an **optional** `word_count` parameter
- Default: **24 words** when no parameter is provided
- Updated UDL bindings to expose the new enum and function signature
- Updated tests to cover all variants and validate entropy mapping

## Breaking Changes

⚠️ **This is a breaking change** - `generate_entropy_mnemonic()` now requires a `word_count` parameter.

Users will need to update their code from:
```rust
let mnemonic = generate_entropy_mnemonic();
```

To:
```rust
let mnemonic = generate_entropy_mnemonic(None);  // Uses default 24 words
// Or specify a word count:
let mnemonic = generate_entropy_mnemonic(Some(WordCount::Words12));
```

## Testing

- Verified default behavior (24 words)
- Added tests for all word count variants
- All tests pass (`cargo test`)

_Summary was co-created with AI_