### PR TITLE
Drop entropy creation helper, cleanup remaining warnings

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1288,18 +1288,6 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	println!("\nB stopped");
 }
 
-// Helper to unify entropy creation
-pub(crate) fn create_test_entropy(seed: [u8; 64]) -> NodeEntropy {
-	#[cfg(feature = "uniffi")]
-	{
-		NodeEntropy::from_seed_bytes(seed.to_vec()).unwrap()
-	}
-	#[cfg(not(feature = "uniffi"))]
-	{
-		NodeEntropy::from_seed_bytes(seed)
-	}
-}
-
 // A `KVStore` impl for testing purposes that wraps all our `KVStore`s and asserts their synchronicity.
 #[derive(Clone)]
 pub(crate) struct TestSyncStore {

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -17,8 +17,8 @@ use bitcoin::hashes::Hash;
 use bitcoin::{Address, Amount, ScriptBuf};
 use common::logging::{init_log_logger, validate_log_entry, MultiNodeLogger, TestLogWriter};
 use common::{
-	bump_fee_and_broadcast, create_test_entropy, distribute_funds_unconfirmed,
-	do_channel_full_cycle, expect_channel_pending_event, expect_channel_ready_event, expect_event,
+	bump_fee_and_broadcast, distribute_funds_unconfirmed, do_channel_full_cycle,
+	expect_channel_pending_event, expect_channel_ready_event, expect_event,
 	expect_payment_claimable_event, expect_payment_received_event, expect_payment_successful_event,
 	expect_splice_pending_event, generate_blocks_and_wait, open_channel, open_channel_push_amt,
 	premine_and_distribute_funds, premine_blocks, prepare_rbf, random_config,
@@ -27,6 +27,7 @@ use common::{
 	TestSyncStore,
 };
 use ldk_node::config::{AsyncPaymentsRole, EsploraSyncConfig};
+use ldk_node::entropy::NodeEntropy;
 use ldk_node::liquidity::LSPS2ServiceConfig;
 use ldk_node::payment::{
 	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
@@ -2445,8 +2446,6 @@ async fn persistence_backwards_compatibility() {
 	let storage_path = common::random_storage_path().to_str().unwrap().to_owned();
 	let seed_bytes = [42u8; 64];
 
-	let node_entropy = create_test_entropy(seed_bytes);
-
 	// Setup a v0.6.2 `Node`
 	let (old_balance, old_node_id) = {
 		let mut builder_old = ldk_node_062::Builder::new();
@@ -2477,11 +2476,18 @@ async fn persistence_backwards_compatibility() {
 	};
 
 	// Now ensure we can still reinit from the same backend.
+	#[cfg(feature = "uniffi")]
+	let builder_new = Builder::new();
+	#[cfg(not(feature = "uniffi"))]
 	let mut builder_new = Builder::new();
 	builder_new.set_network(bitcoin::Network::Regtest);
 	builder_new.set_storage_dir_path(storage_path);
 	builder_new.set_chain_source_esplora(esplora_url, None);
 
+	#[cfg(feature = "uniffi")]
+	let node_entropy = NodeEntropy::from_seed_bytes(seed_bytes.to_vec()).unwrap();
+	#[cfg(not(feature = "uniffi"))]
+	let node_entropy = NodeEntropy::from_seed_bytes(seed_bytes);
 	let node_new = builder_new.build(node_entropy.into()).unwrap();
 
 	node_new.start().unwrap();


### PR DESCRIPTION
Just a tiny follow-up to #750.

Previously we introduced a `create_test_entropy` helper method in `common.rs` that was only used in one specific test. We here opt to drop this again and also clean up the remaining warnings when run under `--features uniffi`.