### PR TITLE
feat: add accessor methods for common PaymentKind fields

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -1,6 +1,11 @@
 namespace ldk_node {
 	Mnemonic generate_entropy_mnemonic(WordCount? word_count);
 	Config default_config();
+
+	// PaymentKind Accessors
+	PaymentHash? payment_kind_get_payment_hash(PaymentKind kind);
+	PaymentPreimage? payment_kind_get_preimage(PaymentKind kind);
+	PaymentSecret? payment_kind_get_secret(PaymentKind kind);
 };
 
 dictionary Config {

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -53,6 +53,7 @@ pub use crate::graph::{ChannelInfo, ChannelUpdateInfo, NodeAnnouncementInfo, Nod
 pub use crate::liquidity::{LSPS1OrderStatus, LSPS2ServiceConfig};
 pub use crate::logger::{LogLevel, LogRecord, LogWriter};
 pub use crate::payment::store::{
+	payment_kind_get_payment_hash, payment_kind_get_preimage, payment_kind_get_secret,
 	ConfirmationStatus, LSPFeeLimits, PaymentDirection, PaymentKind, PaymentStatus,
 };
 pub use crate::payment::QrPaymentResult;

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -529,6 +529,24 @@ impl PaymentKind {
 	}
 }
 
+#[cfg(feature = "uniffi")]
+#[doc(hidden)]
+pub fn payment_kind_get_payment_hash(kind: PaymentKind) -> Option<PaymentHash> {
+	kind.payment_hash()
+}
+
+#[cfg(feature = "uniffi")]
+#[doc(hidden)]
+pub fn payment_kind_get_preimage(kind: PaymentKind) -> Option<PaymentPreimage> {
+	kind.preimage()
+}
+
+#[cfg(feature = "uniffi")]
+#[doc(hidden)]
+pub fn payment_kind_get_secret(kind: PaymentKind) -> Option<PaymentSecret> {
+	kind.secret()
+}
+
 /// Represents the confirmation status of a transaction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ConfirmationStatus {


### PR DESCRIPTION
## Description
Addresses issue #730.

Added `payment_hash()` as requested, but also identified that `preimage` and `secret` are common fields shared across most `PaymentKind` variants. Added accessor methods for all three to unify the API.

## Changes
- Added `payment_hash()`, `preimage()`, and `secret()` to `PaymentKind`.
- Refactored `PaymentDetailsUpdate::from` to use these new methods, removing boilerplate matching logic.
- Added unit test `payment_kind_accessor_methods` to verify behavior across all variants (Bolt11, Bolt12, Spontaneous, Onchain).

## PR Tasks
- [x] Added tests
- [x] Ran `cargo fmt`
- [x] Ran `cargo test`