### PR TITLE
Account for `check_closed_event` being moved on LDK `main`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,29 @@ panic = 'abort'     # Abort on panic
 default = []
 
 [dependencies]
-lightning = { version = "0.2.0-rc1", features = ["std"] }
-lightning-types = { version = "0.3.0-rc1" }
-lightning-invoice = { version = "0.34.0-rc1", features = ["std"] }
-lightning-net-tokio = { version = "0.2.0-rc1" }
-lightning-persister = { version = "0.2.0-rc1", features = ["tokio"] }
-lightning-background-processor = { version = "0.2.0-rc1" }
-lightning-rapid-gossip-sync = { version = "0.2.0-rc1" }
-lightning-block-sync = { version = "0.2.0-rc1", features = ["rest-client", "rpc-client", "tokio"] }
-lightning-transaction-sync = { version = "0.2.0-rc1", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
-lightning-liquidity = { version = "0.2.0-rc1", features = ["std"] }
-lightning-macros = { version = "0.2.0-rc1" }
+#lightning = { version = "0.2.0-rc1", features = ["std"] }
+#lightning-types = { version = "0.3.0-rc1" }
+#lightning-invoice = { version = "0.34.0-rc1", features = ["std"] }
+#lightning-net-tokio = { version = "0.2.0-rc1" }
+#lightning-persister = { version = "0.2.0-rc1", features = ["tokio"] }
+#lightning-background-processor = { version = "0.2.0-rc1" }
+#lightning-rapid-gossip-sync = { version = "0.2.0-rc1" }
+#lightning-block-sync = { version = "0.2.0-rc1", features = ["rest-client", "rpc-client", "tokio"] }
+#lightning-transaction-sync = { version = "0.2.0-rc1", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+#lightning-liquidity = { version = "0.2.0-rc1", features = ["std"] }
+#lightning-macros = { version = "0.2.0-rc1" }
+
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["rest-client", "rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370" }
 
 bdk_chain = { version = "0.23.0", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["async-https-rustls", "tokio"]}
@@ -72,7 +84,7 @@ prost = { version = "0.11.6", default-features = false}
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { version = "0.2.0-rc1", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "bb5504ec62d4b7e9d5626d8b1a6de60d71e8d370", features = ["std", "_test_utils"] }
 proptest = "1.0.0"
 regex = "1.5.6"
 criterion = { version = "0.7.0", features = ["async_tokio"] }

--- a/src/io/test_utils.rs
+++ b/src/io/test_utils.rs
@@ -15,14 +15,15 @@ use std::sync::Mutex;
 
 use lightning::events::ClosureReason;
 use lightning::ln::functional_test_utils::{
-	connect_block, create_announced_chan_between_nodes, create_chanmon_cfgs, create_dummy_block,
-	create_network, create_node_cfgs, create_node_chanmgrs, send_payment, TestChanMonCfg,
+	check_closed_event, connect_block, create_announced_chan_between_nodes, create_chanmon_cfgs,
+	create_dummy_block, create_network, create_node_cfgs, create_node_chanmgrs, send_payment,
+	TestChanMonCfg,
 };
 use lightning::util::persist::{
 	KVStore, KVStoreSync, MonitorUpdatingPersister, KVSTORE_NAMESPACE_KEY_MAX_LEN,
 };
 use lightning::util::test_utils;
-use lightning::{check_added_monitors, check_closed_broadcast, check_closed_event, io};
+use lightning::{check_added_monitors, check_closed_broadcast, io};
 use rand::distr::Alphanumeric;
 use rand::{rng, Rng};
 
@@ -326,12 +327,12 @@ pub(crate) fn do_test_store<K: KVStoreSync + Sync>(store_0: &K, store_1: &K) {
 			message.clone(),
 		)
 		.unwrap();
-	check_closed_event!(
-		nodes[0],
+	check_closed_event(
+		&nodes[0],
 		1,
 		ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(true), message },
-		[nodes[1].node.get_our_node_id()],
-		100000
+		&[nodes[1].node.get_our_node_id()],
+		100000,
 	);
 	check_closed_broadcast!(nodes[0], true);
 	check_added_monitors!(nodes[0], 1);
@@ -345,7 +346,7 @@ pub(crate) fn do_test_store<K: KVStoreSync + Sync>(store_0: &K, store_1: &K) {
 	check_closed_broadcast!(nodes[1], true);
 	let reason = ClosureReason::CommitmentTxConfirmed;
 	let node_id_0 = nodes[0].node.get_our_node_id();
-	check_closed_event!(nodes[1], 1, reason, false, [node_id_0], 100000);
+	check_closed_event(&nodes[1], 1, reason, &[node_id_0], 100000);
 	check_added_monitors!(nodes[1], 1);
 
 	// Make sure everything is persisted as expected after close.


### PR DESCRIPTION
In rust-lightning#4220 the `check_closed_event` macros was replaced with a method and is now also only re-exported via `fuctional_test_utils`.