### PR TITLE
Expose a `VssStoreBuilder` allowing to build `VssStore` independently

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -11,7 +11,7 @@ pub mod sqlite_store;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod utils;
-pub(crate) mod vss_store;
+pub mod vss_store;
 
 /// The event queue will be persisted under this key.
 pub(crate) const EVENT_QUEUE_PERSISTENCE_PRIMARY_NAMESPACE: &str = "";


### PR DESCRIPTION
Previously, `VssStore` was a private object that could only be constructed internally via the `Builder` object. However, some users might want to use `VssStore` independently of/before the `Node` is constructed.

To this end, we here expose a new `VssStoreBuilder` that allows to independently construct a `VssStore` instance that then can be handed to `Builder::build_with_store`.

For now we keep the previous VSS-related methods on `Builder` around, but have them reuse the `VssStoreBuilder` internally. This also allows us to not change anything related to bindings. For bindings, we still have to explore if/how we can expose `VssStore` in the future.

FWIW, after this PR lands it might also be a good time to finally upstream `VssStore` to the `lightning-persister` crate, which was the original plan ever since we added `VssStore`.