### PR TITLE
Add Payjoin Receiver Support (BIP 77)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ prost = { version = "0.11.6", default-features = false}
 #bitcoin-payment-instructions = { version = "0.6" }
 bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", rev = "0e430be98c09540624a68a68022ee0551e86d1be" }
 
+payjoin = { version = "0.25.0", default-features = false, features = ["v2", "io"] }
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -112,6 +112,8 @@ interface Node {
 	SpontaneousPayment spontaneous_payment();
 	OnchainPayment onchain_payment();
 	UnifiedPayment unified_payment();
+	[Throws=NodeError]
+	PayjoinPayment payjoin_payment();
 	Liquidity liquidity();
 	[Throws=NodeError]
 	void lnurl_auth(string lnurl);
@@ -182,6 +184,8 @@ interface FeeRate {
 
 typedef interface UnifiedPayment;
 
+typedef interface PayjoinPayment;
+
 typedef interface Liquidity;
 
 [Error]
@@ -209,6 +213,8 @@ enum NodeError {
 	"OnchainTxSigningFailed",
 	"TxSyncFailed",
 	"TxSyncTimeout",
+	"TxLookupFailed",
+	"TxLookupTimeout",
 	"GossipUpdateFailed",
 	"GossipUpdateTimeout",
 	"LiquidityRequestFailed",
@@ -247,6 +253,9 @@ enum NodeError {
 	"LnurlAuthTimeout",
 	"InvalidLnurl",
 	"ChainSourceNotSupported",
+	"PayjoinNotConfigured",
+	"PayjoinSessionCreationFailed",
+	"PayjoinSessionFailed",
 };
 
 typedef dictionary NodeStatus;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -49,7 +49,7 @@ use crate::chain::ChainSource;
 use crate::config::{
 	default_user_config, may_announce_channel, AnnounceError, AsyncPaymentsRole,
 	BitcoindRestClientConfig, Config, ElectrumSyncConfig, EsploraSyncConfig, HRNResolverConfig,
-	TorConfig, DEFAULT_ESPLORA_SERVER_URL, DEFAULT_LOG_FILENAME, DEFAULT_LOG_LEVEL,
+	PayjoinConfig, TorConfig, DEFAULT_ESPLORA_SERVER_URL, DEFAULT_LOG_FILENAME, DEFAULT_LOG_LEVEL,
 	DEFAULT_MAX_PROBE_AMOUNT_MSAT, DEFAULT_MIN_PROBE_AMOUNT_MSAT,
 };
 use crate::connection::ConnectionManager;
@@ -65,7 +65,8 @@ use crate::io::utils::{
 };
 use crate::io::vss_store::VssStoreBuilder;
 use crate::io::{
-	self, PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE, PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+	self, PAYJOIN_SESSION_STORE_PRIMARY_NAMESPACE, PAYJOIN_SESSION_STORE_SECONDARY_NAMESPACE,
+	PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE, PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
 	PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
 	PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
 };
@@ -74,6 +75,7 @@ use crate::lnurl_auth::LnurlAuth;
 use crate::logger::{log_error, LdkLogger, LogLevel, LogWriter, Logger};
 use crate::message_handler::NodeCustomMessageHandler;
 use crate::payment::asynchronous::om_mailbox::OnionMessageMailbox;
+use crate::payment::payjoin::manager::PayjoinManager;
 use crate::peer_store::PeerStore;
 use crate::probing::{
 	HighDegreeStrategy, Prober, ProbingConfig, ProbingStrategy, ProbingStrategyKind,
@@ -83,8 +85,8 @@ use crate::runtime::{Runtime, RuntimeSpawner};
 use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
 	AsyncPersister, ChainMonitor, ChannelManager, DynStore, DynStoreRef, DynStoreWrapper,
-	GossipSync, Graph, HRNResolver, KeysManager, MessageRouter, OnionMessenger, PaymentStore,
-	PeerManager, PendingPaymentStore,
+	GossipSync, Graph, HRNResolver, KeysManager, MessageRouter, OnionMessenger,
+	PayjoinSessionStore, PaymentStore, PeerManager, PendingPaymentStore,
 };
 use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
@@ -211,6 +213,8 @@ pub enum BuildError {
 	ChainTipFetchFailed,
 	/// The configured wallet rescan height is above the current chain tip.
 	WalletRescanHeightTooHigh,
+	/// The payjoin configuration requires a Bitcoin Core backend, but a different chain source was configured.
+	PayjoinConfigMismatch,
 }
 
 impl fmt::Display for BuildError {
@@ -256,6 +260,9 @@ impl fmt::Display for BuildError {
 			},
 			Self::WalletRescanHeightTooHigh => {
 				write!(f, "Wallet rescan height is above the current chain tip.")
+			},
+			Self::PayjoinConfigMismatch => {
+				write!(f, "Payjoin requires a Bitcoin Core chain source, but a different one was configured.")
 			},
 		}
 	}
@@ -635,6 +642,15 @@ impl NodeBuilder {
 
 		self.async_payments_role = role;
 		Ok(self)
+	}
+
+	/// Configures the [`Node`] instance to enable payjoin payments.
+	///
+	/// The `payjoin_config` specifies the PayJoin directory and OHTTP relay URLs required
+	/// for payjoin V2 protocol.
+	pub fn set_payjoin_config(&mut self, payjoin_config: PayjoinConfig) -> &mut Self {
+		self.config.payjoin_config = Some(payjoin_config);
+		self
 	}
 
 	/// Sets background probing config.
@@ -1199,6 +1215,14 @@ impl ArcedNodeBuilder {
 		self.inner.write().expect("lock").set_async_payments_role(role).map(|_| ())
 	}
 
+	/// Configures the [`Node`] instance to enable payjoin payments.
+	///
+	/// The `payjoin_config` specifies the PayJoin directory and OHTTP relay URLs required
+	/// for payjoin V2 protocol.
+	pub fn set_payjoin_config(&self, payjoin_config: PayjoinConfig) {
+		self.inner.write().expect("lock").set_payjoin_config(payjoin_config);
+	}
+
 	/// Configures background probing.
 	///
 	/// Use [`ProbingConfigBuilder`] to build the configuration.
@@ -1439,7 +1463,7 @@ fn build_with_store_internal(
 
 	let kv_store_ref = Arc::clone(&kv_store);
 	let logger_ref = Arc::clone(&logger);
-	let (payment_store_res, node_metris_res, pending_payment_store_res) =
+	let (payment_store_res, node_metris_res, pending_payment_store_res, payjoin_session_store_res) =
 		runtime.block_on(async move {
 			tokio::join!(
 				read_all_objects(
@@ -1453,6 +1477,12 @@ fn build_with_store_internal(
 					&*kv_store_ref,
 					PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
 					PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+					Arc::clone(&logger_ref),
+				),
+				read_all_objects(
+					&*kv_store_ref,
+					PAYJOIN_SESSION_STORE_PRIMARY_NAMESPACE,
+					PAYJOIN_SESSION_STORE_SECONDARY_NAMESPACE,
 					Arc::clone(&logger_ref),
 				)
 			)
@@ -2249,6 +2279,42 @@ fn build_with_store_internal(
 
 	let pathfinding_scores_sync_url = pathfinding_scores_sync_config.map(|c| c.url.clone());
 
+	let payjoin_manager = if config.payjoin_config.is_some() {
+		if !matches!(chain_data_source_config, Some(ChainDataSourceConfig::Bitcoind { .. })) {
+			return Err(BuildError::PayjoinConfigMismatch);
+		}
+
+		let payjoin_session_store = match payjoin_session_store_res {
+			Ok(payjoin_sessions) => Arc::new(PayjoinSessionStore::new(
+				payjoin_sessions,
+				PAYJOIN_SESSION_STORE_PRIMARY_NAMESPACE.to_string(),
+				PAYJOIN_SESSION_STORE_SECONDARY_NAMESPACE.to_string(),
+				Arc::clone(&kv_store),
+				Arc::clone(&logger),
+			)),
+			Err(e) => {
+				log_error!(logger, "Failed to read payjoin session data from store: {}", e);
+				return Err(BuildError::ReadFailed);
+			},
+		};
+
+		Some(Arc::new(PayjoinManager::new(
+			Arc::clone(&payjoin_session_store),
+			Arc::clone(&logger),
+			Arc::clone(&config),
+			Arc::clone(&wallet),
+			Arc::clone(&fee_estimator),
+			Arc::clone(&chain_source),
+			Arc::clone(&channel_manager),
+			stop_sender.subscribe(),
+			Arc::clone(&payment_store),
+			Arc::clone(&pending_payment_store),
+			Arc::clone(&tx_broadcaster),
+		)))
+	} else {
+		None
+	};
+
 	#[cfg(cycle_tests)]
 	let mut _leak_checker = crate::LeakChecker(Vec::new());
 	#[cfg(cycle_tests)]
@@ -2342,6 +2408,7 @@ fn build_with_store_internal(
 		prober,
 		#[cfg(cycle_tests)]
 		_leak_checker,
+		payjoin_manager,
 	})
 }
 

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -34,7 +34,7 @@ use serde::Serialize;
 use super::WalletSyncStatus;
 use crate::config::{
 	BitcoindRestClientConfig, Config, DEFAULT_FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS,
-	DEFAULT_TX_BROADCAST_TIMEOUT_SECS,
+	DEFAULT_TX_BROADCAST_TIMEOUT_SECS, DEFAULT_TX_LOOKUP_TIMEOUT_SECS,
 };
 use crate::fee_estimator::{
 	apply_post_estimation_adjustments, get_all_conf_targets, get_num_block_defaults_for_target,
@@ -650,6 +650,57 @@ impl BitcoindChainSource {
 						Err(e) => self.log_broadcast_error(e, &[txid], &txs),
 					}
 				}
+			},
+		}
+	}
+
+	pub(crate) async fn can_broadcast_transaction(&self, tx: &Transaction) -> Result<bool, Error> {
+		let timeout_fut = tokio::time::timeout(
+			Duration::from_secs(DEFAULT_TX_LOOKUP_TIMEOUT_SECS),
+			self.api_client.test_mempool_accept(tx),
+		);
+
+		match timeout_fut.await {
+			Ok(res) => res.map_err(|e| {
+				log_error!(
+					self.logger,
+					"Failed to test mempool accept for transaction {}: {}",
+					tx.compute_txid(),
+					e
+				);
+				Error::WalletOperationFailed
+			}),
+			Err(e) => {
+				log_error!(
+					self.logger,
+					"Failed to test mempool accept for transaction {} due to timeout: {}",
+					tx.compute_txid(),
+					e
+				);
+				log_trace!(
+					self.logger,
+					"Failed test mempool accept transaction bytes: {}",
+					log_bytes!(tx.encode())
+				);
+				Err(Error::WalletOperationTimeout)
+			},
+		}
+	}
+
+	pub(crate) async fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+		let timeout_fut = tokio::time::timeout(
+			Duration::from_secs(DEFAULT_TX_LOOKUP_TIMEOUT_SECS),
+			self.api_client.get_raw_transaction(txid),
+		);
+
+		match timeout_fut.await {
+			Ok(res) => res.map_err(|e| {
+				log_error!(self.logger, "Failed to get transaction {}: {}", txid, e);
+				Error::TxLookupFailed
+			}),
+			Err(e) => {
+				log_error!(self.logger, "Failed to get transaction {} due to timeout: {}", txid, e);
+				Err(Error::TxLookupTimeout)
 			},
 		}
 	}
@@ -1269,6 +1320,34 @@ impl BitcoindClient {
 			.collect();
 		Ok(evicted_txids)
 	}
+
+	/// Tests whether the provided transaction would be accepted by the mempool.
+	pub(crate) async fn test_mempool_accept(
+		&self, tx: &Transaction,
+	) -> Result<bool, RpcClientError> {
+		match self {
+			BitcoindClient::Rpc { rpc_client, .. } => {
+				Self::test_mempool_accept_inner(Arc::clone(rpc_client), tx).await
+			},
+			BitcoindClient::Rest { rpc_client, .. } => {
+				// We rely on the internal RPC client to make this call, as this
+				// operation is not supported by Bitcoin Core's REST interface.
+				Self::test_mempool_accept_inner(Arc::clone(rpc_client), tx).await
+			},
+		}
+	}
+
+	async fn test_mempool_accept_inner(
+		rpc_client: Arc<RpcClient>, tx: &Transaction,
+	) -> Result<bool, RpcClientError> {
+		let tx_serialized = bitcoin::consensus::encode::serialize_hex(tx);
+		let tx_array = serde_json::json!([tx_serialized]);
+
+		rpc_client
+			.call_method::<TestMempoolAcceptResponse>("testmempoolaccept", &[tx_array])
+			.await
+			.map(|resp| resp.0)
+	}
 }
 
 impl BlockSource for BitcoindClient {
@@ -1438,6 +1517,23 @@ impl TryInto<SubmitPackageResponse> for JsonResponse {
 				return Err(response);
 			},
 		}
