### PR TITLE
Switch from `reqwest` to `bitreq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ bdk_esplora = { version = "0.22.0", default-features = false, features = ["async
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls-ring"]}
 bdk_wallet = { version = "2.2.0", default-features = false, features = ["std", "keys-bip39"]}
 
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+bitreq = { version = "0.3", default-features = false, features = ["async-https"] }
 rustls = { version = "0.23", default-features = false }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 bitcoin = "0.32.7"

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,11 +87,19 @@ pub(crate) const FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS: u64 = 5;
 // The timeout after which we abort a transaction broadcast operation.
 pub(crate) const TX_BROADCAST_TIMEOUT_SECS: u64 = 5;
 
+// The maximum encoded size of an RGS snapshot we'll accept.
+// In practice the maximum we see is around 4MiB.
+pub(crate) const RGS_SNAPSHOT_MAX_SIZE: usize = 15 * 1024 * 1024;
+
 // The timeout after which we abort a RGS sync operation.
 pub(crate) const RGS_SYNC_TIMEOUT_SECS: u64 = 5;
 
 /// The length in bytes of our wallets' keys seed.
 pub const WALLET_KEYS_SEED_LEN: usize = 64;
+
+// The maximum encoded size of external scores we'll accept.
+// In practice we see scores files in the 5MiB range.
+pub(crate) const EXTERNAL_PATHFINDING_SCORES_MAX_SIZE: usize = 20 * 1024 * 1024;
 
 // The timeout after which we abort a external scores sync operation.
 pub(crate) const EXTERNAL_PATHFINDING_SCORES_SYNC_TIMEOUT_SECS: u64 = 5;


### PR DESCRIPTION
`reqwest` is one of the largest contributors of code size and dependencies (including single-author dependencies) to much of the rust-bitcoin ecosystem, including ldk-node.

Thus, Tobin took the time to (ask an LLM to) fork `minreq` and add async support to it, including async `rustls` support. As its now a functional HTTP(s) client, its time for the ecosystem to start switching over. Luckily, its ~trivial to do.