### PR TITLE
Replace docs.rs build `doc_auto_cfg` feature with `doc_cfg` (main)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 #![deny(rustdoc::private_intra_doc_links)]
 #![allow(bare_trait_objects)]
 #![allow(ellipsis_inclusive_range_patterns)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod balance;
 mod builder;


### PR DESCRIPTION
Unfortunately, `doc_auto_cfg` was removed, breaking doc builds for v0.7.0-rc.0. Here we replace it with the `doc_cfg` attribute.