+	}
+}
+
+pub(crate) struct TestMempoolAcceptResponse(pub bool);
+
+impl TryInto<TestMempoolAcceptResponse> for JsonResponse {
+	type Error = String;
+	fn try_into(self) -> Result<TestMempoolAcceptResponse, String> {
+		let array =
+			self.0.as_array().ok_or("Failed to parse testmempoolaccept response".to_string())?;
+		let first =
+			array.first().ok_or("Empty array response from testmempoolaccept".to_string())?;
+		let allowed = first
+			.get("allowed")
+			.and_then(|v| v.as_bool())
+			.ok_or("Missing 'allowed' field in testmempoolaccept response".to_string())?;
+		Ok(TestMempoolAcceptResponse(allowed))
 	}
 }
 

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -20,6 +20,7 @@ use bitcoin::transaction::Version;
 use bitcoin::{FeeRate, Network, Script, ScriptBuf, Transaction, Txid};
 use electrum_client::{
 	Batch, Client as ElectrumClient, ConfigBuilder as ElectrumConfigBuilder, ElectrumApi,
+	Error as ElectrumError,
 };
 use lightning::chain::{Confirm, Filter, WatchedOutput};
 use lightning::util::ser::Writeable;
@@ -27,8 +28,8 @@ use lightning_transaction_sync::ElectrumSyncClient;
 
 use super::WalletSyncStatus;
 use crate::config::{
-	clamp_full_scan_stop_gap, Config, ElectrumSyncConfig, MAX_FULL_SCAN_STOP_GAP,
-	MIN_FULL_SCAN_STOP_GAP,
+	clamp_full_scan_stop_gap, Config, ElectrumSyncConfig, DEFAULT_TX_LOOKUP_TIMEOUT_SECS,
+	MAX_FULL_SCAN_STOP_GAP, MIN_FULL_SCAN_STOP_GAP,
 };
 use crate::error::Error;
 use crate::fee_estimator::{
@@ -374,6 +375,22 @@ impl ElectrumChainSource {
 				}
 			},
 		}
+	}
+
+	pub(crate) async fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+		let electrum_client: Arc<ElectrumRuntimeClient> = if let Some(client) =
+			self.electrum_runtime_status.read().expect("lock").client().as_ref()
+		{
+			Arc::clone(client)
+		} else {
+			debug_assert!(
+				false,
+				"We should have started the chain source before getting transactions"
+			);
+			return Err(Error::TxLookupFailed);
+		};
+
+		electrum_client.get_transaction(txid).await
 	}
 }
 
@@ -792,6 +809,37 @@ impl ElectrumRuntimeClient {
 		}
 
 		Ok(new_fee_rate_cache)
+	}
+
+	async fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+		let electrum_client = Arc::clone(&self.electrum_client);
+		let txid_copy = *txid;
+
+		let spawn_fut =
+			self.runtime.spawn_blocking(move || electrum_client.transaction_get(&txid_copy));
+		let timeout_fut =
+			tokio::time::timeout(Duration::from_secs(DEFAULT_TX_LOOKUP_TIMEOUT_SECS), spawn_fut);
+
+		match timeout_fut.await {
+			Ok(res) => match res {
+				Ok(inner_res) => match inner_res {
+					Ok(tx) => Ok(Some(tx)),
+					Err(ElectrumError::Protocol(_)) => Ok(None),
+					Err(e) => {
+						log_error!(self.logger, "Failed to get transaction {}: {}", txid, e);
+						Err(Error::TxLookupFailed)
+					},
+				},
+				Err(e) => {
+					log_error!(self.logger, "Failed to get transaction {}: {}", txid, e);
+					Err(Error::TxLookupFailed)
+				},
+			},
+			Err(e) => {
+				log_error!(self.logger, "Failed to get transaction {} due to timeout: {}", txid, e);
+				Err(Error::TxLookupTimeout)
+			},
+		}
 	}
 }
 

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bdk_esplora::EsploraAsyncExt;
 use bitcoin::transaction::Version;
-use bitcoin::{FeeRate, Network, Script, Txid};
+use bitcoin::{FeeRate, Network, Script, Transaction, Txid};
 use esplora_client::AsyncClient as EsploraAsyncClient;
 use lightning::chain::{Confirm, Filter, WatchedOutput};
 use lightning::util::ser::Writeable;
@@ -518,6 +518,13 @@ impl EsploraChainSource {
 				}
 			},
 		}
+	}
+
+	pub(crate) async fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+		self.esplora_client.get_tx(txid).await.map_err(|e| {
+			log_error!(self.logger, "Failed to get transaction {}: {}", txid, e);
+			Error::TxLookupFailed
+		})
 	}
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use bitcoin::{Script, Txid};
+use bitcoin::{Script, Transaction, Txid};
 use lightning::chain::{BlockLocator, Filter};
 
 use crate::chain::bitcoind::{BitcoindChainSource, UtxoSourceClient};
@@ -533,6 +533,42 @@ impl ChainSource {
 				}
 			}
 		}
+	}
+
+	pub(crate) fn can_broadcast_transaction(&self, tx: &Transaction) -> Result<bool, Error> {
+		tokio::task::block_in_place(|| {
+			tokio::runtime::Handle::current().block_on(async {
+				match &self.kind {
+					ChainSourceKind::Bitcoind(bitcoind_chain_source) => {
+						bitcoind_chain_source.can_broadcast_transaction(tx).await
+					},
+					ChainSourceKind::Esplora { .. } => {
+						// Esplora does not support a testmempoolaccept equivalent
+						unreachable!(
+							"Broadcast suitability check not supported by Esplora backend."
+						)
+					},
+					ChainSourceKind::Electrum { .. } => {
+						// Electrum does not support a testmempoolaccept equivalent.
+						unreachable!(
+							"Broadcast suitability check not supported by Electrum backend."
+						)
+					},
+				}
+			})
+		})
+	}
+
+	pub(crate) fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+		tokio::task::block_in_place(|| {
+			tokio::runtime::Handle::current().block_on(async {
+				match &self.kind {
+					ChainSourceKind::Bitcoind(bitcoind) => bitcoind.get_transaction(txid).await,
+					ChainSourceKind::Esplora(esplora) => esplora.get_transaction(txid).await,
+					ChainSourceKind::Electrum(electrum) => electrum.get_transaction(txid).await,
+				}
+			})
+		})
 	}
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
+use bitreq::URL;
 use lightning::ln::msgs::SocketAddress;
 use lightning::routing::gossip::NodeAlias;
 use lightning::routing::router::RouteParametersConfig;
@@ -136,6 +137,18 @@ pub(crate) const LIQUIDITY_DISCOVERY_RETRY_INITIAL_DELAY: Duration = Duration::f
 // thereafter until every configured LSP has been discovered.
 pub(crate) const LIQUIDITY_DISCOVERY_RETRY_MAX_DELAY: Duration = Duration::from_secs(60 * 60);
 
