### PR TITLE
Take `StorableObjectUpdate` by value in `StorableObject::update`

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -657,7 +657,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(&update) {
+						match self.payment_store.update(update) {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -681,7 +681,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(&update) {
+						match self.payment_store.update(update) {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -722,7 +722,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(&update) {
+						match self.payment_store.update(update) {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -739,7 +739,7 @@ where
 									counterparty_skimmed_fee_msat: Some(Some(counterparty_skimmed_fee_msat)),
 									..PaymentDetailsUpdate::new(payment_id)
 								};
-								match self.payment_store.update(&update) {
+								match self.payment_store.update(update) {
 									Ok(_) => (),
 									Err(e) => {
 										log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -910,7 +910,7 @@ where
 						status: Some(PaymentStatus::Failed),
 						..PaymentDetailsUpdate::new(payment_id)
 					};
-					match self.payment_store.update(&update) {
+					match self.payment_store.update(update) {
 						Ok(_) => return Ok(()),
 						Err(e) => {
 							log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -978,7 +978,7 @@ where
 					},
 				};
 
-				match self.payment_store.update(&update) {
+				match self.payment_store.update(update) {
 					Ok(DataStoreUpdateResult::Updated) | Ok(DataStoreUpdateResult::Unchanged) => (
 						// No need to do anything if the idempotent update was applied, which might
 						// be the result of a replayed event.
@@ -1039,7 +1039,7 @@ where
 					..PaymentDetailsUpdate::new(payment_id)
 				};
 
-				match self.payment_store.update(&update) {
+				match self.payment_store.update(update) {
 					Ok(_) => {},
 					Err(e) => {
 						log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -1090,7 +1090,7 @@ where
 					status: Some(PaymentStatus::Failed),
 					..PaymentDetailsUpdate::new(payment_id)
 				};
-				match self.payment_store.update(&update) {
+				match self.payment_store.update(update) {
 					Ok(_) => {},
 					Err(e) => {
 						log_error!(self.logger, "Failed to access payment store: {}", e);

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -383,7 +383,7 @@ impl Bolt11Payment {
 			..PaymentDetailsUpdate::new(payment_id)
 		};
 
-		match self.payment_store.update(&update) {
+		match self.payment_store.update(update) {
 			Ok(DataStoreUpdateResult::Updated) | Ok(DataStoreUpdateResult::Unchanged) => (),
 			Ok(DataStoreUpdateResult::NotFound) => {
 				log_error!(

--- a/src/payment/pending_payment_store.rs
+++ b/src/payment/pending_payment_store.rs
@@ -53,17 +53,17 @@ impl StorableObject for PendingPaymentDetails {
 		self.details.id
 	}
 
-	fn update(&mut self, update: &Self::Update) -> bool {
+	fn update(&mut self, update: Self::Update) -> bool {
 		let mut updated = false;
 
 		// Update the underlying payment details if present
-		if let Some(payment_update) = &update.payment_update {
+		if let Some(payment_update) = update.payment_update {
 			updated |= self.details.update(payment_update);
 		}
 
-		if let Some(new_conflicting_txids) = &update.conflicting_txids {
-			if &self.conflicting_txids != new_conflicting_txids {
-				self.conflicting_txids = new_conflicting_txids.clone();
+		if let Some(new_conflicting_txids) = update.conflicting_txids {
+			if self.conflicting_txids != new_conflicting_txids {
+				self.conflicting_txids = new_conflicting_txids;
 				updated = true;
 			}
 		}

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -170,7 +170,7 @@ impl StorableObject for PaymentDetails {
 		self.id
 	}
 
-	fn update(&mut self, update: &Self::Update) -> bool {
+	fn update(&mut self, update: Self::Update) -> bool {
 		debug_assert_eq!(
 			self.id, update.id,
 			"We should only ever override payment data for the same payment id"


### PR DESCRIPTION
Change the `update` method on `StorableObject` to take the update by value rather than by reference. This avoids unnecessary clones when applying updates, since the caller typically constructs a fresh update struct that can simply be moved.

Co-Authored-By: HAL 9000