### PR TITLE
Add a `docs.rs` CI job checking documentation builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,11 +72,6 @@ jobs:
       - name: Build with UniFFI support on Rust ${{ matrix.toolchain }}
         if: matrix.build-uniffi
         run: cargo build --features uniffi --verbose --color always
-      - name: Build documentation on Rust ${{ matrix.toolchain }}
-        if: "matrix.platform != 'windows-latest' || matrix.toolchain != '1.85.0'"
-        run: |
-          cargo doc --release --verbose --color always
-          cargo doc --document-private-items --verbose --color always
       - name: Check release build on Rust ${{ matrix.toolchain }}
         run: cargo check --release --verbose --color always
       - name: Check release build with UniFFI support on Rust ${{ matrix.toolchain }}
@@ -90,3 +85,14 @@ jobs:
         if: "matrix.platform != 'windows-latest' && matrix.build-uniffi"
         run: |
           RUSTFLAGS="--cfg no_download" cargo test --features uniffi
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ readme = "README.md"
 keywords = ["bitcoin", "lightning", "ldk", "bdk"]
 categories = ["cryptography::cryptocurrencies"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "ldk_node"


### PR DESCRIPTION
We previouly ran into a quiet error that lead to `docs.rs` not rendering our docs properly, which unfortunately didn't surface until after we pushed out a releas (thankfully only an RC in this case).

Here, we add a CI job that tests our docs build with exactly the settings `docs.rs` uses. Additionally, the change also has the benefit that we now only build docs once rather than for every combiantion in our workflow matrix, which was a bit overkill.