+// The time interval at which we resume persisted payjoin sessions.
+pub(crate) const PAYJOIN_RESUME_INTERVAL: Duration = Duration::from_secs(15);
+
+// The duration after which completed or failed payjoin sessions are cleaned up (24 hours).
+pub(crate) const PAYJOIN_SESSION_CLEANUP_AGE_SECS: u64 = 24 * 60 * 60;
+
+// The interval at which we check for old payjoin sessions to clean up (1 hour).
+pub(crate) const PAYJOIN_SESSION_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+// The default timeout after which we abort a transaction lookup operation.
+pub(crate) const DEFAULT_TX_LOOKUP_TIMEOUT_SECS: u64 = 10;
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 /// Represents the configuration of an [`Node`] instance.
@@ -153,8 +166,9 @@ pub(crate) const LIQUIDITY_DISCOVERY_RETRY_MAX_DELAY: Duration = Duration::from_
 /// | `probing_liquidity_limit_multiplier`   | 3                                    |
 /// | `anchor_channels_config`               | AnchorChannelsConfig::default()      |
 /// | `route_parameters`                     | None                                 |
-/// | `tor_config`                           | None                                 |
+/// | `tor_config`                           | None               				|
 /// | `hrn_config`                           | HumanReadableNamesConfig::default()  |
+/// | `payjoin_config`                     	 | None                                 |
 ///
 /// See [`AnchorChannelsConfig`] and [`RouteParametersConfig`] for more information regarding their
 /// respective default values.
@@ -219,6 +233,8 @@ pub struct Config {
 	///
 	/// [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
 	pub hrn_config: HumanReadableNamesConfig,
+	/// Configuration options for PayJoin payments.
+	pub payjoin_config: Option<PayjoinConfig>,
 }
 
 impl Default for Config {
@@ -235,6 +251,7 @@ impl Default for Config {
 			route_parameters: None,
 			node_alias: None,
 			hrn_config: HumanReadableNamesConfig::default(),
+			payjoin_config: None,
 		}
 	}
 }
@@ -776,6 +793,16 @@ pub enum AsyncPaymentsRole {
 	/// Node acts as a server in an async payments context. This means that it will hold async payments HTLCs and onion
 	/// messages for its peers.
 	Server,
+}
+
+/// Configuration options for PayJoin payments.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct PayjoinConfig {
+	/// The URL of the PayJoin directory
+	pub payjoin_directory: URL,
+	/// The URLs of the OHTTP relays to use for sending OHTTP requests to PayJoin receivers.
+	pub ohttp_relays: Vec<URL>,
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,10 @@ pub enum Error {
 	TxSyncFailed,
 	/// A transaction sync operation timed out.
 	TxSyncTimeout,
+	/// A transaction lookup operation failed.
+	TxLookupFailed,
+	/// A transaction lookup operation timed out.
+	TxLookupTimeout,
 	/// A gossip updating operation failed.
 	GossipUpdateFailed,
 	/// A gossip updating operation timed out.
@@ -139,6 +143,12 @@ pub enum Error {
 	InvalidLnurl,
 	/// The configured chain source is not supported.
 	ChainSourceNotSupported,
+	/// Payjoin is not configured.
+	PayjoinNotConfigured,
+	/// Payjoin session creation failed.
+	PayjoinSessionCreationFailed,
+	/// Payjoin session failed.
+	PayjoinSessionFailed,
 }
 
 impl fmt::Display for Error {
@@ -173,6 +183,8 @@ impl fmt::Display for Error {
 			Self::OnchainTxSigningFailed => write!(f, "Failed to sign given transaction."),
 			Self::TxSyncFailed => write!(f, "Failed to sync transactions."),
 			Self::TxSyncTimeout => write!(f, "Syncing transactions timed out."),
+			Self::TxLookupFailed => write!(f, "Failed to look up transaction."),
+			Self::TxLookupTimeout => write!(f, "Transaction lookup timed out."),
 			Self::GossipUpdateFailed => write!(f, "Failed to update gossip data."),
 			Self::GossipUpdateTimeout => write!(f, "Updating gossip data timed out."),
 			Self::LiquidityRequestFailed => write!(f, "Failed to request inbound liquidity."),
@@ -227,6 +239,9 @@ impl fmt::Display for Error {
 			Self::ChainSourceNotSupported => {
 				write!(f, "The configured chain source is not supported.")
 			},
+			Self::PayjoinNotConfigured => write!(f, "Payjoin is not configured."),
+			Self::PayjoinSessionCreationFailed => write!(f, "Payjoin session creation failed."),
+			Self::PayjoinSessionFailed => write!(f, "Payjoin session failed."),
 		}
 	}
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -84,3 +84,7 @@ pub(crate) const BDK_WALLET_INDEXER_KEY: &str = "indexer";
 ///
 /// [`StaticInvoice`]: lightning::offers::static_invoice::StaticInvoice
 pub(crate) const STATIC_INVOICE_STORE_PRIMARY_NAMESPACE: &str = "static_invoices";
+
+/// The payjoin sessions will be persisted under this key.
+pub(crate) const PAYJOIN_SESSION_STORE_PRIMARY_NAMESPACE: &str = "payjoin_sessions";
+pub(crate) const PAYJOIN_SESSION_STORE_SECONDARY_NAMESPACE: &str = "";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ pub use builder::NodeBuilder as Builder;
 use chain::ChainSource;
 use config::{
 	default_user_config, may_announce_channel, AsyncPaymentsRole, ChannelConfig, Config,
-	LNURL_AUTH_TIMEOUT_SECS, NODE_ANN_BCAST_INTERVAL, PEER_RECONNECTION_INTERVAL,
-	RGS_SYNC_INTERVAL,
+	LNURL_AUTH_TIMEOUT_SECS, NODE_ANN_BCAST_INTERVAL, PAYJOIN_RESUME_INTERVAL,
+	PAYJOIN_SESSION_CLEANUP_INTERVAL, PEER_RECONNECTION_INTERVAL, RGS_SYNC_INTERVAL,
 };
 use connection::ConnectionManager;
 pub use error::Error as NodeError;
@@ -172,8 +172,8 @@ use logger::{log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
 use payment::asynchronous::om_mailbox::OnionMessageMailbox;
 use payment::asynchronous::static_invoice_store::StaticInvoiceStore;
 use payment::{
-	Bolt11Payment, Bolt12Payment, OnchainPayment, PaymentDetails, SpontaneousPayment,
-	UnifiedPayment,
+	Bolt11Payment, Bolt12Payment, OnchainPayment, PayjoinPayment, PaymentDetails,
+	SpontaneousPayment, UnifiedPayment,
 };
 use peer_store::{PeerInfo, PeerStore};
 #[cfg(feature = "uniffi")]
@@ -194,6 +194,7 @@ pub use vss_client;
 use crate::config::{LIQUIDITY_DISCOVERY_RETRY_INITIAL_DELAY, LIQUIDITY_DISCOVERY_RETRY_MAX_DELAY};
 use crate::ffi::maybe_wrap;
 use crate::liquidity::Liquidity;
+use crate::payment::payjoin::manager::PayjoinManager;
 use crate::scoring::setup_background_pathfinding_scores_sync;
 use crate::wallet::FundingAmount;
 
@@ -274,6 +275,7 @@ pub struct Node {
 	prober: Option<Arc<Prober>>,
 	#[cfg(cycle_tests)]
 	_leak_checker: LeakChecker,
+	payjoin_manager: Option<Arc<PayjoinManager>>,
 }
 
 impl Node {
@@ -819,6 +821,52 @@ impl Node {
 			}
 		});
 
+		if let Some(payjoin_manager) = self.payjoin_manager.as_ref() {
+			// Periodically resume payjoin sessions.
+			let resume_payjoin_manager = Arc::clone(payjoin_manager);
+			let resume_logger = Arc::clone(&self.logger);
+			let mut stop_resume = self.stop_sender.subscribe();
+			self.runtime.spawn_cancellable_background_task(async move {
+				let mut interval = tokio::time::interval(PAYJOIN_RESUME_INTERVAL);
+				interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+				loop {
+					tokio::select! {
+						_ = stop_resume.changed() => {
+							log_debug!(resume_logger, "Stopping payjoin session resume task.");
+							return;
+						}
+						_ = interval.tick() => {
+							if let Err(e) = resume_payjoin_manager.resume_payjoin_sessions().await {
+								log_error!(resume_logger, "Failed to resume payjoin sessions: {:?}", e);
+							}
+						}
+					}
+				}
+			});
+
+			// Periodically clean up old completed/failed payjoin sessions.
+			let cleanup_payjoin_manager = Arc::clone(&payjoin_manager);
+			let cleanup_logger = Arc::clone(&self.logger);
+			let mut stop_cleanup = self.stop_sender.subscribe();
+			self.runtime.spawn_cancellable_background_task(async move {
+				let mut interval = tokio::time::interval(PAYJOIN_SESSION_CLEANUP_INTERVAL);
+				interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+				loop {
+					tokio::select! {
+						_ = stop_cleanup.changed() => {
+							log_debug!(cleanup_logger, "Stopping payjoin session cleanup task.");
+							return;
+						}
+						_ = interval.tick() => {
+							if let Err(e) = cleanup_payjoin_manager.cleanup_old_sessions().await {
+								log_error!(cleanup_logger, "Failed to cleanup old payjoin sessions: {:?}", e);
+							}
+						}
+					}
+				}
+			});
+		}
+
 		log_info!(self.logger, "Startup complete.");
 		*is_running_lock = true;
 		Ok(())
@@ -1172,6 +1220,24 @@ impl Node {
 			Arc::clone(&self.logger),
 			self.hrn_resolver.clone(),
 		))
+	}
+
+	/// Returns a payment handler allowing to send and receive [Payjoin] payments.
+	///
+	/// [Payjoin]: https://payjoin.org
+	#[cfg(not(feature = "uniffi"))]
+	pub fn payjoin_payment(&self) -> Result<PayjoinPayment, Error> {
+		let manager = self.payjoin_manager.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+		Ok(PayjoinPayment::new(Arc::clone(manager), Arc::clone(&self.is_running)))
+	}
+
+	/// Returns a payment handler allowing to send and receive [Payjoin] payments.
+	///
+	/// [Payjoin]: https://payjoin.org
+	#[cfg(feature = "uniffi")]
+	pub fn payjoin_payment(&self) -> Result<Arc<PayjoinPayment>, Error> {
+		let manager = self.payjoin_manager.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+		Ok(Arc::new(PayjoinPayment::new(Arc::clone(manager), Arc::clone(&self.is_running))))
 	}
 
 	/// Authenticates the user via [LNURL-auth] for the given LNURL string.

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod asynchronous;
 mod bolt11;
 mod bolt12;
 mod onchain;
