### PR TITLE
Revert "Only skip bumping channel closes for trusted peers"

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1465,29 +1465,30 @@ where
 				self.runtime.spawn_cancellable_background_task(future);
 			},
 			LdkEvent::BumpTransaction(bte) => {
-				match bte {
+				let (channel_id, counterparty_node_id) = match bte {
 					BumpTransactionEvent::ChannelClose {
 						ref channel_id,
 						ref counterparty_node_id,
 						..
-					} => {
-						// Skip bumping channel closes if our counterparty is trusted.
-						if let Some(anchor_channels_config) =
-							self.config.anchor_channels_config.as_ref()
-						{
-							if anchor_channels_config
-								.trusted_peers_no_reserve
-								.contains(counterparty_node_id)
-							{
-								log_debug!(self.logger,
-									"Ignoring BumpTransactionEvent::ChannelClose for channel {} due to trusted counterparty {}",
-									channel_id, counterparty_node_id
-								);
-								return Ok(());
-							}
-						}
-					},
-					BumpTransactionEvent::HTLCResolution { .. } => {},
+					} => (channel_id, counterparty_node_id),
+					BumpTransactionEvent::HTLCResolution {
+						ref channel_id,
+						ref counterparty_node_id,
+						..
+					} => (channel_id, counterparty_node_id),
+				};
+
+				if let Some(anchor_channels_config) = self.config.anchor_channels_config.as_ref() {
+					if anchor_channels_config
+						.trusted_peers_no_reserve
+						.contains(counterparty_node_id)
+					{
+						log_debug!(self.logger,
+							"Ignoring BumpTransactionEvent for channel {} due to trusted counterparty {}",
+							channel_id, counterparty_node_id
+						);
+						return Ok(());
+					}
 				}
 
 				self.bump_tx_event_handler.handle_event(&bte).await;


### PR DESCRIPTION
Closes #464.

This reverts commit 7a36e5b3fd46f01119896c9191e52819843f33db, as it's now safe again to skip bump events for fully-trusted counterparties.