### PR TITLE
Make `VssStore` public

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,8 +76,11 @@ use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
 use crate::{Node, NodeMetrics};
 
-const VSS_HARDENED_CHILD_INDEX: u32 = 877;
-const VSS_LNURL_AUTH_HARDENED_CHILD_INDEX: u32 = 138;
+/// Child index used for deriving the VSS XPriv from the wallet seed.
+pub const VSS_HARDENED_CHILD_INDEX: u32 = 877;
+/// Child index used for deriving the LNURL-auth XPriv from the VSS XPriv.
+pub const VSS_LNURL_AUTH_HARDENED_CHILD_INDEX: u32 = 138;
+
 const LSPS_HARDENED_CHILD_INDEX: u32 = 577;
 const PERSISTER_MAX_PENDING_UPDATES: u64 = 100;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -11,7 +11,7 @@ pub mod sqlite_store;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod utils;
-pub(crate) mod vss_store;
+pub mod vss_store;
 
 /// The event queue will be persisted under this key.
 pub(crate) const EVENT_QUEUE_PERSISTENCE_PRIMARY_NAMESPACE: &str = "";

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+//! Objects related to [`VssStore`] live here.
+
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::future::Future;
@@ -36,7 +38,6 @@ use vss_client::util::retry::{
 	MaxAttemptsRetryPolicy, MaxTotalDelayRetryPolicy, RetryPolicy,
 };
 use vss_client::util::storable_builder::{EntropySource, StorableBuilder};
-
 use crate::io::utils::check_namespace_key_validity;
 
 type CustomRetryPolicy = FilteredRetryPolicy<
@@ -84,7 +85,12 @@ pub struct VssStore {
 }
 
 impl VssStore {
-	pub(crate) fn new(
+	/// Constructs a new [`VssStore`].
+	///
+	/// **Caution**: VSS support is in **alpha** and is considered experimental.
+	/// Using VSS (or any remote persistence) may cause LDK to panic if persistence failures are
+	/// unrecoverable, i.e., if they remain unresolved after internal retries are exhausted.
+	pub fn new(
 		base_url: String, store_id: String, vss_seed: [u8; 32],
 		header_provider: Arc<dyn VssHeaderProvider>,
 	) -> io::Result<Self> {


### PR DESCRIPTION
We currently have the `SqliteStore` public so others can use it outside of just their ldk-node wallet but did not do the same for the `VssStore`. This makes it public along with the 2 derivation path consts used when deriving the keys so people can more easily replicate the key schema as well