+pub(crate) mod payjoin;
 pub(crate) mod pending_payment_store;
 mod spontaneous;
 pub(crate) mod store;
@@ -20,6 +21,7 @@ pub use bolt11::Bolt11Payment;
 pub(crate) use bolt11::PaymentMetadata;
 pub use bolt12::Bolt12Payment;
 pub use onchain::OnchainPayment;
+pub use payjoin::PayjoinPayment;
 pub(crate) use pending_payment_store::{FundingTxCandidate, PendingPaymentDetails};
 pub use spontaneous::SpontaneousPayment;
 pub use store::{

--- a/src/payment/payjoin/manager.rs
+++ b/src/payment/payjoin/manager.rs
@@ -1,0 +1,893 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+use bitcoin::{Amount, FeeRate, TxIn};
+use lightning::ln::channelmanager::PaymentId;
+use lightning::log_warn;
+use payjoin::persist::OptionalTransitionOutcome;
+use payjoin::receive::InputPair;
+use payjoin::ImplementationError;
+
+use crate::chain::ChainSource;
+use crate::config::{Config, PayjoinConfig, PAYJOIN_SESSION_CLEANUP_AGE_SECS};
+use crate::fee_estimator::{ConfirmationTarget, FeeEstimator, OnchainFeeEstimator};
+use crate::logger::{log_debug, log_error, log_info, LdkLogger, Logger};
+use crate::payment::payjoin::payjoin_session::{PayjoinDirection, PayjoinSession, PayjoinStatus};
+use crate::payment::{
+	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
+	PendingPaymentDetails, TransactionType,
+};
+use crate::total_anchor_channels_reserve_sats;
+use crate::types::{Broadcaster, ChannelManager};
+use crate::types::{PaymentStore, PendingPaymentStore};
+use crate::Error;
+use crate::{
+	payment::payjoin::persist::KVStorePayjoinReceiverPersister, types::PayjoinSessionStore,
+	wallet::Wallet,
+};
+use payjoin::bitcoin::psbt::Input;
+use payjoin::io::fetch_ohttp_keys;
+use payjoin::receive::v2::{
+	replay_event_log_async as replay_receiver_event_log_async, HasReplyableError, Initialized,
+	MaybeInputsOwned, MaybeInputsSeen, Monitor, OutputsUnknown, PayjoinProposal,
+	ProvisionalProposal, ReceiveSession, Receiver, ReceiverBuilder, SessionOutcome,
+	UncheckedOriginalPayload, WantsFeeRange, WantsInputs, WantsOutputs,
+};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Clone)]
+pub(crate) struct PayjoinManager {
+	payjoin_session_store: Arc<PayjoinSessionStore>,
+	logger: Arc<Logger>,
+	config: Arc<Config>,
+	wallet: Arc<Wallet>,
+	fee_estimator: Arc<OnchainFeeEstimator>,
+	chain_source: Arc<ChainSource>,
+	channel_manager: Arc<ChannelManager>,
+	stop_receiver: tokio::sync::watch::Receiver<()>,
+	payment_store: Arc<PaymentStore>,
+	pending_payment_store: Arc<PendingPaymentStore>,
+	broadcaster: Arc<Broadcaster>,
+}
+
+impl PayjoinManager {
+	pub(crate) fn new(
+		payjoin_session_store: Arc<PayjoinSessionStore>, logger: Arc<Logger>, config: Arc<Config>,
+		wallet: Arc<Wallet>, fee_estimator: Arc<OnchainFeeEstimator>,
+		chain_source: Arc<ChainSource>, channel_manager: Arc<ChannelManager>,
+		stop_receiver: tokio::sync::watch::Receiver<()>, payment_store: Arc<PaymentStore>,
+		pending_payment_store: Arc<PendingPaymentStore>, broadcaster: Arc<Broadcaster>,
+	) -> Self {
+		Self {
+			payjoin_session_store,
+			logger,
+			config,
+			wallet,
+			fee_estimator,
+			chain_source,
+			channel_manager,
+			stop_receiver,
+			payment_store,
+			pending_payment_store,
+			broadcaster,
+		}
+	}
+
+	pub(crate) async fn receive_payjoin(
+		&self, amount_sats: u64, fee_rate: Option<FeeRate>,
+	) -> Result<String, Error> {
+		let payjoin_config =
+			self.config.payjoin_config.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+
+		if payjoin_config.ohttp_relays.is_empty() {
+			log_error!(self.logger, "No OHTTP relays configured.");
+			return Err(Error::PayjoinNotConfigured);
+		}
+
+		// Generate a new session ID
+		let mut random_bytes = [0u8; 32];
+		getrandom::fill(&mut random_bytes).map_err(|e| {
+			log_error!(self.logger, "Failed to generate random session ID: {}", e);
+			Error::PayjoinSessionCreationFailed
+		})?;
+		let session_id = PaymentId(random_bytes);
+
+		let confirmation_target = ConfirmationTarget::OnchainPayment;
+		let fee_rate =
+			fee_rate.unwrap_or_else(|| self.fee_estimator.estimate_fee_rate(confirmation_target));
+
+		// Create a new persister for this session
+		let persister = KVStorePayjoinReceiverPersister::new(
+			session_id,
+			Some(amount_sats * 1000),
+			Arc::clone(&self.payjoin_session_store),
+			fee_rate.to_sat_per_kwu(),
+			None,
+			None,
+			None,
+		)
+		.await?;
+
+		let address = self.wallet.get_new_address().await?;
+		let ohttp_keys = {
+			let mut result = Err(Error::ConnectionFailed);
+			for relay in self.relay_order(payjoin_config)? {
+				match fetch_ohttp_keys(relay, payjoin_config.payjoin_directory.as_str()).await {
+					Ok(keys) => {
+						result = Ok(keys);
+						break;
+					},
+					Err(e) => {
+						log_error!(
+							self.logger,
+							"Failed to fetch OHTTP keys via {}: {}. Trying next relay.",
+							relay,
+							e
+						);
+					},
+				}
+			}
+			result
+		}?;
+		log_debug!(self.logger, "Fetched OHTTP keys: {:?}", ohttp_keys);
+
+		let amount = Amount::from_sat(amount_sats);
+
+		let session = ReceiverBuilder::new(
+			address,
+			payjoin_config.payjoin_directory.clone().as_str(),
+			ohttp_keys,
+		)
+		.map_err(|e| {
+			log_error!(self.logger, "Failed to create receiver builder: {}", e);
+			Error::PayjoinSessionCreationFailed
+		})?
+		.with_amount(amount)
+		.with_max_fee_rate(fee_rate)
+		.build()
+		.save_async(&persister)
+		.await
+		.map_err(|_| Error::PersistenceFailed)?;
+
+		log_info!(self.logger, "Receive session established");
+		let pj_uri = session.pj_uri();
+		log_info!(self.logger, "Request Payjoin by sharing this Payjoin Uri: {}", pj_uri);
+
+		Ok(pj_uri.to_string())
+	}
+
+	fn relay_order<'a>(&self, payjoin_config: &'a PayjoinConfig) -> Result<Vec<&'a str>, Error> {
+		let count = payjoin_config.ohttp_relays.len();
+		let start = if count > 0 {
+			let mut bytes = [0u8; 8];
+			getrandom::fill(&mut bytes).map_err(|e| {
+				log_error!(self.logger, "Failed to generate random relay index: {}", e);
+				Error::PayjoinSessionFailed
+			})?;
+			u64::from_ne_bytes(bytes) as usize % count
+		} else {
+			0
+		};
+		Ok((0..count).map(|i| payjoin_config.ohttp_relays[(start + i) % count].as_str()).collect())
+	}
+
+	async fn process_receiver_session(
+		&self, session: ReceiveSession, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let res = {
+			match session {
+				ReceiveSession::Initialized(proposal) => {
+					self.read_from_directory(proposal, persister).await
+				},
+				ReceiveSession::UncheckedOriginalPayload(proposal) => {
+					self.check_proposal(proposal, persister).await
+				},
+				ReceiveSession::MaybeInputsOwned(proposal) => {
+					self.check_inputs_not_owned(proposal, persister).await
+				},
+				ReceiveSession::MaybeInputsSeen(proposal) => {
+					self.check_no_inputs_seen_before(proposal, persister).await
+				},
+				ReceiveSession::OutputsUnknown(proposal) => {
+					self.identify_receiver_outputs(proposal, persister).await
+				},
+				ReceiveSession::WantsOutputs(proposal) => {
+					self.commit_outputs(proposal, persister).await
+				},
+				ReceiveSession::WantsInputs(proposal) => {
+					self.contribute_inputs(proposal, persister).await
+				},
+				ReceiveSession::WantsFeeRange(proposal) => {
+					self.apply_fee_range(proposal, persister).await
+				},
+				ReceiveSession::ProvisionalProposal(proposal) => {
+					self.finalize_proposal(proposal, persister).await
+				},
+				ReceiveSession::PayjoinProposal(proposal) => {
+					self.send_payjoin_proposal(proposal, persister).await
+				},
+				ReceiveSession::HasReplyableError(error) => {
+					self.handle_error(error, persister).await
+				},
+				ReceiveSession::Monitor(proposal) => {
+					self.monitor_payjoin_proposal(proposal, persister).await
+				},
+				ReceiveSession::Closed(outcome) => {
+					self.handle_closed_session(outcome, persister).await
+				},
+			}
+		};
+		res
+	}
+
+	async fn read_from_directory(
+		&self, session: Receiver<Initialized>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let mut interrupt = self.stop_receiver.clone();
+		let receiver = tokio::select! {
+			res = self.long_poll_fallback(session, &*persister) => res,
+			_ = interrupt.changed() => {
+				log_info!(self.logger, "Session interrupted by node shutdown. Will resume on restart.");
+				return Err(Error::NotRunning);
+			}
+		}?;
+		self.check_proposal(receiver, &*persister).await
+	}
+
+	async fn long_poll_fallback(
+		&self, session: Receiver<Initialized>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<Receiver<UncheckedOriginalPayload>, Error> {
+		let payjoin_config =
+			self.config.payjoin_config.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+
+		let mut session = session;
+		loop {
+			let (ohttp_response, context) = {
+				let mut result = Err(Error::ConnectionFailed);
+				for relay in self.relay_order(payjoin_config)? {
+					let (req, ctx) = match session.create_poll_request(relay) {
+						Ok(r) => r,
+						Err(e) => {
+							// create_poll_request is fatal. No fallback tx exists yet at this stage
+							// (sender hasn't sent their PSBT), so we just fail the session.
+							log_error!(self.logger, "Failed to create poll request: {}", e);
+							result = Err(Error::PayjoinSessionFailed);
+							self.handle_closed_session(SessionOutcome::Failure, persister).await?;
+							break;
+						},
+					};
+					match self.post_request(req).await {
+						Ok(resp) => {
+							result = Ok((resp, ctx));
+							break;
+						},
+						Err(e) => {
+							log_error!(self.logger, "Polling failed via relay, trying next: {}", e);
+						},
+					}
+				}
+				result
+			}?;
+			log_debug!(self.logger, "Polling receive request...");
+			let state_transition = session
+				.process_response(ohttp_response.as_bytes().to_vec().as_slice(), context)
+				.save_async(persister)
+				.await;
+			match state_transition {
+				Ok(OptionalTransitionOutcome::Progress(next_state)) => {
+					log_info!(
+						self.logger,
+						"Got a request from the sender. Responding with a Payjoin proposal."
+					);
+					return Ok(next_state);
+				},
+				Ok(OptionalTransitionOutcome::Stasis(current_state)) => {
+					session = current_state;
+					continue;
+				},
+				Err(_) => return Err(Error::PersistenceFailed),
+			}
+		}
+	}
+
+	async fn post_request(&self, req: payjoin::Request) -> Result<bitreq::Response, Error> {
+		bitreq::post(req.url)
+			.with_header("Content-Type", req.content_type)
+			.with_body(req.body)
+			.send_async()
+			.await
+			.map_err(|e| {
+				log_error!(self.logger, "HTTP request failed: {}", e);
+				Error::ConnectionFailed
+			})
+	}
+
+	async fn check_proposal(
+		&self, proposal: Receiver<UncheckedOriginalPayload>,
+		persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		// Note: broadcast suitability can only be verified when using the BitcoindRpc backend.
+		// For Esplora and Electrum backends this check will return an error as they do not
+		// support a testmempoolaccept equivalent.
+		let proposal = proposal
+			.check_broadcast_suitability(None, |tx| {
+				self.chain_source
+					.can_broadcast_transaction(tx)
+					.map_err(|e| ImplementationError::from(e.to_string().as_str()))
+			})
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+
+		// If the payjoin fails or times out, broadcast this fallback tx to ensure the receiver still gets paid.
+		let fallback_tx = proposal.extract_tx_to_schedule_broadcast();
+
+		let session_id = persister.session_id();
+		let mut session =
+			self.payjoin_session_store.get(&session_id).ok_or(Error::InvalidPaymentId)?;
+
+		session.fallback_tx = Some(fallback_tx);
+		self.payjoin_session_store.insert_or_update(session).await?;
+
+		log_info!(
+			self.logger,
+			"Fallback transaction received. This will be broadcast if the Payjoin fails"
+		);
+		self.check_inputs_not_owned(proposal, persister).await
+	}
+
+	async fn check_inputs_not_owned(
+		&self, proposal: Receiver<MaybeInputsOwned>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let proposal = proposal
+			.check_inputs_not_owned(&mut |input| {
+				self.wallet
+					.is_mine(input.to_owned())
+					.map_err(|e| ImplementationError::from(e.to_string().as_str()))
+			})
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+
+		self.check_no_inputs_seen_before(proposal, persister).await
+	}
+
+	async fn check_no_inputs_seen_before(
+		&self, proposal: Receiver<MaybeInputsSeen>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let mut inputs_seen = persister.get_session().ok_or(Error::InvalidPaymentId)?.inputs_seen;
+		let mut newly_seen = Vec::new();
+
+		let transition = proposal.check_no_inputs_seen_before(&mut |input| {
+			if inputs_seen.contains(input) {
+				return Ok(true);
+			}
+			inputs_seen.push(*input);
+			newly_seen.push(*input);
+			Ok(false)
+		});
+
+		persister.insert_inputs_seen(newly_seen).await?;
+
+		let proposal =
+			transition.save_async(persister).await.map_err(|_| Error::PersistenceFailed)?;
+
+		self.identify_receiver_outputs(proposal, persister).await
+	}
+
+	async fn identify_receiver_outputs(
+		&self, proposal: Receiver<OutputsUnknown>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let proposal = proposal
+			.identify_receiver_outputs(&mut |output_script| {
+				self.wallet
+					.is_mine(output_script.to_owned())
+					.map_err(|e| ImplementationError::from(e.to_string().as_str()))
+			})
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+		self.commit_outputs(proposal, persister).await
+	}
+
+	async fn commit_outputs(
+		&self, proposal: Receiver<WantsOutputs>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let proposal = proposal
+			.commit_outputs()
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+		self.contribute_inputs(proposal, persister).await
+	}
+
+	async fn contribute_inputs(
+		&self, proposal: Receiver<WantsInputs>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		// Check wallet has spendable funds after accounting for anchor reserve
+		let cur_anchor_reserve_sats =
+			total_anchor_channels_reserve_sats(&self.channel_manager, &self.config);
+		let spendable_amount_sats =
+			self.wallet.get_spendable_amount_sats(cur_anchor_reserve_sats).unwrap_or(0);
+
+		if spendable_amount_sats == 0 {
+			log_error!(
+				self.logger,
+				"No spendable funds available after anchor reserve. Cannot contribute inputs to payjoin."
+			);
+			return Err(Error::InsufficientFunds);
+		}
+
+		let candidate_inputs = self.list_input_pairs()?;
+
+		if candidate_inputs.is_empty() {
+			return Err({
+				log_error!(
+					self.logger,
+					"No spendable UTXOs available in wallet. Cannot contribute inputs to payjoin."
+				);
+				Error::InsufficientFunds
+			});
+		}
+
+		let selected_input = proposal.try_preserving_privacy(candidate_inputs).map_err(|e| {
+			log_error!(self.logger, "Failed to select input for payjoin contribution: {}", e);
+			Error::PayjoinSessionFailed
+		})?;
+		let proposal = proposal
+			.contribute_inputs(vec![selected_input])
+			.map_err(|e| {
+				log_error!(self.logger, "Failed to contribute inputs to payjoin: {}", e);
+				Error::PayjoinSessionFailed
+			})?
+			.commit_inputs()
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+		self.apply_fee_range(proposal, persister).await
+	}
+
+	fn list_input_pairs(&self) -> Result<Vec<InputPair>, Error> {
+		let unspent = self.wallet.list_unspent_confirmed_utxos()?;
+
+		let mut input_pairs = Vec::with_capacity(unspent.len());
+
+		for u in unspent {
+			let txin = TxIn { previous_output: u.outpoint, ..Default::default() };
+			let psbtin = Input { witness_utxo: Some(u.output.clone()), ..Default::default() };
+
+			let input_pair = InputPair::new(txin, psbtin, None).map_err(|e| {
+				log_error!(self.logger, "Failed to create InputPair: {}", e);
+				Error::PayjoinSessionFailed
+			})?;
+
+			input_pairs.push(input_pair);
+		}
+
+		Ok(input_pairs)
+	}
+
+	async fn apply_fee_range(
+		&self, proposal: Receiver<WantsFeeRange>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let session = persister.get_session().ok_or(Error::InvalidPaymentId)?;
+		let fee_rate = FeeRate::from_sat_per_kwu(session.fee_rate_kwu);
+
+		let proposal = proposal
+			.apply_fee_range(None, Some(fee_rate))
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+
+		self.finalize_proposal(proposal, persister).await
+	}
+
+	async fn finalize_proposal(
+		&self, proposal: Receiver<ProvisionalProposal>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let proposal = proposal
+			.finalize_proposal(|psbt| {
+				self.wallet
+					.process_psbt(psbt.clone())
+					.map_err(|e| ImplementationError::from(e.to_string().as_str()))
+			})
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+		self.send_payjoin_proposal(proposal, persister).await
+	}
+
+	async fn send_payjoin_proposal(
+		&self, proposal: Receiver<PayjoinProposal>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let payjoin_config =
+			self.config.payjoin_config.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+
+		let (res, ohttp_ctx) = {
+			let mut result = Err(Error::ConnectionFailed);
+			for relay in self.relay_order(payjoin_config)? {
+				let (req, ctx) = match proposal.create_post_request(relay) {
+					Ok(r) => r,
+					Err(e) => {
+						// create_post_request is fatal, so we trigger a session failure
+						// immediately and broadcast the fallback transaction.
+						log_error!(self.logger, "v2 req extraction failed {}", e);
+						result = Err(Error::PayjoinSessionFailed);
+						self.handle_closed_session(SessionOutcome::Failure, persister).await?;
+						break;
+					},
+				};
+				match self.post_request(req).await {
+					Ok(resp) => {
+						result = Ok((resp, ctx));
+						break;
+					},
+					Err(e) => {
+						log_error!(
+							self.logger,
+							"Proposal send failed via relay, trying next: {}",
+							e
+						);
+					},
+				}
+			}
+			result
+		}?;
+		let payjoin_psbt = proposal.psbt().clone();
+		let session = proposal
+			.process_response(&res.as_bytes(), ohttp_ctx)
+			.save_async(persister)
+			.await
+			.map_err(|_| Error::PersistenceFailed)?;
+
+		// At this point we will persist the fee and txid to the session store
+		let fee = payjoin_psbt.fee().unwrap_or(Amount::ZERO);
+		let fee_sat = fee.to_sat();
+		let txid = payjoin_psbt.extract_tx_unchecked_fee_rate().compute_txid();
+
+		let session_id = persister.session_id();
+		let mut payjoin_session =
+			self.payjoin_session_store.get(&session_id).ok_or(Error::InvalidPaymentId)?;
+
+		payjoin_session.fee_paid_msat = Some(fee_sat * 1000);
+		payjoin_session.txid = Some(txid);
+		self.payjoin_session_store.insert_or_update(payjoin_session).await.map_err(|e| {
+			log_error!(
+				self.logger,
+				"Failed to update payjoin session for {:?}: {:?}",
+				session_id,
+				e
+			);
+			Error::PersistenceFailed
+		})?;
+
+		log_info!(
+			self.logger,
+			"Response successful. Watch mempool for successful Payjoin. TXID: {}",
+			txid
+		);
+
+		self.monitor_payjoin_proposal(session, persister).await
+	}
+
+	async fn handle_error(
+		&self, session: Receiver<HasReplyableError>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let payjoin_config =
+			self.config.payjoin_config.as_ref().ok_or(Error::PayjoinNotConfigured)?;
+
+		let (err_response, err_ctx) = {
+			let mut result = Err(Error::ConnectionFailed);
+			for relay in self.relay_order(payjoin_config)? {
+				let (req, ctx) = match session.create_error_request(relay) {
+					Ok(r) => r,
+					Err(_) => {
+						result = Err(Error::PayjoinSessionFailed);
+						break;
+					},
+				};
+				match self.post_request(req).await {
+					Ok(resp) => {
+						result = Ok((resp, ctx));
+						break;
+					},
+					Err(e) => {
+						log_error!(
+							self.logger,
+							"Error response send failed via relay, trying next: {}",
+							e
+						);
+					},
+				}
+			}
+			result
+		}?;
+
+		let err_bytes = err_response.as_bytes();
+
+		if let Err(_) =
+			session.process_error_response(&err_bytes, err_ctx).save_async(persister).await
+		{
+			return Err(Error::PersistenceFailed);
+		}
+
+		Ok(())
+	}
+
+	async fn handle_closed_session(
+		&self, outcome: SessionOutcome, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		let session_id = persister.session_id();
+		let mut session =
+			self.payjoin_session_store.get(&session_id).ok_or(Error::InvalidPaymentId)?;
+
+		match outcome {
+			SessionOutcome::Success(_) => {
+				log_info!(
+					self.logger,
+					"Payjoin session detected in the mempool and completed successfully."
+				);
+				let kind = PaymentKind::Onchain {
+					txid: session.txid.ok_or_else(|| {
+						log_error!(self.logger, "Payjoin session {} missing txid.", session_id);
+						Error::PayjoinSessionFailed
+					})?,
+					tx_type: Some(TransactionType::Payjoin),
+					status: ConfirmationStatus::Unconfirmed,
+				};
+
+				let payment = PaymentDetails::new(
+					session_id,
+					kind,
+					session.amount_msat,
+					session.fee_paid_msat,
+					PaymentDirection::Inbound,
+					PaymentStatus::Pending,
+				);
+
+				self.payment_store.insert_or_update(payment.clone()).await?;
+
+				let pending_payment = PendingPaymentDetails::new(payment, Vec::new(), Vec::new());
+				self.pending_payment_store.insert_or_update(pending_payment).await?;
+
+				session.status = PayjoinStatus::Completed;
+				session.completed_at = Some(
+					SystemTime::now()
+						.duration_since(UNIX_EPOCH)
+						.unwrap_or(Duration::from_secs(0))
+						.as_secs(),
+				);
+				self.payjoin_session_store.insert_or_update(session).await?;
+			},
+			SessionOutcome::PayjoinProposalSent => {
+				log_info!(
+					self.logger,
+					"Payjoin proposal sent. Cannot track broadcast due to non-SegWit sender inputs."
+				);
+				session.status = PayjoinStatus::Completed;
+				session.completed_at = Some(
+					SystemTime::now()
+						.duration_since(UNIX_EPOCH)
+						.unwrap_or(Duration::from_secs(0))
+						.as_secs(),
+				);
+				self.payjoin_session_store.insert_or_update(session).await?;
+			},
+			SessionOutcome::FallbackBroadcasted => {
+				log_info!(self.logger, "Payjoin failed. Fallback transaction was broadcasted.");
+				session.status = PayjoinStatus::Failed;
+				self.payjoin_session_store.insert_or_update(session).await?;
+			},
+			SessionOutcome::Cancel => {
+				log_info!(self.logger, "Payjoin session was cancelled.");
+				self.close_session_with_fallback(&mut session).await;
+			},
+			SessionOutcome::Failure => {
+				log_error!(self.logger, "Payjoin session failed due to a protocol error.");
+				self.close_session_with_fallback(&mut session).await;
+			},
+		}
+		Ok(())
+	}
+
+	async fn monitor_payjoin_proposal(
+		&self, proposal: Receiver<Monitor>, persister: &KVStorePayjoinReceiverPersister,
+	) -> Result<(), Error> {
+		// On a session resumption, the receiver will resume again in this state.
+		let poll_interval = tokio::time::Duration::from_secs(2);
+
+		let timeout_duration = tokio::time::Duration::from_secs(10);
+
+		let mut interval = tokio::time::interval(poll_interval);
+		interval.tick().await;
+
+		log_debug!(self.logger, "Polling for payjoin transaction in the mempool...");
+
+		let result = tokio::time::timeout(timeout_duration, async {
+			loop {
+				interval.tick().await;
+				let check_result = proposal
+					.check_payment(|txid| {
+						self.chain_source
+							.get_transaction(&txid)
+							.map_err(|e| ImplementationError::from(e.to_string().as_str()))
+					})
+					.save_async(persister)
+					.await;
+
+				match check_result {
+					Ok(_) => {
+						log_info!(self.logger, "Payjoin transaction detected in the mempool!");
+						return Ok(());
+					},
+					Err(_) => {
+						continue;
+					},
+				}
+			}
+		})
+		.await;
+
+		match result {
+			Ok(ok) => ok,
+			Err(_) => {
+				log_debug!(
+					self.logger,
+					"Payjoin transaction not yet seen after {:?}. Will retry on next background tick.",
+					timeout_duration
+				);
+				Ok(())
+			},
+		}
+	}
+
+	pub(crate) async fn resume_payjoin_sessions(&self) -> Result<(), Error> {
+		let recv_session_ids = self
+			.payjoin_session_store
+			.list_filter(|p| {
+				p.direction == PayjoinDirection::Receive && p.status == PayjoinStatus::Active
+			})
+			.iter()
+			.map(|s| s.session_id.clone())
+			.collect::<Vec<PaymentId>>();
+
+		if recv_session_ids.is_empty() {
+			log_debug!(self.logger, "No sessions to resume.");
+			return Ok(());
+		}
+
+		let mut join_set: tokio::task::JoinSet<Result<(), Error>> = tokio::task::JoinSet::new();
+
+		// Process receiver sessions
+		for session_id in recv_session_ids {
+			let self_clone = self.clone();
+			// Create a persister for this session
+			let recv_persister = match KVStorePayjoinReceiverPersister::from_session(
+				session_id.clone(),
+				Arc::clone(&self.payjoin_session_store),
+			) {
+				Ok(p) => p,
+				Err(e) => {
+					log_error!(
+						self.logger,
+						"Failed to create persister for session {:?}: {:?}",
+						session_id,
+						e
+					);
+					continue;
+				},
+			};
+
+			match replay_receiver_event_log_async(&recv_persister).await {
+				Ok((receiver_state, _)) => {
+					join_set.spawn(async move {
+						self_clone.process_receiver_session(receiver_state, &recv_persister).await
+					});
+				},
+				Err(e) => {
+					log_error!(
+						self.logger,
+						"An error {:?} occurred while replaying receiver session",
+						e
+					);
+					let mut session = self
+						.payjoin_session_store
+						.get(&session_id)
+						.ok_or(Error::InvalidPaymentId)?;
+
+					self.close_session_with_fallback(&mut session).await;
+				},
+			}
+		}
+
+		let mut interrupt = self.stop_receiver.clone();
+		tokio::select! {
+			_ = async {
+				while let Some(result) = join_set.join_next().await {
+					match result {
+						Ok(Ok(())) => log_info!(self.logger, "A payjoin session completed successfully."),
+						Ok(Err(e)) => log_error!(self.logger, "A payjoin session failed: {:?}", e),
+						Err(e) => log_error!(self.logger, "A payjoin session task panicked: {:?}", e),
+					}
+				}
+			} => {
+				log_info!(self.logger, "All payjoin resumed sessions completed.");
+			}
+			_ = interrupt.changed() => {
+				join_set.abort_all();
+				log_info!(self.logger, "Resumed payjoin sessions were interrupted.");
+			}
+		}
+		Ok(())
+	}
+
+	async fn close_session_with_fallback(&self, session: &mut PayjoinSession) {
+		session.status = PayjoinStatus::Failed;
+
+		if let Some(fallback_tx) = session.fallback_tx.as_ref() {
+			self.broadcaster.broadcast_unclassified_transaction(fallback_tx.clone());
+		} else {
+			log_warn!(
+              self.logger,
+              "Payjoin session {} missing fallback transaction; closing as Failed without broadcast.",
+              session.session_id
+          );
+		}
+
+		if let Err(close_err) = self.payjoin_session_store.insert_or_update(session.clone()).await {
+			log_error!(
+				self.logger,
+				"Failed to close receiver session {}: {:?}",
+				session.session_id,
+				close_err
+			);
+		} else {
+			log_info!(self.logger, "Closed failed receiver session: {}", session.session_id);
+		}
+	}
+
+	/// Cleans up old payjoin sessions that are completed or failed.
+	/// Sessions older than `PAYJOIN_SESSION_CLEANUP_AGE_SECS` will be removed.
+	pub(crate) async fn cleanup_old_sessions(&self) -> Result<(), Error> {
+		let now = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.unwrap_or(std::time::Duration::from_secs(0))
+			.as_secs();
+
+		let sessions_to_remove: Vec<PaymentId> = self
+			.payjoin_session_store
+			.list_filter(|s| {
+				let is_terminal =
+					s.status == PayjoinStatus::Completed || s.status == PayjoinStatus::Failed;
+				let age = now.saturating_sub(s.latest_update_timestamp);
+				is_terminal && age > PAYJOIN_SESSION_CLEANUP_AGE_SECS
+			})
+			.iter()
+			.map(|s| s.session_id)
+			.collect();
+
+		if sessions_to_remove.is_empty() {
+			return Ok(());
+		}
+
+		log_info!(self.logger, "Cleaning up {} old payjoin sessions", sessions_to_remove.len());
+
+		for session_id in sessions_to_remove {
+			if let Err(e) = self.payjoin_session_store.remove(&session_id).await {
+				log_error!(
+					self.logger,
+					"Failed to remove old payjoin session {:?}: {:?}",
+					session_id,
+					e
+				);
+			}
+		}
+
+		Ok(())
+	}
+}

