### PR TITLE
docs: improve scannability of chain data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ fn main() {
 LDK Node currently comes with a decidedly opinionated set of design choices:
 
 - On-chain data is handled by the integrated [BDK][bdk] wallet.
-- Chain data may currently be sourced from the Bitcoin Core RPC interface, or from an [Electrum][electrum] or [Esplora][esplora] server.
+- Chain data may currently be sourced from:
+  * Bitcoin Core RPC interface
+  * Electrum server
+  * Esplora server
 - Wallet and channel state may be persisted to an [SQLite][sqlite] database, to file system, or to a custom back-end to be implemented by the user.
 - Gossip data may be sourced via Lightning's peer-to-peer network or the [Rapid Gossip Sync](https://docs.rs/lightning-rapid-gossip-sync/*/lightning_rapid_gossip_sync/) protocol.
 - Entropy for the Lightning and on-chain wallets may be sourced from raw bytes or a [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonic. In addition, LDK Node offers the means to generate and persist the entropy bytes to disk.


### PR DESCRIPTION
This PR improves the readability of the 'Modularity' section in the README. I have  converted the chain data source list into a nested list to make it easier for new developers to see the supported backends at a glance hope i added little value to  our world 