### PR TITLE
Add inbound channel blocking and per-peer channel limits

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -13,6 +13,8 @@ dictionary Config {
 	u64 probing_liquidity_limit_multiplier;
 	AnchorChannelsConfig? anchor_channels_config;
 	RouteParametersConfig? route_parameters;
+	sequence<PublicKey> blocked_peers;
+	u32? max_channels_per_peer;
 };
 
 dictionary AnchorChannelsConfig {
@@ -97,6 +99,10 @@ interface Builder {
 	void set_node_alias(string node_alias);
 	[Throws=BuildError]
 	void set_async_payments_role(AsyncPaymentsRole? role);
+	[Throws=BuildError]
+	void set_blocked_peers(sequence<PublicKey> blocked_peers);
+	[Throws=BuildError]
+	void set_max_channels_per_peer(u32? max_channels_per_peer);
 	[Throws=BuildError]
 	Node build();
 	[Throws=BuildError]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -582,6 +582,25 @@ impl NodeBuilder {
 		Ok(self)
 	}
 
+	/// Sets the list of peers from which we will not accept inbound channels.
+	pub fn set_blocked_peers(
+		&mut self, blocked_peers: Vec<PublicKey>,
+	) -> Result<&mut Self, BuildError> {
+		self.config.blocked_peers = blocked_peers;
+		Ok(self)
+	}
+
+	/// Sets the maximum number of channels we'll accept from any single peer.
+	///
+	/// If set, we will reject inbound channel requests from peers that already have this many
+	/// channels open with us. If set to `None`, no limit is enforced.
+	pub fn set_max_channels_per_peer(
+		&mut self, max_channels_per_peer: Option<u32>,
+	) -> Result<&mut Self, BuildError> {
+		self.config.max_channels_per_peer = max_channels_per_peer;
+		Ok(self)
+	}
+
 	/// Builds a [`Node`] instance with a [`SqliteStore`] backend and according to the options
 	/// previously configured.
 	pub fn build(&self) -> Result<Node, BuildError> {
@@ -1043,6 +1062,21 @@ impl ArcedNodeBuilder {
 		&self, role: Option<AsyncPaymentsRole>,
 	) -> Result<(), BuildError> {
 		self.inner.write().unwrap().set_async_payments_role(role).map(|_| ())
+	}
+
+	/// Sets the list of peers from which we will not accept inbound channels.
+	pub fn set_blocked_peers(&self, blocked_peers: Vec<PublicKey>) -> Result<(), BuildError> {
+		self.inner.write().unwrap().set_blocked_peers(blocked_peers).map(|_| ())
+	}
+
+	/// Sets the maximum number of channels we'll accept from any single peer.
+	///
+	/// If set, we will reject inbound channel requests from peers that already have this many
+	/// channels open with us. If set to `None`, no limit is enforced.
+	pub fn set_max_channels_per_peer(
+		&self, max_channels_per_peer: Option<u32>,
+	) -> Result<(), BuildError> {
+		self.inner.write().unwrap().set_max_channels_per_peer(max_channels_per_peer).map(|_| ())
 	}
 
 	/// Builds a [`Node`] instance with a [`SqliteStore`] backend and according to the options

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,9 @@ pub(crate) const EXTERNAL_PATHFINDING_SCORES_SYNC_TIMEOUT_SECS: u64 = 5;
 /// | `probing_liquidity_limit_multiplier`   | 3                  |
 /// | `log_level`                            | Debug              |
 /// | `anchor_channels_config`               | Some(..)           |
-/// | `route_parameters`                   | None               |
+/// | `route_parameters`                     | None               |
+/// | `blocked_peers`                        | []                 |
+/// | `max_channels_per_peer`                | None               |
 ///
 /// See [`AnchorChannelsConfig`] and [`RouteParametersConfig`] for more information regarding their
 /// respective default values.
@@ -184,6 +186,15 @@ pub struct Config {
 	/// **Note:** If unset, default parameters will be used, and you will be able to override the
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub route_parameters: Option<RouteParametersConfig>,
+	/// A list of peers from which we will not accept inbound channels.
+	///
+	/// Channels requested by peers in this list will be automatically rejected.
+	pub blocked_peers: Vec<PublicKey>,
+	/// The maximum number of channels we'll accept from any single peer.
+	///
+	/// If set, we will reject inbound channel requests from peers that already have this many
+	/// channels open with us. If set to `None`, no limit is enforced.
+	pub max_channels_per_peer: Option<u32>,
 }
 
 impl Default for Config {
@@ -198,6 +209,8 @@ impl Default for Config {
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			route_parameters: None,
 			node_alias: None,
+			blocked_peers: Vec::new(),
+			max_channels_per_peer: None,
 		}
 	}
 }


### PR DESCRIPTION
This PR adds configuration options to control which peers can open inbound channels and how many channels each peer can open.


Right now, we can manually accept/reject each channel, but we don't have a way to automatically block known bad peers or stop a peer from spamming with lots of channels.

### Changes
- Add `blocked_peers` list to automatically reject channels from specific peers
- Add `max_channels_per_peer` option to limit channels per peer

Fixes: #1018 