--- a/src/payment/payjoin/mod.rs
+++ b/src/payment/payjoin/mod.rs
@@ -1,0 +1,71 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+//! Holds a payment handler for sending and receiving Payjoin payments.
+
+pub(crate) mod manager;
+pub(crate) mod payjoin_session;
+pub(crate) mod persist;
+
+use std::sync::{Arc, RwLock};
+
+use crate::error::Error;
+use crate::types::PayjoinManager;
+
+#[cfg(not(feature = "uniffi"))]
+type FeeRate = bitcoin::FeeRate;
+#[cfg(feature = "uniffi")]
+type FeeRate = Arc<bitcoin::FeeRate>;
+
+macro_rules! maybe_map_fee_rate_opt {
+	($fee_rate_opt:expr) => {{
+		#[cfg(not(feature = "uniffi"))]
+		{
+			$fee_rate_opt
+		}
+		#[cfg(feature = "uniffi")]
+		{
+			$fee_rate_opt.map(|f| *f)
+		}
+	}};
+}
+
+/// A payment handler allowing to receive [Payjoin] payments.
+///
+/// Should be retrieved by calling [`Node::payjoin_payment`].
+///
+/// [Payjoin]: https://payjoin.org
+/// [`Node::payjoin_payment`]: crate::Node::payjoin_payment
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct PayjoinPayment {
+	manager: Arc<PayjoinManager>,
+	is_running: Arc<RwLock<bool>>,
+}
+
+impl PayjoinPayment {
+	pub(crate) fn new(manager: Arc<PayjoinManager>, is_running: Arc<RwLock<bool>>) -> Self {
+		Self { manager, is_running }
+	}
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+impl PayjoinPayment {
+	/// Returns a Payjoin URI that can be shared with a sender to receive a Payjoin payment.
+	///
+	/// The returned string is a BIP 21 URI with Payjoin parameters that the sender can use
+	/// to initiate the Payjoin flow.
+	pub async fn receive(
+		&self, amount_sats: u64, fee_rate: Option<FeeRate>,
+	) -> Result<String, Error> {
+		if !*self.is_running.read().expect("lock") {
+			return Err(Error::NotRunning);
+		}
+
+		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
+		self.manager.receive_payjoin(amount_sats, fee_rate_opt).await
+	}
+}

--- a/src/payment/payjoin/payjoin_session.rs
+++ b/src/payment/payjoin/payjoin_session.rs
@@ -1,0 +1,247 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bitcoin::{OutPoint, Transaction, Txid};
+use lightning::ln::channelmanager::PaymentId;
+use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+
+use crate::data_store::{StorableObject, StorableObjectUpdate};
+
+/// Represents a payjoin session with persisted events
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PayjoinSession {
+	/// Session identifier (uses PaymentId from PaymentDetails)
+	pub session_id: PaymentId,
+
+	/// Direction of the payjoin (Send or Receive)
+	pub direction: PayjoinDirection,
+
+	/// HPKE public key of receiver (only for sender sessions)
+	pub receiver_pubkey: Option<Vec<u8>>,
+
+	/// The amount transferred.
+	pub amount_msat: Option<u64>,
+
+	/// The fee rate in satoshis per kilo-weight-unit
+	pub fee_rate_kwu: u64,
+
+	/// The fees that were paid for this payment.
+	pub fee_paid_msat: Option<u64>,
+
+	/// The transaction identifier of this payment.
+	/// Will be None for Receive sessions until the session is completed and the transaction is known.
+	pub txid: Option<Txid>,
+
+	/// Serialized session events
+	pub events: Vec<SerializedSessionEvent>,
+
+	/// The fallback transaction (if any) that the sender created for a receive session.
+	/// This is broadcasted if the payjoin transacion fails.
+	pub fallback_tx: Option<Transaction>,
+
+	/// A list of inputs that were seen before in this session.
+	/// This is used to detect if the sender is reusing inputs across multiple attempts (only for receiver sessions).
+	pub inputs_seen: Vec<OutPoint>,
+
+	/// Current status of the session
+	pub status: PayjoinStatus,
+
+	/// Unix timestamp of session completion (if completed)
+	pub completed_at: Option<u64>,
+
+	/// The timestamp, in seconds since start of the UNIX epoch, when this entry was last updated.
+	pub latest_update_timestamp: u64,
+}
+
+impl PayjoinSession {
+	pub fn new(
+		session_id: PaymentId, direction: PayjoinDirection, receiver_pubkey: Option<Vec<u8>>,
+		amount_msat: Option<u64>, fee_rate_kwu: u64, fee_paid_msat: Option<u64>,
+		txid: Option<Txid>, fallback_tx: Option<Transaction>,
+	) -> Self {
+		let latest_update_timestamp = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.unwrap_or(Duration::from_secs(0))
+			.as_secs();
+		Self {
+			session_id,
+			direction,
+			receiver_pubkey,
+			amount_msat,
+			fee_rate_kwu,
+			fee_paid_msat,
+			txid,
+			events: Vec::new(),
+			fallback_tx,
+			inputs_seen: Vec::new(),
+			status: PayjoinStatus::Active,
+			completed_at: None,
+			latest_update_timestamp,
+		}
+	}
+}
+
+impl_writeable_tlv_based!(PayjoinSession, {
+	(0, session_id, required),
+	(2, direction, required),
+	(4, receiver_pubkey, option),
+	(6, amount_msat, option),
+	(8, fee_rate_kwu, required),
+	(10, fee_paid_msat, option),
+	(12, txid, option),
+	(14, events, required_vec),
+	(16, fallback_tx, option),
+	(18, inputs_seen, optional_vec),
+	(20, status, required),
+	(22, completed_at, option),
+	(24, latest_update_timestamp, (default_value, 0u64)),
+});
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PayjoinDirection {
+	/// The session is for sending a payment
+	Send,
+	/// The session is for receiving a payment
+	Receive,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PayjoinStatus {
+	/// The session is active
+	Active,
+	/// The session has completed successfully
+	Completed,
+	/// The session has failed
+	Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SerializedSessionEvent {
+	/// Serialized event bytes.
+	pub event_bytes: Vec<u8>,
+	/// Unix timestamp of when the event occurred
+	pub created_at: u64,
+}
+
+impl_writeable_tlv_based!(SerializedSessionEvent, {
+	(0, event_bytes, required),
+	(2, created_at, required),
+});
+
+impl_writeable_tlv_based_enum!(PayjoinDirection,
+	(0, Send) => {},
+	(2, Receive) => {}
+);
+
+impl_writeable_tlv_based_enum!(PayjoinStatus,
+	(0, Active) => {},
+	(2, Completed) => {},
+	(4, Failed) => {}
+);
+
+/// Represents a payjoin session with persisted events
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PayjoinSessionUpdate {
+	pub session_id: PaymentId,
+	pub receiver_pubkey: Option<Option<Vec<u8>>>,
+	pub fee_paid_msat: Option<Option<u64>>,
+	pub txid: Option<Option<Txid>>,
+	pub events: Option<Vec<SerializedSessionEvent>>,
+	pub fallback_tx: Option<Option<Transaction>>,
+	pub inputs_seen: Option<Vec<OutPoint>>,
+	pub status: Option<PayjoinStatus>,
+	pub completed_at: Option<Option<u64>>,
+}
+
+impl From<&PayjoinSession> for PayjoinSessionUpdate {
+	fn from(value: &PayjoinSession) -> Self {
+		Self {
+			session_id: value.session_id,
+			receiver_pubkey: Some(value.receiver_pubkey.clone()),
+			fee_paid_msat: Some(value.fee_paid_msat),
+			txid: Some(value.txid),
+			events: Some(value.events.clone()),
+			fallback_tx: Some(value.fallback_tx.clone()),
+			inputs_seen: Some(value.inputs_seen.clone()),
+			status: Some(value.status),
+			completed_at: Some(value.completed_at),
+		}
+	}
+}
+
+impl StorableObject for PayjoinSession {
+	type Id = PaymentId;
+	type Update = PayjoinSessionUpdate;
+
+	fn id(&self) -> Self::Id {
+		self.session_id
+	}
+
+	fn update(&mut self, update: Self::Update) -> bool {
+		debug_assert_eq!(
+			self.session_id, update.session_id,
+			"We should only ever override data for the same id"
+		);
+
+		let mut updated = false;
+
+		macro_rules! update_if_necessary {
+			($val:expr, $update:expr) => {
+				if $val != $update {
+					$val = $update;
+					updated = true;
+				}
+			};
+		}
+
+		if let Some(receiver_pubkey_opt) = &update.receiver_pubkey {
+			update_if_necessary!(self.receiver_pubkey, receiver_pubkey_opt.clone());
+		}
+		if let Some(fee_paid_msat_opt) = update.fee_paid_msat {
+			update_if_necessary!(self.fee_paid_msat, fee_paid_msat_opt);
+		}
+		if let Some(txid_opt) = update.txid {
+			update_if_necessary!(self.txid, txid_opt);
+		}
+		if let Some(events_opt) = &update.events {
+			update_if_necessary!(self.events, events_opt.clone());
+		}
+		if let Some(fallback_tx_opt) = update.fallback_tx {
+			update_if_necessary!(self.fallback_tx, fallback_tx_opt);
+		}
+		if let Some(txids_input_seen_before_opt) = update.inputs_seen {
+			update_if_necessary!(self.inputs_seen, txids_input_seen_before_opt);
+		}
+		if let Some(status_opt) = update.status {
+			update_if_necessary!(self.status, status_opt);
+		}
+		if let Some(completed_at_opt) = update.completed_at {
+			update_if_necessary!(self.completed_at, completed_at_opt);
+		}
+
+		if updated {
+			self.latest_update_timestamp = SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.unwrap_or(Duration::from_secs(0))
+				.as_secs();
+		}
+
+		updated
+	}
+
+	fn to_update(&self) -> Self::Update {
+		self.into()
+	}
+}
+
+impl StorableObjectUpdate<PayjoinSession> for PayjoinSessionUpdate {
+	fn id(&self) -> <PayjoinSession as StorableObject>::Id {
+		self.session_id
+	}
+}

--- a/src/payment/payjoin/persist.rs
+++ b/src/payment/payjoin/persist.rs
@@ -1,0 +1,155 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+use crate::payment::payjoin::payjoin_session::SerializedSessionEvent;
+use crate::Error;
+use std::{
+	sync::Arc,
+	time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use bitcoin::{OutPoint, Transaction, Txid};
+use lightning::ln::channelmanager::PaymentId;
+
+use crate::payment::payjoin::payjoin_session::{PayjoinDirection, PayjoinSession};
+use crate::types::PayjoinSessionStore;
+
+use payjoin::persist::AsyncSessionPersister;
+use payjoin::receive::v2::SessionEvent as ReceiverSessionEvent;
+
+pub(crate) struct KVStorePayjoinReceiverPersister {
+	session_id: PaymentId,
+	payjoin_session_store: Arc<PayjoinSessionStore>,
+}
+
+impl KVStorePayjoinReceiverPersister {
+	pub async fn new(
+		session_id: PaymentId, amount_msat: Option<u64>,
+		payjoin_session_store: Arc<PayjoinSessionStore>, fee_rate_kwu: u64,
+		fee_paid_msat: Option<u64>, txid: Option<Txid>, fallback_tx: Option<Transaction>,
+	) -> Result<Self, Error> {
+		let session = PayjoinSession::new(
+			session_id,
+			PayjoinDirection::Receive,
+			None,
+			amount_msat,
+			fee_rate_kwu,
+			fee_paid_msat,
+			txid,
+			fallback_tx,
+		);
+
+		payjoin_session_store.insert(session).await?;
+
+		Ok(Self { session_id, payjoin_session_store })
+	}
+
+	pub(super) fn session_id(&self) -> PaymentId {
+		self.session_id
+	}
+
+	pub(super) fn get_session(&self) -> Option<PayjoinSession> {
+		self.payjoin_session_store.get(&self.session_id)
+	}
+
+	/// Reconstruct persister from existing session
+	pub fn from_session(
+		session_id: PaymentId, payjoin_session_store: Arc<PayjoinSessionStore>,
+	) -> Result<Self, Error> {
+		if payjoin_session_store.get(&session_id).is_none() {
+			return Err(Error::InvalidPaymentId);
+		}
+
+		Ok(Self { session_id, payjoin_session_store })
+	}
+
+	/// Records the given inputs as seen in this session.
+	pub async fn insert_inputs_seen(&self, inputs: Vec<OutPoint>) -> Result<(), Error> {
+		if inputs.is_empty() {
+			return Ok(());
+		}
+		let mut session = self.get_session().ok_or(Error::InvalidPaymentId)?;
+		for input in inputs {
+			if !session.inputs_seen.contains(&input) {
+				session.inputs_seen.push(input);
+			}
+		}
+		self.payjoin_session_store.insert_or_update(session).await?;
+		Ok(())
+	}
+}
+
+impl AsyncSessionPersister for KVStorePayjoinReceiverPersister {
+	type SessionEvent = ReceiverSessionEvent;
+	type InternalStorageError = Error;
+
+	fn save_event(
+		&self, event: Self::SessionEvent,
+	) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+		async move {
+			let mut session =
+				self.payjoin_session_store.get(&self.session_id).ok_or(Error::InvalidPaymentId)?;
+
+			let event_bytes = serde_json::to_vec(&event).map_err(|_| Error::PersistenceFailed)?;
+
+			session.events.push(SerializedSessionEvent {
+				event_bytes,
+				created_at: SystemTime::now()
+					.duration_since(UNIX_EPOCH)
+					.unwrap_or(Duration::from_secs(0))
+					.as_secs(),
+			});
+
+			self.payjoin_session_store.insert_or_update(session).await?;
+
+			Ok(())
+		}
+	}
+
+	fn load(
+		&self,
+	) -> impl std::future::Future<
+		Output = Result<
+			Box<dyn Iterator<Item = Self::SessionEvent> + Send>,
+			Self::InternalStorageError,
+		>,
+	> + Send {
+		async move {
+			let session =
+				self.payjoin_session_store.get(&self.session_id).ok_or(Error::InvalidPaymentId)?;
+
+			let events: Vec<ReceiverSessionEvent> = session
+				.events
+				.iter()
+				.map(|e| serde_json::from_slice(&e.event_bytes))
+				.collect::<Result<Vec<_>, _>>()
+				.map_err(|_| Error::PersistenceFailed)?;
+
+			Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = Self::SessionEvent> + Send>)
+		}
+	}
+
+	fn close(
+		&self,
+	) -> impl std::future::Future<Output = Result<(), Self::InternalStorageError>> + Send {
+		async move {
+			let mut session =
+				self.payjoin_session_store.get(&self.session_id).ok_or(Error::InvalidPaymentId)?;
+
+			session.completed_at = Some(
+				SystemTime::now()
+					.duration_since(UNIX_EPOCH)
+					.unwrap_or(Duration::from_secs(0))
+					.as_secs(),
+			);
+
+			self.payjoin_session_store.insert_or_update(session).await?;
+
+			Ok(())
+		}
+	}
+}

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -412,6 +412,9 @@ pub enum TransactionType {
 		/// The channels participating in the negotiation.
 		channels: Vec<Channel>,
 	},
+	/// A transaction settling a payjoin, i.e., one to which both we and our counterparty
+	/// contributed inputs.
+	Payjoin,
 }
 
 impl_writeable_tlv_based_enum!(TransactionType,
@@ -439,7 +442,8 @@ impl_writeable_tlv_based_enum!(TransactionType,
 	},
 	(12, InteractiveFunding) => {
 		(0, channels, optional_vec),
-	}
+	},
+	(13, Payjoin) => {}
 );
 
 impl From<LdkTransactionType> for TransactionType {
@@ -629,7 +633,7 @@ impl_writeable_tlv_based_enum!(PaymentKind,
 		(2, preimage, option),
 		(3, quantity, option),
 		(4, secret, option),
-	}
+	},
 );
 
 /// Represents the confirmation status of a transaction.
