### PR TITLE
Classify onchain transactions

### DIFF
--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -288,7 +288,9 @@ impl StorableObject for PaymentDetails {
 		if let Some(tx_type_update) = update.tx_type {
 			match self.kind {
 				PaymentKind::Onchain { ref mut tx_type, .. } => {
-					update_if_necessary!(*tx_type, tx_type_update);
+					if tx_type.is_none() || tx_type_update.is_some() {
+						update_if_necessary!(*tx_type, tx_type_update);
+					}
 				},
 				_ => {},
 			}
@@ -920,6 +922,103 @@ mod tests {
 			}),
 		};
 		assert_eq!(kind, PaymentKind::read(&mut &*kind.encode()).unwrap());
+	}
+
+	#[test]
+	fn known_onchain_tx_type_survives_unknown_update() {
+		use bitcoin::hashes::Hash;
+		use std::str::FromStr;
+
+		let txid = Txid::from_byte_array([8u8; 32]);
+		let payment_id = PaymentId(txid.to_byte_array());
+		let pubkey = PublicKey::from_str(
+			"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		)
+		.unwrap();
+		let tx_type = TransactionType::CooperativeClose {
+			counterparty_node_id: pubkey,
+			channel_id: ChannelId([4u8; 32]),
+		};
+		let mut classified = PaymentDetails::new(
+			payment_id,
+			PaymentKind::Onchain {
+				txid,
+				status: ConfirmationStatus::Unconfirmed,
+				tx_type: Some(tx_type.clone()),
+			},
+			Some(1_000),
+			Some(100),
+			PaymentDirection::Inbound,
+			PaymentStatus::Pending,
+		);
+		let wallet_sync_update = PaymentDetails::new(
+			payment_id,
+			PaymentKind::Onchain {
+				txid,
+				status: ConfirmationStatus::Confirmed {
+					block_hash: BlockHash::from_byte_array([9u8; 32]),
+					height: 42,
+					timestamp: 123,
+				},
+				tx_type: None,
+			},
+			Some(1_000),
+			Some(100),
+			PaymentDirection::Inbound,
+			PaymentStatus::Pending,
+		);
+
+		assert!(classified.update(PaymentDetailsUpdate::from(&wallet_sync_update)));
+		match classified.kind {
+			PaymentKind::Onchain { status, tx_type: Some(updated_tx_type), .. } => {
+				assert!(matches!(status, ConfirmationStatus::Confirmed { height: 42, .. }));
+				assert_eq!(updated_tx_type, tx_type);
+			},
+			other => panic!("Unexpected payment kind: {:?}", other),
+		}
+	}
+
+	#[test]
+	fn transaction_type_from_ldk_variants() {
+		use std::str::FromStr;
+
+		let pubkey = PublicKey::from_str(
+			"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		)
+		.unwrap();
+		let channel_id = ChannelId([5u8; 32]);
+		let channel = Channel { counterparty_node_id: pubkey, channel_id };
+
+		let variants = vec![
+			(
+				LdkTransactionType::Funding { channels: vec![(pubkey, channel_id)] },
+				TransactionType::Funding { channels: vec![channel.clone()] },
+			),
+			(
+				LdkTransactionType::CooperativeClose { counterparty_node_id: pubkey, channel_id },
+				TransactionType::CooperativeClose { counterparty_node_id: pubkey, channel_id },
+			),
+			(
+				LdkTransactionType::UnilateralClose { counterparty_node_id: pubkey, channel_id },
+				TransactionType::UnilateralClose { counterparty_node_id: pubkey, channel_id },
+			),
+			(
+				LdkTransactionType::AnchorBump { counterparty_node_id: pubkey, channel_id },
+				TransactionType::AnchorBump { counterparty_node_id: pubkey, channel_id },
+			),
+			(
+				LdkTransactionType::Claim { counterparty_node_id: pubkey, channel_id },
+				TransactionType::Claim { counterparty_node_id: pubkey, channel_id },
+			),
+			(
+				LdkTransactionType::Sweep { channels: vec![(pubkey, channel_id)] },
+				TransactionType::Sweep { channels: vec![channel] },
+			),
+		];
+
+		for (ldk_type, expected_type) in variants {
+			assert_eq!(TransactionType::from(ldk_type), expected_type);
+		}
 	}
 
 	#[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/tx_broadcaster.rs
+++ b/src/tx_broadcaster.rs
@@ -9,7 +9,9 @@ use std::ops::Deref;
 use std::sync::{Mutex as StdMutex, Weak};
 
 use bitcoin::Transaction;
-use lightning::chain::chaininterface::{BroadcasterInterface, TransactionType};
+use lightning::chain::chaininterface::{
+	BroadcasterInterface, TransactionType as LdkTransactionType,
+};
 use tokio::sync::{mpsc, Mutex, MutexGuard};
 
 use crate::logger::{log_error, LdkLogger};
@@ -22,16 +24,21 @@ const BCAST_PACKAGE_QUEUE_SIZE: usize = 50;
 /// call, along with each transaction's type. Queued until the background task classifies and
 /// broadcasts it. Built only via [`BroadcastPackage::new`] from such a call, so unrelated
 /// transactions can't be grouped into one package by accident.
-pub(crate) struct BroadcastPackage(Vec<(Transaction, TransactionType)>);
+pub(crate) struct BroadcastPackage(Vec<(Transaction, Option<LdkTransactionType>)>);
 
 impl BroadcastPackage {
 	/// Builds a package from the transactions of a single `broadcast_transactions` call.
-	fn new(txs: &[(&Transaction, TransactionType)]) -> Self {
-		Self(txs.iter().map(|(tx, tx_type)| ((*tx).clone(), tx_type.clone())).collect())
+	fn new(txs: &[(&Transaction, LdkTransactionType)]) -> Self {
+		Self(txs.iter().map(|(tx, tx_type)| ((*tx).clone(), Some(tx_type.clone()))).collect())
+	}
+
+	/// Builds a package for wallet-originated broadcasts that have no LDK classification.
+	fn unclassified(txs: Vec<Transaction>) -> Self {
+		Self(txs.into_iter().map(|tx| (tx, None)).collect())
 	}
 
 	/// The packaged transactions and their types, for classification.
-	fn transactions(&self) -> &[(Transaction, TransactionType)] {
+	fn transactions(&self) -> &[(Transaction, Option<LdkTransactionType>)] {
 		&self.0
 	}
 
@@ -91,10 +98,18 @@ where
 		let wallet_opt = self.wallet.lock().expect("lock").as_ref().and_then(Weak::upgrade);
 		if let Some(wallet) = wallet_opt {
 			for (tx, tx_type) in package.transactions() {
-				wallet.classify_broadcast(tx, tx_type).await?;
+				if let Some(tx_type) = tx_type {
+					wallet.classify_broadcast(tx, tx_type).await?;
+				}
 			}
 		}
 		Ok(package)
+	}
+
+	pub(crate) fn broadcast_unclassified_transactions(&self, txs: Vec<Transaction>) {
+		self.queue_sender.try_send(BroadcastPackage::unclassified(txs)).unwrap_or_else(|e| {
+			log_error!(self.logger, "Failed to broadcast transactions: {}", e);
+		});
 	}
 }
 
@@ -102,7 +117,7 @@ impl<L: Deref> BroadcasterInterface for TransactionBroadcaster<L>
 where
 	L::Target: LdkLogger,
 {
-	fn broadcast_transactions(&self, txs: &[(&Transaction, TransactionType)]) {
+	fn broadcast_transactions(&self, txs: &[(&Transaction, LdkTransactionType)]) {
 		self.queue_sender.try_send(BroadcastPackage::new(txs)).unwrap_or_else(|e| {
 			log_error!(self.logger, "Failed to broadcast transactions: {}", e);
 		});

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -32,7 +32,7 @@ use bitcoin::{
 	WPubkeyHash, Weight, WitnessProgram, WitnessVersion,
 };
 use lightning::chain::chaininterface::{
-	BroadcasterInterface, FundingCandidate, TransactionType as LdkTransactionType,
+	FundingCandidate, TransactionType as LdkTransactionType,
 	INCREMENTAL_RELAY_FEE_SAT_PER_1000_WEIGHT,
 };
 use lightning::chain::channelmonitor::ANTI_REORG_DELAY;
@@ -335,21 +335,12 @@ impl Wallet {
 							.collect();
 
 						if !txs_to_broadcast.is_empty() {
-							let tx_refs: Vec<(
-								&Transaction,
-								lightning::chain::chaininterface::TransactionType,
-							)> =
-								txs_to_broadcast
-									.iter()
-									.map(|tx| {
-										(tx, lightning::chain::chaininterface::TransactionType::Sweep { channels: vec![] })
-									})
-									.collect();
-							self.broadcaster.broadcast_transactions(&tx_refs);
+							let tx_count = txs_to_broadcast.len();
+							self.broadcaster.broadcast_unclassified_transactions(txs_to_broadcast);
 							log_info!(
 								self.logger,
 								"Rebroadcast {} unconfirmed transactions on chain tip change",
-								txs_to_broadcast.len()
+								tx_count
 							);
 						}
 					}
@@ -889,12 +880,8 @@ impl Wallet {
 			})?
 		};
 
-		self.broadcaster.broadcast_transactions(&[(
-			&tx,
-			lightning::chain::chaininterface::TransactionType::Sweep { channels: vec![] },
-		)]);
-
 		let txid = tx.compute_txid();
+		self.broadcaster.broadcast_unclassified_transactions(vec![tx]);
 
 		match send_amount {
 			OnchainSendAmount::ExactRetainingReserve { amount_sats, .. } => {
@@ -1719,11 +1706,6 @@ impl Wallet {
 
 		let new_txid = fee_bumped_tx.compute_txid();
 
-		self.broadcaster.broadcast_transactions(&[(
-			&fee_bumped_tx,
-			lightning::chain::chaininterface::TransactionType::Sweep { channels: vec![] },
-		)]);
-
 		let new_payment = self.create_payment_from_tx(
 			&locked_wallet,
 			new_txid,
@@ -1736,9 +1718,11 @@ impl Wallet {
 		let pending_payment_store =
 			self.create_pending_payment_from_tx(new_payment.clone(), Vec::new());
 
+		self.runtime.block_on(self.payment_store.insert_or_update(new_payment))?;
 		self.runtime
 			.block_on(self.pending_payment_store.insert_or_update(pending_payment_store))?;
-		self.runtime.block_on(self.payment_store.insert_or_update(new_payment))?;
+
+		self.broadcaster.broadcast_unclassified_transactions(vec![fee_bumped_tx]);
 
 		log_info!(self.logger, "RBF successful: replaced {} with {}", txid, new_txid);
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1171,9 +1171,8 @@ impl Wallet {
 		Ok(tx)
 	}
 
-	/// Classifies a funding broadcast (channel open or splice) handed to the broadcaster by LDK,
-	/// recording a payment for it before it is sent. Other transaction types are left for wallet
-	/// sync to record normally.
+	/// Classifies an on-chain broadcast handed to the broadcaster by LDK, recording a payment for it
+	/// before it is sent when it affects this node's wallet.
 	pub(crate) async fn classify_broadcast(
 		&self, tx: &Transaction, tx_type: &LdkTransactionType,
 	) -> Result<(), Error> {
@@ -1184,7 +1183,13 @@ impl Wallet {
 			LdkTransactionType::InteractiveFunding { candidates } => {
 				self.classify_interactive_funding(tx, candidates, tx_type.clone().into()).await
 			},
-			_ => Ok(()),
+			LdkTransactionType::CooperativeClose { .. }
+			| LdkTransactionType::UnilateralClose { .. }
+			| LdkTransactionType::AnchorBump { .. }
+			| LdkTransactionType::Claim { .. }
+			| LdkTransactionType::Sweep { .. } => {
+				self.classify_regular_broadcast(tx, tx_type.clone().into()).await
+			},
 		}
 	}
 
@@ -1322,6 +1327,40 @@ impl Wallet {
 			candidates.len(),
 			active.channels.len(),
 		);
+		Ok(())
+	}
+
+	/// Records a non-funding LDK broadcast as an on-chain payment, tagged with its transaction type.
+	/// Wallet sync later refreshes confirmation status while preserving the type.
+	async fn classify_regular_broadcast(
+		&self, tx: &Transaction, tx_type: TransactionType,
+	) -> Result<(), Error> {
+		let txid = tx.compute_txid();
+		let (amount_msat, fee_paid_msat, direction) = self.onchain_payment_fields(tx);
+
+		if amount_msat == Some(0) && fee_paid_msat == Some(0) {
+			log_trace!(
+				self.logger,
+				"Not recording classified broadcast {} as a payment: no wallet-level activity",
+				txid,
+			);
+			return Ok(());
+		}
+
+		let details = PaymentDetails::new(
+			PaymentId(txid.to_byte_array()),
+			PaymentKind::Onchain {
+				txid,
+				status: ConfirmationStatus::Unconfirmed,
+				tx_type: Some(tx_type),
+			},
+			amount_msat,
+			fee_paid_msat,
+			direction,
+			PaymentStatus::Pending,
+		);
+		self.payment_store.insert_or_update(details).await?;
+		log_debug!(self.logger, "Recorded classified on-chain broadcast {}", txid);
 		Ok(())
 	}
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::{
 	Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, Txid, Witness,
 };
@@ -42,7 +43,7 @@ use ldk_node::config::{
 };
 use ldk_node::entropy::{generate_entropy_mnemonic, NodeEntropy};
 use ldk_node::io::sqlite_store::SqliteStore;
-use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus};
+use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus, TransactionType};
 use ldk_node::{
 	Builder, ChannelShutdownState, CustomTlvRecord, Event, LightningBalance, Node, NodeError,
 	PendingSweepBalance, UserChannelId,
@@ -406,6 +407,116 @@ pub(crate) fn random_config(anchor_channels: bool) -> TestConfig {
 type TestNode = Arc<Node>;
 #[cfg(not(feature = "uniffi"))]
 type TestNode = Node;
+
+fn has_onchain_tx_type<F: Fn(&TransactionType) -> bool>(node: &TestNode, predicate: F) -> bool {
+	node.list_payments().into_iter().any(|payment| {
+		matches!(
+			payment.kind,
+			PaymentKind::Onchain { tx_type: Some(ref tx_type), .. } if predicate(tx_type)
+		)
+	})
+}
+
+fn assert_any_node_has_onchain_tx_type<F: Fn(&TransactionType) -> bool + Copy>(
+	nodes: &[(&str, &TestNode)], tx_type_name: &str, predicate: F,
+) {
+	if nodes.iter().any(|(_, node)| has_onchain_tx_type(node, predicate)) {
+		return;
+	}
+
+	let observed: Vec<String> = nodes
+		.iter()
+		.flat_map(|(name, node)| {
+			node.list_payments().into_iter().filter_map(move |payment| match payment.kind {
+				PaymentKind::Onchain { tx_type, .. } => Some(format!("{}:{:?}", name, tx_type)),
+				_ => None,
+			})
+		})
+		.collect();
+	panic!("Expected on-chain payment with tx_type {}; observed {:?}", tx_type_name, observed);
+}
+
+fn assert_all_nodes_have_onchain_tx_type<F: Fn(&TransactionType) -> bool + Copy>(
+	nodes: &[(&str, &TestNode)], tx_type_name: &str, predicate: F,
+) {
+	if nodes.iter().all(|(_, node)| has_onchain_tx_type(node, predicate)) {
+		return;
+	}
+
+	let observed: Vec<String> = nodes
+		.iter()
+		.flat_map(|(name, node)| {
+			node.list_payments().into_iter().filter_map(move |payment| match payment.kind {
+				PaymentKind::Onchain { tx_type, .. } => Some(format!("{}:{:?}", name, tx_type)),
+				_ => None,
+			})
+		})
+		.collect();
+	panic!(
+		"Expected all nodes to have on-chain payment with tx_type {}; observed {:?}",
+		tx_type_name, observed
+	);
+}
+
+async fn settle_force_close_balance<E: ElectrumApi>(
+	node: &TestNode, counterparty_node_id: PublicKey, peer_node: &TestNode,
+	bitcoind: &BitcoindClient, electrsd: &E,
+) {
+	let balances = node.list_balances();
+	if balances.lightning_balances.len() == 1 {
+		match balances.lightning_balances[0] {
+			LightningBalance::ClaimableAwaitingConfirmations {
+				counterparty_node_id: actual_counterparty_node_id,
+				confirmation_height,
+				..
+			} => {
+				assert_eq!(actual_counterparty_node_id, counterparty_node_id);
+				let cur_height = node.status().current_best_block.height;
+				let blocks_to_go = confirmation_height - cur_height;
+				generate_blocks_and_wait(bitcoind, electrsd, blocks_to_go as usize).await;
+				node.sync_wallets().unwrap();
+				peer_node.sync_wallets().unwrap();
+			},
+			_ => panic!("Unexpected balance state!"),
+		}
+	} else {
+		assert!(balances.lightning_balances.is_empty(), "Unexpected balance state: {:?}", balances);
+		assert_eq!(balances.pending_balances_from_channel_closures.len(), 1);
+	}
+
+	for _ in 0..6 {
+		if node.list_balances().lightning_balances.is_empty() {
+			break;
+		}
+		generate_blocks_and_wait(bitcoind, electrsd, 1).await;
+		node.sync_wallets().unwrap();
+		peer_node.sync_wallets().unwrap();
+	}
+
+	let balances = node.list_balances();
+	assert!(balances.lightning_balances.is_empty(), "Unexpected balance state: {:?}", balances);
+	assert_eq!(balances.pending_balances_from_channel_closures.len(), 1);
+	match balances.pending_balances_from_channel_closures[0] {
+		PendingSweepBalance::BroadcastAwaitingConfirmation { .. } => {
+			generate_blocks_and_wait(bitcoind, electrsd, 1).await;
+			node.sync_wallets().unwrap();
+			peer_node.sync_wallets().unwrap();
+
+			assert!(node.list_balances().lightning_balances.is_empty());
+			assert_eq!(node.list_balances().pending_balances_from_channel_closures.len(), 1);
+			match node.list_balances().pending_balances_from_channel_closures[0] {
+				PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
+				_ => panic!("Unexpected balance state!"),
+			}
+		},
+		PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
+		_ => panic!("Unexpected balance state!"),
+	}
+
+	generate_blocks_and_wait(bitcoind, electrsd, 5).await;
+	node.sync_wallets().unwrap();
+	peer_node.sync_wallets().unwrap();
+}
 
 #[derive(Clone)]
 pub(crate) enum TestChainSource<'a> {
@@ -1487,84 +1598,11 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	node_b.sync_wallets().unwrap();
 
 	if force_close {
-		// Check node_b properly sees all balances and sweeps them.
-		assert_eq!(node_b.list_balances().lightning_balances.len(), 1);
-		match node_b.list_balances().lightning_balances[0] {
-			LightningBalance::ClaimableAwaitingConfirmations {
-				counterparty_node_id,
-				confirmation_height,
-				..
-			} => {
-				assert_eq!(counterparty_node_id, node_a.node_id());
-				let cur_height = node_b.status().current_best_block.height;
-				let blocks_to_go = confirmation_height - cur_height;
-				generate_blocks_and_wait(&bitcoind, electrsd, blocks_to_go as usize).await;
-				node_b.sync_wallets().unwrap();
-				node_a.sync_wallets().unwrap();
-			},
-			_ => panic!("Unexpected balance state!"),
-		}
-
-		assert!(node_b.list_balances().lightning_balances.is_empty());
-		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
-		match node_b.list_balances().pending_balances_from_channel_closures[0] {
-			PendingSweepBalance::BroadcastAwaitingConfirmation { .. } => {},
-			_ => panic!("Unexpected balance state!"),
-		}
-		generate_blocks_and_wait(&bitcoind, electrsd, 1).await;
-		node_b.sync_wallets().unwrap();
-		node_a.sync_wallets().unwrap();
-
-		assert!(node_b.list_balances().lightning_balances.is_empty());
-		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
-		match node_b.list_balances().pending_balances_from_channel_closures[0] {
-			PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
-			_ => panic!("Unexpected balance state!"),
-		}
-		generate_blocks_and_wait(&bitcoind, electrsd, 5).await;
-		node_b.sync_wallets().unwrap();
-		node_a.sync_wallets().unwrap();
-
+		settle_force_close_balance(&node_b, node_a.node_id(), &node_a, &bitcoind, electrsd).await;
 		assert!(node_b.list_balances().lightning_balances.is_empty());
 		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
 
-		// Check node_a properly sees all balances and sweeps them.
-		assert_eq!(node_a.list_balances().lightning_balances.len(), 1);
-		match node_a.list_balances().lightning_balances[0] {
-			LightningBalance::ClaimableAwaitingConfirmations {
-				counterparty_node_id,
-				confirmation_height,
-				..
-			} => {
-				assert_eq!(counterparty_node_id, node_b.node_id());
-				let cur_height = node_a.status().current_best_block.height;
-				let blocks_to_go = confirmation_height - cur_height;
-				generate_blocks_and_wait(&bitcoind, electrsd, blocks_to_go as usize).await;
-				node_a.sync_wallets().unwrap();
-				node_b.sync_wallets().unwrap();
-			},
-			_ => panic!("Unexpected balance state!"),
-		}
-
-		assert!(node_a.list_balances().lightning_balances.is_empty());
-		assert_eq!(node_a.list_balances().pending_balances_from_channel_closures.len(), 1);
-		match node_a.list_balances().pending_balances_from_channel_closures[0] {
-			PendingSweepBalance::BroadcastAwaitingConfirmation { .. } => {},
-			_ => panic!("Unexpected balance state!"),
-		}
-		generate_blocks_and_wait(&bitcoind, electrsd, 1).await;
-		node_a.sync_wallets().unwrap();
-		node_b.sync_wallets().unwrap();
-
-		assert!(node_a.list_balances().lightning_balances.is_empty());
-		assert_eq!(node_a.list_balances().pending_balances_from_channel_closures.len(), 1);
-		match node_a.list_balances().pending_balances_from_channel_closures[0] {
-			PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
-			_ => panic!("Unexpected balance state!"),
-		}
-		generate_blocks_and_wait(&bitcoind, electrsd, 5).await;
-		node_a.sync_wallets().unwrap();
-		node_b.sync_wallets().unwrap();
+		settle_force_close_balance(&node_a, node_b.node_id(), &node_b, &bitcoind, electrsd).await;
 	} else {
 		assert_eq!(node_a.list_balances().lightning_balances.len(), 1);
 		assert!(node_a.list_balances().pending_balances_from_channel_closures.is_empty());
@@ -1616,7 +1654,22 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 			node_a.list_peers().iter().any(|p| p.node_id == node_b.node_id() && p.is_persisted),
 			"node_b should remain persisted in node_a peer store after locally-initiated force-close"
 		);
+		assert_any_node_has_onchain_tx_type(
+			&[("node_a", &node_a), ("node_b", &node_b)],
+			"UnilateralClose",
+			|tx_type| matches!(tx_type, TransactionType::UnilateralClose { .. }),
+		);
+		assert_any_node_has_onchain_tx_type(
+			&[("node_a", &node_a), ("node_b", &node_b)],
+			"Sweep",
+			|tx_type| matches!(tx_type, TransactionType::Sweep { .. }),
+		);
 	} else {
+		assert_all_nodes_have_onchain_tx_type(
+			&[("node_a", &node_a), ("node_b", &node_b)],
+			"CooperativeClose",
+			|tx_type| matches!(tx_type, TransactionType::CooperativeClose { .. }),
+		);
 		// Peer removed after cooperative close — no further reason to reconnect.
 		assert!(
 			!node_a.list_peers().iter().any(|p| p.node_id == node_b.node_id() && p.is_persisted),
@@ -1646,20 +1699,20 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	assert_eq!(node_b.list_balances().total_anchor_channels_reserve_sats, 0);
 
 	// Now we should have seen the channel closing transaction on-chain.
-	assert_eq!(
-		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
-				&& matches!(p.kind, PaymentKind::Onchain { .. }))
-			.len(),
-		3
-	);
-	assert_eq!(
-		node_b
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
-				&& matches!(p.kind, PaymentKind::Onchain { .. }))
-			.len(),
-		2
-	);
+	let node_a_inbound_onchain_count = node_a
+		.list_payments_with_filter(|p| {
+			p.direction == PaymentDirection::Inbound
+				&& matches!(p.kind, PaymentKind::Onchain { .. })
+		})
+		.len();
+	let node_b_inbound_onchain_count = node_b
+		.list_payments_with_filter(|p| {
+			p.direction == PaymentDirection::Inbound
+				&& matches!(p.kind, PaymentKind::Onchain { .. })
+		})
+		.len();
+	assert!(node_a_inbound_onchain_count >= 3);
+	assert!(node_b_inbound_onchain_count >= 2);
 
 	// Check we handled all events
 	assert_eq!(node_a.next_event(), None);

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -649,8 +649,9 @@ async fn onchain_send_receive() {
 	let payment_a = node_a.payment(&payment_id).unwrap();
 	assert_eq!(payment_a.status, PaymentStatus::Pending);
 	match payment_a.kind {
-		PaymentKind::Onchain { status, .. } => {
+		PaymentKind::Onchain { status, tx_type, .. } => {
 			assert!(matches!(status, ConfirmationStatus::Unconfirmed));
+			assert_eq!(tx_type, None);
 		},
 		_ => panic!("Unexpected payment kind"),
 	}
@@ -658,8 +659,9 @@ async fn onchain_send_receive() {
 	let payment_b = node_b.payment(&payment_id).unwrap();
 	assert_eq!(payment_b.status, PaymentStatus::Pending);
 	match payment_b.kind {
-		PaymentKind::Onchain { status, .. } => {
+		PaymentKind::Onchain { status, tx_type, .. } => {
 			assert!(matches!(status, ConfirmationStatus::Unconfirmed));
+			assert_eq!(tx_type, None);
 		},
 		_ => panic!("Unexpected payment kind"),
 	}
@@ -688,18 +690,20 @@ async fn onchain_send_receive() {
 
 	let payment_a = node_a.payment(&payment_id).unwrap();
 	match payment_a.kind {
-		PaymentKind::Onchain { txid: _txid, status, .. } => {
+		PaymentKind::Onchain { txid: _txid, status, tx_type } => {
 			assert_eq!(_txid, txid);
 			assert!(matches!(status, ConfirmationStatus::Confirmed { .. }));
+			assert_eq!(tx_type, None);
 		},
 		_ => panic!("Unexpected payment kind"),
 	}
 
 	let payment_b = node_b.payment(&payment_id).unwrap();
 	match payment_b.kind {
-		PaymentKind::Onchain { txid: _txid, status, .. } => {
+		PaymentKind::Onchain { txid: _txid, status, tx_type } => {
 			assert_eq!(_txid, txid);
 			assert!(matches!(status, ConfirmationStatus::Confirmed { .. }));
+			assert_eq!(tx_type, None);
 		},
 		_ => panic!("Unexpected payment kind"),
 	}

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -657,7 +657,7 @@ async fn onchain_send_receive() {
 	assert!(payment_a.fee_paid_msat > Some(0));
 	let payment_b = node_b.payment(&payment_id).unwrap();
 	assert_eq!(payment_b.status, PaymentStatus::Pending);
-	match payment_a.kind {
+	match payment_b.kind {
 		PaymentKind::Onchain { status, .. } => {
 			assert!(matches!(status, ConfirmationStatus::Unconfirmed));
 		},
@@ -695,7 +695,7 @@ async fn onchain_send_receive() {
 		_ => panic!("Unexpected payment kind"),
 	}
 
-	let payment_b = node_a.payment(&payment_id).unwrap();
+	let payment_b = node_b.payment(&payment_id).unwrap();
 	match payment_b.kind {
 		PaymentKind::Onchain { txid: _txid, status, .. } => {
 			assert_eq!(_txid, txid);


### PR DESCRIPTION
Fixes #447.

In #888 we started exposing `TransactionType` for funding-related transactions. Here, we continue that work and also classify the remaining transaction types so they are shown in the payment store.