### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1352,11 +1352,11 @@ fn build_with_store_internal(
 	let mut user_config = default_user_config(&config);
 
 	if liquidity_source_config.and_then(|lsc| lsc.lsps2_service.as_ref()).is_some() {
-		// If we act as an LSPS2 service, we need to to be able to intercept HTLCs and forward the
+		// If we act as an LSPS2 service, we need to be able to intercept HTLCs and forward the
 		// information to the service handler.
 		user_config.accept_intercept_htlcs = true;
 
-		// If we act as an LSPS2 service, we allow forwarding to unnannounced channels.
+		// If we act as an LSPS2 service, we allow forwarding to unannounced channels.
 		user_config.accept_forwards_to_priv_channels = true;
 
 		// If we act as an LSPS2 service, set the HTLC-value-in-flight to 100% of the channel value

--- a/src/event.rs
+++ b/src/event.rs
@@ -165,7 +165,7 @@ pub enum Event {
 	///
 	/// This needs to be manually claimed by supplying the correct preimage to [`claim_for_hash`].
 	///
-	/// If the the provided parameters don't match the expectations or the preimage can't be
+	/// If the provided parameters don't match the expectations or the preimage can't be
 	/// retrieved in time, should be failed-back via [`fail_for_hash`].
 	///
 	/// Note claiming will necessarily fail after the `claim_deadline` has been reached.

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -1169,9 +1169,9 @@ pub struct LSPS1OnchainPaymentInfo {
 	pub expires_at: LSPSDateTime,
 	/// The total fee the LSP will charge to open this channel in satoshi.
 	pub fee_total_sat: u64,
-	/// The amount the client needs to pay to have the requested channel openend.
+	/// The amount the client needs to pay to have the requested channel opened.
 	pub order_total_sat: u64,
-	/// An on-chain address the client can send [`Self::order_total_sat`] to to have the channel
+	/// An on-chain address the client can send [`Self::order_total_sat`] to have the channel
 	/// opened.
 	pub address: bitcoin::Address,
 	/// The minimum number of block confirmations that are required for the on-chain payment to be

--- a/src/io/sqlite_store/migrations.rs
+++ b/src/io/sqlite_store/migrations.rs
@@ -124,7 +124,7 @@ mod tests {
 
 			connection.execute(&sql, []).unwrap();
 
-			// We write some data to to the table
+			// We write some data to the table
 			let sql = format!(
 				"INSERT OR REPLACE INTO {} (namespace, key, value) VALUES (:namespace, :key, :value);",
 				kv_table_name


### PR DESCRIPTION
I asked HAL to find and fix all typos in the codebase.