@@ -726,7 +730,7 @@ impl From<&PaymentDetails> for PaymentDetailsUpdate {
 
 		let (confirmation_status, txid, tx_type) = match &value.kind {
 			PaymentKind::Onchain { status, txid, tx_type } => {
-				(Some(*status), Some(*txid), Some(tx_type.clone()))
+				({ Some(*status) }, Some(*txid), Some(tx_type.clone()))
 			},
 			_ => (None, None, None),
 		};

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,6 +48,7 @@ use crate::fee_estimator::OnchainFeeEstimator;
 use crate::ffi::maybe_wrap;
 use crate::logger::Logger;
 use crate::message_handler::NodeCustomMessageHandler;
+use crate::payment::payjoin::payjoin_session::PayjoinSession;
 use crate::payment::{PaymentDetails, PendingPaymentDetails};
 use crate::runtime::RuntimeSpawner;
 
@@ -372,6 +373,8 @@ pub(crate) type BumpTransactionEventHandler =
 	>;
 
 pub(crate) type PaymentStore = DataStore<PaymentDetails, Arc<Logger>>;
+
+pub(crate) type PayjoinSessionStore = DataStore<PayjoinSession, Arc<Logger>>;
 
 /// A local, potentially user-provided, identifier of a channel.
 ///
@@ -748,3 +751,5 @@ impl From<&(u64, Vec<u8>)> for CustomTlvRecord {
 }
 
 pub(crate) type PendingPaymentStore = DataStore<PendingPaymentDetails, Arc<Logger>>;
+
+pub(crate) type PayjoinManager = crate::PayjoinManager;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1796,6 +1796,32 @@ impl Wallet {
 
 		Ok(new_txid)
 	}
+
+	/// Check if a script belongs to this wallet
+	pub fn is_mine(&self, script: ScriptBuf) -> Result<bool, Error> {
+		let locked_wallet = self.inner.lock().expect("lock");
+		Ok(locked_wallet.is_mine(script))
+	}
+
+	#[allow(deprecated)]
+	pub fn process_psbt(&self, mut psbt: Psbt) -> Result<Psbt, Error> {
+		let locked_wallet = self.inner.lock().expect("lock");
+
+		let mut sign_options = SignOptions::default();
+		sign_options.trust_witness_utxo = true;
+
+		locked_wallet.sign(&mut psbt, sign_options).map_err(|e| {
+			log_error!(self.logger, "Failed to sign PSBT: {}", e);
+			Error::WalletOperationFailed
+		})?;
+
+		// Return the signed PSBT (not extracted transaction)
+		Ok(psbt)
+	}
+
+	pub fn list_unspent_confirmed_utxos(&self) -> Result<Vec<Utxo>, Error> {
+		self.list_confirmed_utxos_inner().map_err(|()| Error::WalletOperationFailed)
+	}
 }
 
 struct LocalStakeAggregate {


### PR DESCRIPTION
This PR adds support for receiving payjoin payments in LDK Node. This is currently a work in progress and implements the receiver side of the payjoin protocol.

- Add session store for persisting payjoin receiver events across restarts
- Implement `KVStorePayjoinReceiverPersister` to handle session persistence
- Add `Payjoin` as a `PaymentKind` to the payment store
- Add event polling mechanism for active payjoin sessions
- Wire up payjoin payment request and receive flows

Note on persistence: The payjoin library currently only supports synchronous persistence, but they're working on adding async support(https://github.com/payjoin/rust-payjoin/pull/1235). This PR sets up the persistence structure (`KVStorePayjoinReceiverPersister`), which will be updated to use async operations once the upstream PR is merged.


This PR partially fixes #177 and fixes #1019 