### PR TITLE
Allow to set optional `RouteParametersConfig` in BOLT12 API

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -201,9 +201,9 @@ interface Bolt11Payment {
 
 interface Bolt12Payment {
 	[Throws=NodeError]
-	PaymentId send([ByRef]Offer offer, u64? quantity, string? payer_note);
+	PaymentId send([ByRef]Offer offer, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
-	PaymentId send_using_amount([ByRef]Offer offer, u64 amount_msat, u64? quantity, string? payer_note);
+	PaymentId send_using_amount([ByRef]Offer offer, u64 amount_msat, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	Offer receive(u64 amount_msat, [ByRef]string description, u32? expiry_secs, u64? quantity);
 	[Throws=NodeError]
@@ -211,7 +211,7 @@ interface Bolt12Payment {
 	[Throws=NodeError]
 	Bolt12Invoice request_refund_payment([ByRef]Refund refund);
 	[Throws=NodeError]
-	Refund initiate_refund(u64 amount_msat, u32 expiry_secs, u64? quantity, string? payer_note);
+	Refund initiate_refund(u64 amount_msat, u32 expiry_secs, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	Offer receive_async();
 	[Throws=NodeError]
@@ -256,7 +256,7 @@ interface UnifiedQrPayment {
 	[Throws=NodeError]
 	string receive(u64 amount_sats, [ByRef]string message, u32 expiry_sec);
 	[Throws=NodeError]
-	QrPaymentResult send([ByRef]string uri_str);
+	QrPaymentResult send([ByRef]string uri_str, RouteParametersConfig? route_parameters);
 };
 
 interface LSPS1Liquidity {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -854,6 +854,7 @@ impl Node {
 		Bolt12Payment::new(
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.payment_store),
+			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
 			Arc::clone(&self.logger),
 			self.async_payments_role,
@@ -868,6 +869,7 @@ impl Node {
 		Arc::new(Bolt12Payment::new(
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.payment_store),
+			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
 			Arc::clone(&self.logger),
 			self.async_payments_role,


### PR DESCRIPTION
Closes #347.

Previously, LDK only allowed to set this for BOLT11 payments. Since we now can, we allow to specify the `RouteParametersConfig` in BOLT12 and `UnifiedQrPayment` APIs.