### PR TITLE
Update rust-lightning to fix InvoiceBuilder breakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,17 +39,17 @@ default = []
 #lightning-liquidity = { version = "0.2.0", features = ["std"] }
 #lightning-macros = { version = "0.2.0" }
 
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["std"] }
-lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099" }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["std"] }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["tokio"] }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["rest-client", "rpc-client", "tokio"] }
-lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["std"] }
-lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099" }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["rest-client", "rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a" }
 
 bdk_chain = { version = "0.23.0", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["async-https-rustls", "tokio"]}
@@ -78,13 +78,13 @@ log = { version = "0.4.22", default-features = false, features = ["std"]}
 vss-client = { package = "vss-client-ng", version = "0.4" }
 prost = { version = "0.11.6", default-features = false}
 #bitcoin-payment-instructions = { version = "0.6" }
-bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", rev = "7ee3958834aba575e04b91a862f790d798a7d578" }
+bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", rev = "e4d519b95b26916dc6efa22f8f1cc11a818ce7a7" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "35ab03fbe0fe0927a9242754a0797553f6f7f099", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "817ab5e583002df5e32b3a71e7ab093005a2a39a", features = ["std", "_test_utils"] }
 proptest = "1.0.0"
 regex = "1.5.6"
 criterion = { version = "0.7.0", features = ["async_tokio"] }

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -1314,7 +1314,7 @@ where
 		let currency = self.config.network.into();
 		let mut invoice_builder = InvoiceBuilder::new(currency)
 			.invoice_description(description.clone())
-			.payment_hash(payment_hash)
+			.payment_hash(lightning_invoice::PaymentHash(payment_hash.to_byte_array()))
 			.payment_secret(payment_secret)
 			.current_timestamp()
 			.min_final_cltv_expiry_delta(min_final_cltv_expiry_delta.into())


### PR DESCRIPTION
Updates rust-lightning dependencies to `817ab5e583002df5e32b3a71e7ab093005a2a39a`.

This fixes the build breakage resulting from the `InvoiceBuilder` and `PaymentHash` refactor in upstream [PR #4363](https://github.com/lightningdevkit/rust-lightning/pull/4363).

Specific changes:
*   Updates `Cargo.toml` revision.
*   Wraps `Sha256` hash in `PaymentHash` in `src/liquidity.rs` to match the new `InvoiceBuilder` API.