### PR TITLE
Move most logs in the chain module to the debug level

### DIFF
--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -38,7 +38,7 @@ use crate::fee_estimator::{
 	ConfirmationTarget, OnchainFeeEstimator,
 };
 use crate::io::utils::write_node_metrics;
-use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkLogger, Logger};
+use crate::logger::{log_bytes, log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
 use crate::types::{ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
 
@@ -364,7 +364,7 @@ impl BitcoindChainSource {
 		};
 
 		if let Some(mut sync_receiver) = receiver_res {
-			log_info!(self.logger, "Sync in progress, skipping.");
+			log_debug!(self.logger, "Sync in progress, skipping.");
 			return sync_receiver.recv().await.map_err(|e| {
 				debug_assert!(false, "Failed to receive wallet polling result: {:?}", e);
 				log_error!(self.logger, "Failed to receive wallet polling result: {:?}", e);
@@ -558,7 +558,7 @@ impl BitcoindChainSource {
 
 		if self.fee_estimator.set_fee_rate_cache(new_fee_rate_cache) {
 			// We only log if the values changed, as it might be very spammy otherwise.
-			log_info!(
+			log_debug!(
 				self.logger,
 				"Fee rate cache update finished in {}ms.",
 				now.elapsed().as_millis()

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -34,7 +34,7 @@ use crate::fee_estimator::{
 	ConfirmationTarget, OnchainFeeEstimator,
 };
 use crate::io::utils::write_node_metrics;
-use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkLogger, Logger};
+use crate::logger::{log_bytes, log_debug, log_error, log_trace, LdkLogger, Logger};
 use crate::runtime::Runtime;
 use crate::types::{ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::NodeMetrics;
@@ -100,7 +100,7 @@ impl ElectrumChainSource {
 			status_lock.register_or_subscribe_pending_sync()
 		};
 		if let Some(mut sync_receiver) = receiver_res {
-			log_info!(self.logger, "Sync in progress, skipping.");
+			log_debug!(self.logger, "Sync in progress, skipping.");
 			return sync_receiver.recv().await.map_err(|e| {
 				debug_assert!(false, "Failed to receive wallet sync result: {:?}", e);
 				log_error!(self.logger, "Failed to receive wallet sync result: {:?}", e);
@@ -135,7 +135,7 @@ impl ElectrumChainSource {
 			|update_res: Result<BdkUpdate, Error>, now: Instant| match update_res {
 				Ok(update) => match onchain_wallet.apply_update(update) {
 					Ok(()) => {
-						log_info!(
+						log_debug!(
 							self.logger,
 							"{} of on-chain wallet finished in {}ms.",
 							if incremental_sync { "Incremental sync" } else { "Sync" },
@@ -191,7 +191,7 @@ impl ElectrumChainSource {
 			status_lock.register_or_subscribe_pending_sync()
 		};
 		if let Some(mut sync_receiver) = receiver_res {
-			log_info!(self.logger, "Sync in progress, skipping.");
+			log_debug!(self.logger, "Sync in progress, skipping.");
 			return sync_receiver.recv().await.map_err(|e| {
 				debug_assert!(false, "Failed to receive wallet sync result: {:?}", e);
 				log_error!(self.logger, "Failed to receive wallet sync result: {:?}", e);
@@ -261,7 +261,7 @@ impl ElectrumChainSource {
 		let new_fee_rate_cache = electrum_client.get_fee_rate_cache_update().await?;
 		self.fee_estimator.set_fee_rate_cache(new_fee_rate_cache);
 
-		log_info!(
+		log_debug!(
 			self.logger,
 			"Fee rate cache update finished in {}ms.",
 			now.elapsed().as_millis()
@@ -437,7 +437,7 @@ impl ElectrumRuntimeClient {
 				Error::TxSyncFailed
 			})?;
 
-		log_info!(
+		log_debug!(
 			self.logger,
 			"Sync of Lightning wallet finished in {}ms.",
 			now.elapsed().as_millis()

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -27,7 +27,7 @@ use crate::fee_estimator::{
 	OnchainFeeEstimator,
 };
 use crate::io::utils::write_node_metrics;
-use crate::logger::{log_bytes, log_error, log_info, log_trace, LdkLogger, Logger};
+use crate::logger::{log_bytes, log_debug, log_error, log_trace, LdkLogger, Logger};
 use crate::types::{ChainMonitor, ChannelManager, DynStore, Sweeper, Wallet};
 use crate::{Error, NodeMetrics};
 
@@ -85,7 +85,7 @@ impl EsploraChainSource {
 			status_lock.register_or_subscribe_pending_sync()
 		};
 		if let Some(mut sync_receiver) = receiver_res {
-			log_info!(self.logger, "Sync in progress, skipping.");
+			log_debug!(self.logger, "Sync in progress, skipping.");
 			return sync_receiver.recv().await.map_err(|e| {
 				debug_assert!(false, "Failed to receive wallet sync result: {:?}", e);
 				log_error!(self.logger, "Failed to receive wallet sync result: {:?}", e);
@@ -113,7 +113,7 @@ impl EsploraChainSource {
 					Ok(res) => match res {
 						Ok(update) => match onchain_wallet.apply_update(update) {
 							Ok(()) => {
-								log_info!(
+								log_debug!(
 									self.logger,
 									"{} of on-chain wallet finished in {}ms.",
 									if incremental_sync { "Incremental sync" } else { "Sync" },
@@ -210,7 +210,7 @@ impl EsploraChainSource {
 			status_lock.register_or_subscribe_pending_sync()
 		};
 		if let Some(mut sync_receiver) = receiver_res {
-			log_info!(self.logger, "Sync in progress, skipping.");
+			log_debug!(self.logger, "Sync in progress, skipping.");
 			return sync_receiver.recv().await.map_err(|e| {
 				debug_assert!(false, "Failed to receive wallet sync result: {:?}", e);
 				log_error!(self.logger, "Failed to receive wallet sync result: {:?}", e);
@@ -247,7 +247,7 @@ impl EsploraChainSource {
 		match timeout_fut.await {
 			Ok(res) => match res {
 				Ok(()) => {
-					log_info!(
+					log_debug!(
 						self.logger,
 						"Sync of Lightning wallet finished in {}ms.",
 						now.elapsed().as_millis()
@@ -331,7 +331,7 @@ impl EsploraChainSource {
 
 		self.fee_estimator.set_fee_rate_cache(new_fee_rate_cache);
 
-		log_info!(
+		log_debug!(
 			self.logger,
 			"Fee rate cache update finished in {}ms.",
 			now.elapsed().as_millis()


### PR DESCRIPTION
When the node is idle, the info level was quite spammy. It is now quiet.