### PR TITLE
Fix NodeEntropy type mismatch in UniFFI builds

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1288,6 +1288,18 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	println!("\nB stopped");
 }
 
+// Helper to unify entropy creation
+pub(crate) fn create_test_entropy(seed: [u8; 64]) -> NodeEntropy {
+	#[cfg(feature = "uniffi")]
+	{
+		NodeEntropy::from_seed_bytes(seed.to_vec()).unwrap()
+	}
+	#[cfg(not(feature = "uniffi"))]
+	{
+		NodeEntropy::from_seed_bytes(seed)
+	}
+}
+
 // A `KVStore` impl for testing purposes that wraps all our `KVStore`s and asserts their synchronicity.
 #[derive(Clone)]
 pub(crate) struct TestSyncStore {

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -17,8 +17,8 @@ use bitcoin::hashes::Hash;
 use bitcoin::{Address, Amount, ScriptBuf};
 use common::logging::{init_log_logger, validate_log_entry, MultiNodeLogger, TestLogWriter};
 use common::{
-	bump_fee_and_broadcast, distribute_funds_unconfirmed, do_channel_full_cycle,
-	expect_channel_pending_event, expect_channel_ready_event, expect_event,
+	bump_fee_and_broadcast, create_test_entropy, distribute_funds_unconfirmed,
+	do_channel_full_cycle, expect_channel_pending_event, expect_channel_ready_event, expect_event,
 	expect_payment_claimable_event, expect_payment_received_event, expect_payment_successful_event,
 	expect_splice_pending_event, generate_blocks_and_wait, open_channel, open_channel_push_amt,
 	premine_and_distribute_funds, premine_blocks, prepare_rbf, random_config,
@@ -27,7 +27,6 @@ use common::{
 	TestSyncStore,
 };
 use ldk_node::config::{AsyncPaymentsRole, EsploraSyncConfig};
-use ldk_node::entropy::NodeEntropy;
 use ldk_node::liquidity::LSPS2ServiceConfig;
 use ldk_node::payment::{
 	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
@@ -2445,10 +2444,8 @@ async fn persistence_backwards_compatibility() {
 
 	let storage_path = common::random_storage_path().to_str().unwrap().to_owned();
 	let seed_bytes = [42u8; 64];
-	#[cfg(feature = "uniffi")]
-	let node_entropy = Arc::new(NodeEntropy::from_seed_bytes(seed_bytes.to_vec()).unwrap());
-	#[cfg(not(feature = "uniffi"))]
-	let node_entropy = NodeEntropy::from_seed_bytes(seed_bytes);
+
+	let node_entropy = create_test_entropy(seed_bytes);
 
 	// Setup a v0.6.2 `Node`
 	let (old_balance, old_node_id) = {
@@ -2485,7 +2482,7 @@ async fn persistence_backwards_compatibility() {
 	builder_new.set_storage_dir_path(storage_path);
 	builder_new.set_chain_source_esplora(esplora_url, None);
 
-	let node_new = builder_new.build(node_entropy).unwrap();
+	let node_new = builder_new.build(node_entropy.into()).unwrap();
 
 	node_new.start().unwrap();
 	node_new.sync_wallets().unwrap();


### PR DESCRIPTION
### Context 
In https://github.com/lightningdevkit/ldk-node/commit/06a8108aff12196210728b0078453641a9aa85aa, `persistence_backwards_compatibility` was introduced. Currently, the `from_seed_bytes` constructor and the subsequent build method have diverging signatures depending on whether the `uniffi` feature is enabled.

### Changes 
- A helper function is added to unify entropy creation.
-  `into()` is used to conditionally wrap `node_entropy` with an Arc or not.

### Why this is necessary 
UniFFI requires Arc<T> wrappers for cross-language memory management. Without this change, the integration tests fail to compile when the `uniffi` feature is active because the builder receives a raw struct instead of the expected shared pointer.