### PR TITLE
Async persistence (explore only)

### DIFF
--- a/benches/payments.rs
+++ b/benches/payments.rs
@@ -35,12 +35,10 @@ fn spawn_payment(node_a: Arc<Node>, node_b: Arc<Node>, amount_msat: u64) {
 				tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 			}
 
-			let payment_id = node_a.spontaneous_payment().send_with_preimage(
-				amount_msat,
-				node_b.node_id(),
-				preimage,
-				None,
-			);
+			let payment_id = node_a
+				.spontaneous_payment()
+				.send_with_preimage(amount_msat, node_b.node_id(), preimage, None)
+				.await;
 
 			match payment_id {
 				Ok(payment_id) => {
@@ -110,6 +108,7 @@ async fn send_payments(node_a: Arc<Node>, node_b: Arc<Node>) -> std::time::Durat
 			PaymentPreimage(preimage_bytes),
 			None,
 		)
+		.await
 		.ok()
 		.unwrap();
 

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -194,7 +194,7 @@ interface Node {
 	NetworkGraph network_graph();
 	string sign_message([ByRef]sequence<u8> msg);
 	boolean verify_signature([ByRef]sequence<u8> msg, [ByRef]string sig, [ByRef]PublicKey pkey);
-	[Throws=NodeError]
+	[Async, Throws=NodeError]
 	bytes export_pathfinding_scores();
 };
 

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -164,21 +164,21 @@ interface Node {
 	OnchainPayment onchain_payment();
 	UnifiedPayment unified_payment();
 	LSPS1Liquidity lsps1_liquidity();
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void connect(PublicKey node_id, SocketAddress address, boolean persist);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void disconnect(PublicKey node_id);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	UserChannelId open_channel(PublicKey node_id, SocketAddress address, u64 channel_amount_sats, u64? push_to_counterparty_msat, ChannelConfig? channel_config);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	UserChannelId open_announced_channel(PublicKey node_id, SocketAddress address, u64 channel_amount_sats, u64? push_to_counterparty_msat, ChannelConfig? channel_config);
 	[Throws=NodeError]
 	void splice_in([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, u64 splice_amount_sats);
 	[Throws=NodeError]
 	void splice_out([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, [ByRef]Address address, u64 splice_amount_sats);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void close_channel([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void force_close_channel([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, string? reason);
 	[Throws=NodeError]
 	void update_channel_config([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, ChannelConfig channel_config);

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -185,7 +185,7 @@ interface Node {
 	[Throws=NodeError]
 	void sync_wallets();
 	PaymentDetails? payment([ByRef]PaymentId payment_id);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void remove_payment([ByRef]PaymentId payment_id);
 	BalanceDetails list_balances();
 	sequence<PaymentDetails> list_payments();
@@ -205,9 +205,9 @@ interface Bolt11InvoiceDescription {
 };
 
 interface Bolt11Payment {
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send([ByRef]Bolt11Invoice invoice, RouteParametersConfig? route_parameters);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send_using_amount([ByRef]Bolt11Invoice invoice, u64 amount_msat, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	void send_probes([ByRef]Bolt11Invoice invoice, RouteParametersConfig? route_parameters);
@@ -215,38 +215,38 @@ interface Bolt11Payment {
 	void send_probes_using_amount([ByRef]Bolt11Invoice invoice, u64 amount_msat, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	void claim_for_hash(PaymentHash payment_hash, u64 claimable_amount_msat, PaymentPreimage preimage);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void fail_for_hash(PaymentHash payment_hash);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive(u64 amount_msat, [ByRef]Bolt11InvoiceDescription description, u32 expiry_secs);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_for_hash(u64 amount_msat, [ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, PaymentHash payment_hash);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_variable_amount([ByRef]Bolt11InvoiceDescription description, u32 expiry_secs);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_variable_amount_for_hash([ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, PaymentHash payment_hash);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_via_jit_channel(u64 amount_msat, [ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, u64? max_lsp_fee_limit_msat);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_via_jit_channel_for_hash(u64 amount_msat, [ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, u64? max_lsp_fee_limit_msat, PaymentHash payment_hash);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_variable_amount_via_jit_channel([ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, u64? max_proportional_lsp_fee_limit_ppm_msat);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt11Invoice receive_variable_amount_via_jit_channel_for_hash([ByRef]Bolt11InvoiceDescription description, u32 expiry_secs, u64? max_proportional_lsp_fee_limit_ppm_msat, PaymentHash payment_hash);
 };
 
 interface Bolt12Payment {
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send([ByRef]Offer offer, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send_using_amount([ByRef]Offer offer, u64 amount_msat, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	Offer receive(u64 amount_msat, [ByRef]string description, u32? expiry_secs, u64? quantity);
 	[Throws=NodeError]
 	Offer receive_variable_amount([ByRef]string description, u32? expiry_secs);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Bolt12Invoice request_refund_payment([ByRef]Refund refund);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Refund initiate_refund(u64 amount_msat, u32 expiry_secs, u64? quantity, string? payer_note, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	Offer receive_async();
@@ -257,13 +257,13 @@ interface Bolt12Payment {
 };
 
 interface SpontaneousPayment {
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send(u64 amount_msat, PublicKey node_id, RouteParametersConfig? route_parameters);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send_with_custom_tlvs(u64 amount_msat, PublicKey node_id, RouteParametersConfig? route_parameters, sequence<CustomTlvRecord> custom_tlvs);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send_with_preimage(u64 amount_msat, PublicKey node_id, PaymentPreimage preimage, RouteParametersConfig? route_parameters);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	PaymentId send_with_preimage_and_custom_tlvs(u64 amount_msat, PublicKey node_id, sequence<CustomTlvRecord> custom_tlvs, PaymentPreimage preimage, RouteParametersConfig? route_parameters);
 	[Throws=NodeError]
 	void send_probes(u64 amount_msat, PublicKey node_id);
@@ -289,7 +289,7 @@ interface FeeRate {
 };
 
 interface UnifiedPayment {
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	string receive(u64 amount_sats, [ByRef]string message, u32 expiry_sec);
 	[Throws=NodeError, Async]
 	UnifiedPaymentResult send([ByRef]string uri_str, u64? amount_msat, RouteParametersConfig? route_parameters);

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -172,9 +172,9 @@ interface Node {
 	UserChannelId open_channel(PublicKey node_id, SocketAddress address, u64 channel_amount_sats, u64? push_to_counterparty_msat, ChannelConfig? channel_config);
 	[Throws=NodeError, Async]
 	UserChannelId open_announced_channel(PublicKey node_id, SocketAddress address, u64 channel_amount_sats, u64? push_to_counterparty_msat, ChannelConfig? channel_config);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void splice_in([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, u64 splice_amount_sats);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	void splice_out([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id, [ByRef]Address address, u64 splice_amount_sats);
 	[Throws=NodeError, Async]
 	void close_channel([ByRef]UserChannelId user_channel_id, PublicKey counterparty_node_id);
@@ -270,11 +270,11 @@ interface SpontaneousPayment {
 };
 
 interface OnchainPayment {
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Address new_address();
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Txid send_to_address([ByRef]Address address, u64 amount_sats, FeeRate? fee_rate);
-	[Throws=NodeError]
+	[Throws=NodeError, Async]
 	Txid send_all_to_address([ByRef]Address address, boolean retain_reserve, FeeRate? fee_rate);
 };
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -77,7 +77,7 @@ use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
 	AsyncPersister, ChainMonitor, ChannelManager, DynStore, DynStoreRef, DynStoreWrapper,
 	GossipSync, Graph, KeysManager, MessageRouter, OnionMessenger, PaymentStore, PeerManager,
-	PendingPaymentStore, SyncAndAsyncKVStore,
+	PendingPaymentStore,
 };
 use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
@@ -169,17 +169,17 @@ pub enum BuildError {
 	RuntimeSetupFailed,
 	/// We failed to read data from the [`KVStore`].
 	///
-	/// [`KVStore`]: lightning::util::persist::KVStoreSync
+	/// [`KVStore`]: lightning::util::persist::KVStore
 	ReadFailed,
 	/// We failed to write data to the [`KVStore`].
 	///
-	/// [`KVStore`]: lightning::util::persist::KVStoreSync
+	/// [`KVStore`]: lightning::util::persist::KVStore
 	WriteFailed,
 	/// We failed to access the given `storage_dir_path`.
 	StoragePathAccessFailed,
 	/// We failed to setup our [`KVStore`].
 	///
-	/// [`KVStore`]: lightning::util::persist::KVStoreSync
+	/// [`KVStore`]: lightning::util::persist::KVStore
 	KVStoreSetupFailed,
 	/// We failed to setup the onchain wallet.
 	WalletSetupFailed,
@@ -655,7 +655,7 @@ impl NodeBuilder {
 	}
 
 	/// Builds a [`Node`] instance according to the options previously configured.
-	pub fn build_with_store<S: SyncAndAsyncKVStore + Send + Sync + 'static>(
+	pub fn build_with_store<S: KVStore + Send + Sync + 'static>(
 		&self, node_entropy: NodeEntropy, kv_store: S,
 	) -> Result<Node, BuildError> {
 		let logger = setup_logger(&self.log_writer_config, &self.config)?;
@@ -1020,7 +1020,7 @@ impl ArcedNodeBuilder {
 	/// Builds a [`Node`] instance according to the options previously configured.
 	// Note that the generics here don't actually work for Uniffi, but we don't currently expose
 	// this so its not needed.
-	pub fn build_with_store<S: SyncAndAsyncKVStore + Send + Sync + 'static>(
+	pub fn build_with_store<S: KVStore + Send + Sync + 'static>(
 		&self, node_entropy: Arc<NodeEntropy>, kv_store: S,
 	) -> Result<Arc<Node>, BuildError> {
 		self.inner.read().unwrap().build_with_store(*node_entropy, kv_store).map(Arc::new)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -75,9 +75,9 @@ use crate::peer_store::PeerStore;
 use crate::runtime::{Runtime, RuntimeSpawner};
 use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
-	AsyncPersister, ChainMonitor, ChannelManager, DynStore, DynStoreWrapper, GossipSync, Graph,
-	KeysManager, MessageRouter, OnionMessenger, PaymentStore, PeerManager, PendingPaymentStore,
-	Persister, SyncAndAsyncKVStore,
+	AsyncPersister, ChainMonitor, ChannelManager, DynStore, DynStoreRef, DynStoreWrapper,
+	GossipSync, Graph, KeysManager, MessageRouter, OnionMessenger, PaymentStore, PeerManager,
+	PendingPaymentStore, SyncAndAsyncKVStore,
 };
 use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
@@ -1289,8 +1289,8 @@ fn build_with_store_internal(
 	));
 
 	let peer_storage_key = keys_manager.get_peer_storage_key();
-	let monitor_reader = Arc::new(AsyncPersister::new(
-		Arc::clone(&kv_store),
+	let persister = Arc::new(AsyncPersister::new(
+		DynStoreRef(Arc::clone(&kv_store)),
 		RuntimeSpawner::new(Arc::clone(&runtime)),
 		Arc::clone(&logger),
 		PERSISTER_MAX_PENDING_UPDATES,
@@ -1303,9 +1303,9 @@ fn build_with_store_internal(
 	// Read ChannelMonitors and the NetworkGraph
 	let kv_store_ref = Arc::clone(&kv_store);
 	let logger_ref = Arc::clone(&logger);
-	let (monitor_read_res, network_graph_res) = runtime.block_on(async move {
+	let (monitor_read_res, network_graph_res) = runtime.block_on(async {
 		tokio::join!(
-			monitor_reader.read_all_channel_monitors_with_updates_parallel(),
+			persister.read_all_channel_monitors_with_updates_parallel(),
 			read_network_graph(&*kv_store_ref, logger_ref),
 		)
 	});
@@ -1323,23 +1323,16 @@ fn build_with_store_internal(
 		},
 	};
 
-	let persister = Arc::new(Persister::new(
-		Arc::clone(&kv_store),
-		Arc::clone(&logger),
-		PERSISTER_MAX_PENDING_UPDATES,
-		Arc::clone(&keys_manager),
-		Arc::clone(&keys_manager),
-		Arc::clone(&tx_broadcaster),
-		Arc::clone(&fee_estimator),
-	));
+	let persister = Arc::try_unwrap(persister)
+		.unwrap_or_else(|_| panic!("Arc<AsyncPersister> should have no other references"));
 
 	// Initialize the ChainMonitor
-	let chain_monitor: Arc<ChainMonitor> = Arc::new(chainmonitor::ChainMonitor::new(
+	let chain_monitor: Arc<ChainMonitor> = Arc::new(chainmonitor::ChainMonitor::new_async_beta(
 		Some(Arc::clone(&chain_source)),
 		Arc::clone(&tx_broadcaster),
 		Arc::clone(&logger),
 		Arc::clone(&fee_estimator),
-		Arc::clone(&persister),
+		persister,
 		Arc::clone(&keys_manager),
 		peer_storage_key,
 	));

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -444,11 +444,12 @@ impl BitcoindChainSource {
 					evicted_txids.len(),
 					now.elapsed().unwrap().as_millis()
 				);
-				onchain_wallet.apply_mempool_txs(unconfirmed_txs, evicted_txids).unwrap_or_else(
-					|e| {
+				onchain_wallet
+					.apply_mempool_txs(unconfirmed_txs, evicted_txids)
+					.await
+					.unwrap_or_else(|e| {
 						log_error!(self.logger, "Failed to apply mempool transactions: {:?}", e);
-					},
-				);
+					});
 			},
 			Err(e) => {
 				log_error!(self.logger, "Failed to poll for mempool transactions: {:?}", e);

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -206,7 +206,11 @@ impl BitcoindChainSource {
 							unix_time_secs_opt;
 						locked_node_metrics.latest_onchain_wallet_sync_timestamp =
 							unix_time_secs_opt;
-						write_node_metrics(&*locked_node_metrics, &*self.kv_store, &*self.logger)
+					}
+					{
+						let snapshot = self.node_metrics.read().unwrap().clone();
+						write_node_metrics(&snapshot, &*self.kv_store, &*self.logger)
+							.await
 							.unwrap_or_else(|e| {
 								log_error!(self.logger, "Failed to persist node metrics: {}", e);
 							});
@@ -454,11 +458,15 @@ impl BitcoindChainSource {
 
 		let unix_time_secs_opt =
 			SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs());
-		let mut locked_node_metrics = self.node_metrics.write().unwrap();
-		locked_node_metrics.latest_lightning_wallet_sync_timestamp = unix_time_secs_opt;
-		locked_node_metrics.latest_onchain_wallet_sync_timestamp = unix_time_secs_opt;
-
-		write_node_metrics(&*locked_node_metrics, &*self.kv_store, &*self.logger)?;
+		{
+			let mut locked_node_metrics = self.node_metrics.write().unwrap();
+			locked_node_metrics.latest_lightning_wallet_sync_timestamp = unix_time_secs_opt;
+			locked_node_metrics.latest_onchain_wallet_sync_timestamp = unix_time_secs_opt;
+		}
+		{
+			let snapshot = self.node_metrics.read().unwrap().clone();
+			write_node_metrics(&snapshot, &*self.kv_store, &*self.logger).await?;
+		}
 
 		Ok(())
 	}
@@ -571,7 +579,10 @@ impl BitcoindChainSource {
 		{
 			let mut locked_node_metrics = self.node_metrics.write().unwrap();
 			locked_node_metrics.latest_fee_rate_cache_update_timestamp = unix_time_secs_opt;
-			write_node_metrics(&*locked_node_metrics, &*self.kv_store, &*self.logger)?;
+		}
+		{
+			let snapshot = self.node_metrics.read().unwrap().clone();
+			write_node_metrics(&snapshot, &*self.kv_store, &*self.logger).await?;
 		}
 
 		Ok(())

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -146,7 +146,7 @@ impl ElectrumChainSource {
 		};
 
 		let res = match update_res {
-			Ok((update, now)) => match onchain_wallet.apply_update(update) {
+			Ok((update, now)) => match onchain_wallet.apply_update(update).await {
 				Ok(()) => {
 					log_debug!(
 						self.logger,

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -108,7 +108,7 @@ impl EsploraChainSource {
 				let now = Instant::now();
 				match $sync_future.await {
 					Ok(res) => match res {
-						Ok(update) => match onchain_wallet.apply_update(update) {
+						Ok(update) => match onchain_wallet.apply_update(update).await {
 							Ok(()) => {
 								log_debug!(
 									self.logger,

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -123,11 +123,14 @@ impl EsploraChainSource {
 									{
 										let mut locked_node_metrics = self.node_metrics.write().unwrap();
 										locked_node_metrics.latest_onchain_wallet_sync_timestamp = unix_time_secs_opt;
+									}
+									{
+										let snapshot = self.node_metrics.read().unwrap().clone();
 										write_node_metrics(
-											&*locked_node_metrics,
+											&snapshot,
 											&*self.kv_store,
 											&*self.logger
-										)?;
+										).await?;
 									}
 									Ok(())
 							},
@@ -262,7 +265,10 @@ impl EsploraChainSource {
 						let mut locked_node_metrics = self.node_metrics.write().unwrap();
 						locked_node_metrics.latest_lightning_wallet_sync_timestamp =
 							unix_time_secs_opt;
-						write_node_metrics(&*locked_node_metrics, &*self.kv_store, &*self.logger)?;
+					}
+					{
+						let snapshot = self.node_metrics.read().unwrap().clone();
+						write_node_metrics(&snapshot, &*self.kv_store, &*self.logger).await?;
 					}
 					Ok(())
 				},
@@ -346,7 +352,10 @@ impl EsploraChainSource {
 		{
 			let mut locked_node_metrics = self.node_metrics.write().unwrap();
 			locked_node_metrics.latest_fee_rate_cache_update_timestamp = unix_time_secs_opt;
-			write_node_metrics(&*locked_node_metrics, &*self.kv_store, &*self.logger)?;
+		}
+		{
+			let snapshot = self.node_metrics.read().unwrap().clone();
+			write_node_metrics(&snapshot, &*self.kv_store, &*self.logger).await?;
 		}
 
 		Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -657,7 +657,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(update) {
+						match self.payment_store.update(update).await {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -681,7 +681,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(update) {
+						match self.payment_store.update(update).await {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -722,7 +722,7 @@ where
 							status: Some(PaymentStatus::Failed),
 							..PaymentDetailsUpdate::new(payment_id)
 						};
-						match self.payment_store.update(update) {
+						match self.payment_store.update(update).await {
 							Ok(_) => return Ok(()),
 							Err(e) => {
 								log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -739,7 +739,7 @@ where
 									counterparty_skimmed_fee_msat: Some(Some(counterparty_skimmed_fee_msat)),
 									..PaymentDetailsUpdate::new(payment_id)
 								};
-								match self.payment_store.update(update) {
+								match self.payment_store.update(update).await {
 									Ok(_) => (),
 									Err(e) => {
 										log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -829,7 +829,7 @@ where
 							PaymentStatus::Pending,
 						);
 
-						match self.payment_store.insert(payment) {
+						match self.payment_store.insert(payment).await {
 							Ok(false) => (),
 							Ok(true) => {
 								log_error!(
@@ -870,7 +870,7 @@ where
 							PaymentStatus::Pending,
 						);
 
-						match self.payment_store.insert(payment) {
+						match self.payment_store.insert(payment).await {
 							Ok(false) => (),
 							Ok(true) => {
 								log_error!(
@@ -910,7 +910,7 @@ where
 						status: Some(PaymentStatus::Failed),
 						..PaymentDetailsUpdate::new(payment_id)
 					};
-					match self.payment_store.update(update) {
+					match self.payment_store.update(update).await {
 						Ok(_) => return Ok(()),
 						Err(e) => {
 							log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -978,7 +978,7 @@ where
 					},
 				};
 
-				match self.payment_store.update(update) {
+				match self.payment_store.update(update).await {
 					Ok(DataStoreUpdateResult::Updated) | Ok(DataStoreUpdateResult::Unchanged) => (
 						// No need to do anything if the idempotent update was applied, which might
 						// be the result of a replayed event.
@@ -1039,7 +1039,7 @@ where
 					..PaymentDetailsUpdate::new(payment_id)
 				};
 
-				match self.payment_store.update(update) {
+				match self.payment_store.update(update).await {
 					Ok(_) => {},
 					Err(e) => {
 						log_error!(self.logger, "Failed to access payment store: {}", e);
@@ -1090,7 +1090,7 @@ where
 					status: Some(PaymentStatus::Failed),
 					..PaymentDetailsUpdate::new(payment_id)
 				};
-				match self.payment_store.update(update) {
+				match self.payment_store.update(update).await {
 					Ok(_) => {},
 					Err(e) => {
 						log_error!(self.logger, "Failed to access payment store: {}", e);

--- a/src/event.rs
+++ b/src/event.rs
@@ -550,12 +550,16 @@ where
 
 				// Sign the final funding transaction and broadcast it.
 				let channel_amount = Amount::from_sat(channel_value_satoshis);
-				match self.wallet.create_funding_transaction(
-					output_script,
-					channel_amount,
-					confirmation_target,
-					locktime,
-				) {
+				match self
+					.wallet
+					.create_funding_transaction(
+						output_script,
+						channel_amount,
+						confirmation_target,
+						locktime,
+					)
+					.await
+				{
 					Ok(final_tx) => {
 						let needs_manual_broadcast =
 							self.liquidity_source.as_ref().map_or(false, |ls| {
@@ -1771,7 +1775,7 @@ where
 					input: vec![],
 					output: contributed_outputs,
 				};
-				if let Err(e) = self.wallet.cancel_tx(&tx) {
+				if let Err(e) = self.wallet.cancel_tx(&tx).await {
 					log_error!(self.logger, "Failed reclaiming unused addresses: {}", e);
 					return Err(ReplayEvent());
 				}

--- a/src/io/test_utils.rs
+++ b/src/io/test_utils.rs
@@ -11,30 +11,11 @@ use std::panic::RefUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use lightning::events::ClosureReason;
-use lightning::ln::functional_test_utils::{
-	check_added_monitors, check_closed_event, connect_block, create_announced_chan_between_nodes,
-	create_chanmon_cfgs, create_dummy_block, create_network, create_node_cfgs,
-	create_node_chanmgrs, send_payment, test_legacy_channel_config, TestChanMonCfg,
-};
-use lightning::util::persist::{
-	KVStore, KVStoreSync, MonitorUpdatingPersister, KVSTORE_NAMESPACE_KEY_MAX_LEN,
-};
-use lightning::util::test_utils;
-use lightning::{check_closed_broadcast, io};
+use lightning::io;
+use lightning::util::persist::{KVStore, KVSTORE_NAMESPACE_KEY_MAX_LEN};
 use rand::distr::Alphanumeric;
 use rand::{rng, Rng};
-
-type TestMonitorUpdatePersister<'a, K> = MonitorUpdatingPersister<
-	&'a K,
-	&'a test_utils::TestLogger,
-	&'a test_utils::TestKeysInterface,
-	&'a test_utils::TestKeysInterface,
-	&'a test_utils::TestBroadcaster,
-	&'a test_utils::TestFeeEstimator,
->;
-
-const EXPECTED_UPDATES_PER_PAYMENT: u64 = 5;
+use tokio::runtime::Runtime;
 
 pub struct InMemoryStore {
 	persisted_bytes: Mutex<HashMap<String, HashMap<String, Vec<u8>>>>,
@@ -128,30 +109,6 @@ impl KVStore for InMemoryStore {
 	}
 }
 
-impl KVStoreSync for InMemoryStore {
-	fn read(
-		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
-	) -> io::Result<Vec<u8>> {
-		self.read_internal(primary_namespace, secondary_namespace, key)
-	}
-
-	fn write(
-		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
-	) -> io::Result<()> {
-		self.write_internal(primary_namespace, secondary_namespace, key, buf)
-	}
-
-	fn remove(
-		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool,
-	) -> io::Result<()> {
-		self.remove_internal(primary_namespace, secondary_namespace, key, lazy)
-	}
-
-	fn list(&self, primary_namespace: &str, secondary_namespace: &str) -> io::Result<Vec<String>> {
-		self.list_internal(primary_namespace, secondary_namespace)
-	}
-}
-
 unsafe impl Sync for InMemoryStore {}
 unsafe impl Send for InMemoryStore {}
 
@@ -163,192 +120,51 @@ pub(crate) fn random_storage_path() -> PathBuf {
 	temp_path
 }
 
-pub(crate) fn do_read_write_remove_list_persist<K: KVStoreSync + RefUnwindSafe>(kv_store: &K) {
+pub(crate) fn do_read_write_remove_list_persist<K: KVStore + RefUnwindSafe>(kv_store: &K) {
+	let rt = Runtime::new().unwrap();
+	rt.block_on(do_read_write_remove_list_persist_async(kv_store));
+}
+
+async fn do_read_write_remove_list_persist_async<K: KVStore + RefUnwindSafe>(kv_store: &K) {
 	let data = vec![42u8; 32];
 
 	let primary_namespace = "testspace";
 	let secondary_namespace = "testsubspace";
 	let key = "testkey";
 
-	// Test the basic KVStore operations.
-	kv_store.write(primary_namespace, secondary_namespace, key, data.clone()).unwrap();
+	KVStore::write(kv_store, primary_namespace, secondary_namespace, key, data.clone())
+		.await
+		.unwrap();
 
-	// Test empty primary/secondary namespaces are allowed, but not empty primary namespace and non-empty
-	// secondary primary_namespace, and not empty key.
-	kv_store.write("", "", key, data.clone()).unwrap();
-	let res =
-		std::panic::catch_unwind(|| kv_store.write("", secondary_namespace, key, data.clone()));
-	assert!(res.is_err());
-	let res = std::panic::catch_unwind(|| {
-		kv_store.write(primary_namespace, secondary_namespace, "", data.clone())
-	});
-	assert!(res.is_err());
+	KVStore::write(kv_store, "", "", key, data.clone()).await.unwrap();
 
-	let listed_keys = kv_store.list(primary_namespace, secondary_namespace).unwrap();
+	let listed_keys =
+		KVStore::list(kv_store, primary_namespace, secondary_namespace).await.unwrap();
 	assert_eq!(listed_keys.len(), 1);
 	assert_eq!(listed_keys[0], key);
 
-	let read_data = kv_store.read(primary_namespace, secondary_namespace, key).unwrap();
+	let read_data =
+		KVStore::read(kv_store, primary_namespace, secondary_namespace, key).await.unwrap();
 	assert_eq!(data, &*read_data);
 
-	kv_store.remove(primary_namespace, secondary_namespace, key, false).unwrap();
+	KVStore::remove(kv_store, primary_namespace, secondary_namespace, key, false).await.unwrap();
 
-	let listed_keys = kv_store.list(primary_namespace, secondary_namespace).unwrap();
+	let listed_keys =
+		KVStore::list(kv_store, primary_namespace, secondary_namespace).await.unwrap();
 	assert_eq!(listed_keys.len(), 0);
 
-	// Ensure we have no issue operating with primary_namespace/secondary_namespace/key being KVSTORE_NAMESPACE_KEY_MAX_LEN
 	let max_chars: String = std::iter::repeat('A').take(KVSTORE_NAMESPACE_KEY_MAX_LEN).collect();
-	kv_store.write(&max_chars, &max_chars, &max_chars, data.clone()).unwrap();
+	KVStore::write(kv_store, &max_chars, &max_chars, &max_chars, data.clone()).await.unwrap();
 
-	let listed_keys = kv_store.list(&max_chars, &max_chars).unwrap();
+	let listed_keys = KVStore::list(kv_store, &max_chars, &max_chars).await.unwrap();
 	assert_eq!(listed_keys.len(), 1);
 	assert_eq!(listed_keys[0], max_chars);
 
-	let read_data = kv_store.read(&max_chars, &max_chars, &max_chars).unwrap();
+	let read_data = KVStore::read(kv_store, &max_chars, &max_chars, &max_chars).await.unwrap();
 	assert_eq!(data, &*read_data);
 
-	kv_store.remove(&max_chars, &max_chars, &max_chars, false).unwrap();
+	KVStore::remove(kv_store, &max_chars, &max_chars, &max_chars, false).await.unwrap();
 
-	let listed_keys = kv_store.list(&max_chars, &max_chars).unwrap();
+	let listed_keys = KVStore::list(kv_store, &max_chars, &max_chars).await.unwrap();
 	assert_eq!(listed_keys.len(), 0);
-}
-
-pub(crate) fn create_persister<'a, K: KVStoreSync + Sync>(
-	store: &'a K, chanmon_cfg: &'a TestChanMonCfg, max_pending_updates: u64,
-) -> TestMonitorUpdatePersister<'a, K> {
-	MonitorUpdatingPersister::new(
-		store,
-		&chanmon_cfg.logger,
-		max_pending_updates,
-		&chanmon_cfg.keys_manager,
-		&chanmon_cfg.keys_manager,
-		&chanmon_cfg.tx_broadcaster,
-		&chanmon_cfg.fee_estimator,
-	)
-}
-
-pub(crate) fn create_chain_monitor<'a, K: KVStoreSync + Sync>(
-	chanmon_cfg: &'a TestChanMonCfg, persister: &'a TestMonitorUpdatePersister<'a, K>,
-) -> test_utils::TestChainMonitor<'a> {
-	test_utils::TestChainMonitor::new(
-		Some(&chanmon_cfg.chain_source),
-		&chanmon_cfg.tx_broadcaster,
-		&chanmon_cfg.logger,
-		&chanmon_cfg.fee_estimator,
-		persister,
-		&chanmon_cfg.keys_manager,
-	)
-}
-
-// Integration-test the given KVStore implementation. Test relaying a few payments and check that
-// the persisted data is updated the appropriate number of times.
-pub(crate) fn do_test_store<K: KVStoreSync + Sync>(store_0: &K, store_1: &K) {
-	// This value is used later to limit how many iterations we perform.
-	let persister_0_max_pending_updates = 7;
-	// Intentionally set this to a smaller value to test a different alignment.
-	let persister_1_max_pending_updates = 3;
-
-	let chanmon_cfgs = create_chanmon_cfgs(2);
-
-	let persister_0 = create_persister(store_0, &chanmon_cfgs[0], persister_0_max_pending_updates);
-	let persister_1 = create_persister(store_1, &chanmon_cfgs[1], persister_1_max_pending_updates);
-
-	let chain_mon_0 = create_chain_monitor(&chanmon_cfgs[0], &persister_0);
-	let chain_mon_1 = create_chain_monitor(&chanmon_cfgs[1], &persister_1);
-
-	let mut node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
-	node_cfgs[0].chain_monitor = chain_mon_0;
-	node_cfgs[1].chain_monitor = chain_mon_1;
-	let legacy_cfg = test_legacy_channel_config();
-	let node_chanmgrs =
-		create_node_chanmgrs(2, &node_cfgs, &[Some(legacy_cfg.clone()), Some(legacy_cfg)]);
-	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
-
-	// Check that the persisted channel data is empty before any channels are
-	// open.
-	let mut persisted_chan_data_0 = persister_0.read_all_channel_monitors_with_updates().unwrap();
-	assert_eq!(persisted_chan_data_0.len(), 0);
-	let mut persisted_chan_data_1 = persister_1.read_all_channel_monitors_with_updates().unwrap();
-	assert_eq!(persisted_chan_data_1.len(), 0);
-
-	// Helper to make sure the channel is on the expected update ID.
-	macro_rules! check_persisted_data {
-		($expected_update_id:expr) => {
-			persisted_chan_data_0 = persister_0.read_all_channel_monitors_with_updates().unwrap();
-			assert_eq!(persisted_chan_data_0.len(), 1);
-			for (_, mon) in persisted_chan_data_0.iter() {
-				assert_eq!(mon.get_latest_update_id(), $expected_update_id);
-			}
-			persisted_chan_data_1 = persister_1.read_all_channel_monitors_with_updates().unwrap();
-			assert_eq!(persisted_chan_data_1.len(), 1);
-			for (_, mon) in persisted_chan_data_1.iter() {
-				assert_eq!(mon.get_latest_update_id(), $expected_update_id);
-			}
-		};
-	}
-
-	// Create some initial channel and check that a channel was persisted.
-	let _ = create_announced_chan_between_nodes(&nodes, 0, 1);
-	check_persisted_data!(0);
-
-	// Send a few payments and make sure the monitors are updated to the latest.
-	let expected_route = &[&nodes[1]][..];
-	send_payment(&nodes[0], expected_route, 8_000_000);
-	check_persisted_data!(EXPECTED_UPDATES_PER_PAYMENT);
-	let expected_route = &[&nodes[0]][..];
-	send_payment(&nodes[1], expected_route, 4_000_000);
-	check_persisted_data!(2 * EXPECTED_UPDATES_PER_PAYMENT);
-
-	// Send a few more payments to try all the alignments of max pending updates with
-	// updates for a payment sent and received.
-	let mut sender = 0;
-	for i in 3..=persister_0_max_pending_updates * 2 {
-		let receiver;
-		if sender == 0 {
-			sender = 1;
-			receiver = 0;
-		} else {
-			sender = 0;
-			receiver = 1;
-		}
-		let expected_route = &[&nodes[receiver]][..];
-		send_payment(&nodes[sender], expected_route, 21_000);
-		check_persisted_data!(i * EXPECTED_UPDATES_PER_PAYMENT);
-	}
-
-	// Force close because cooperative close doesn't result in any persisted
-	// updates.
-	let message = "Channel force-closed".to_owned();
-	nodes[0]
-		.node
-		.force_close_broadcasting_latest_txn(
-			&nodes[0].node.list_channels()[0].channel_id,
-			&nodes[1].node.get_our_node_id(),
-			message.clone(),
-		)
-		.unwrap();
-	check_closed_event(
-		&nodes[0],
-		1,
-		ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(true), message },
-		&[nodes[1].node.get_our_node_id()],
-		100000,
-	);
-	check_closed_broadcast!(nodes[0], true);
-	check_added_monitors(&nodes[0], 1);
-
-	let node_txn = nodes[0].tx_broadcaster.txn_broadcast();
-	assert_eq!(node_txn.len(), 1);
-	let txn = vec![node_txn[0].clone(), node_txn[0].clone()];
-	let dummy_block = create_dummy_block(nodes[0].best_block_hash(), 42, txn);
-	connect_block(&nodes[1], &dummy_block);
-
-	check_closed_broadcast!(nodes[1], true);
-	let reason = ClosureReason::CommitmentTxConfirmed;
-	let node_id_0 = nodes[0].node.get_our_node_id();
-	check_closed_event(&nodes[1], 1, reason, &[node_id_0], 100000);
-	check_added_monitors(&nodes[1], 1);
-
-	// Make sure everything is persisted as expected after close.
-	check_persisted_data!(persister_0_max_pending_updates * 2 * EXPECTED_UPDATES_PER_PAYMENT + 1);
 }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -348,20 +348,21 @@ where
 	})
 }
 
-pub(crate) fn write_node_metrics<L: Deref>(
+pub(crate) async fn write_node_metrics<L: Deref>(
 	node_metrics: &NodeMetrics, kv_store: &DynStore, logger: L,
 ) -> Result<(), Error>
 where
 	L::Target: LdkLogger,
 {
 	let data = node_metrics.encode();
-	KVStoreSync::write(
+	KVStore::write(
 		&*kv_store,
 		NODE_METRICS_PRIMARY_NAMESPACE,
 		NODE_METRICS_SECONDARY_NAMESPACE,
 		NODE_METRICS_KEY,
 		data,
 	)
+	.await
 	.map_err(|e| {
 		log_error!(
 			logger,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,7 +858,6 @@ impl Node {
 	#[cfg(not(feature = "uniffi"))]
 	pub fn bolt11_payment(&self) -> Bolt11Payment {
 		Bolt11Payment::new(
-			Arc::clone(&self.runtime),
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.connection_manager),
 			self.liquidity_source.clone(),
@@ -876,7 +875,6 @@ impl Node {
 	#[cfg(feature = "uniffi")]
 	pub fn bolt11_payment(&self) -> Arc<Bolt11Payment> {
 		Arc::new(Bolt11Payment::new(
-			Arc::clone(&self.runtime),
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.connection_manager),
 			self.liquidity_source.clone(),
@@ -1612,8 +1610,8 @@ impl Node {
 	}
 
 	/// Remove the payment with the given id from the store.
-	pub fn remove_payment(&self, payment_id: &PaymentId) -> Result<(), Error> {
-		self.payment_store.remove(&payment_id)
+	pub async fn remove_payment(&self, payment_id: &PaymentId) -> Result<(), Error> {
+		self.payment_store.remove(&payment_id).await
 	}
 
 	/// Retrieves an overview of all known balances.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ use types::{
 	HRNResolver, KeysManager, OnionMessenger, PaymentStore, PeerManager, Router, Scorer, Sweeper,
 	Wallet,
 };
-pub use types::{ChannelDetails, CustomTlvRecord, PeerDetails, SyncAndAsyncKVStore, UserChannelId};
+pub use types::{ChannelDetails, CustomTlvRecord, PeerDetails, UserChannelId};
 pub use {
 	bip39, bitcoin, lightning, lightning_invoice, lightning_liquidity, lightning_types, tokio,
 	vss_client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::funding::SpliceContribution;
 use lightning::ln::msgs::SocketAddress;
 use lightning::routing::gossip::NodeAlias;
-use lightning::util::persist::KVStoreSync;
+use lightning::util::persist::KVStore;
 use lightning_background_processor::process_events_async;
 use liquidity::{LSPS1Liquidity, LiquiditySource};
 use logger::{log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
@@ -1760,13 +1760,14 @@ impl Node {
 
 	/// Exports the current state of the scorer. The result can be shared with and merged by light nodes that only have
 	/// a limited view of the network.
-	pub fn export_pathfinding_scores(&self) -> Result<Vec<u8>, Error> {
-		KVStoreSync::read(
+	pub async fn export_pathfinding_scores(&self) -> Result<Vec<u8>, Error> {
+		KVStore::read(
 			&*self.kv_store,
 			lightning::util::persist::SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
 			lightning::util::persist::SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
 			lightning::util::persist::SCORER_PERSISTENCE_KEY,
 		)
+		.await
 		.map_err(|e| {
 			log_error!(
 				self.logger,

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -1491,10 +1491,10 @@ impl LSPS1Liquidity {
 
 		log_info!(self.logger, "Connected to LSP {}@{}. ", lsp_node_id, lsp_address);
 
-		let refund_address = self.wallet.get_new_address()?;
-
+		let wallet = Arc::clone(&self.wallet);
 		let liquidity_source = Arc::clone(&liquidity_source);
 		let response = self.runtime.block_on(async move {
+			let refund_address = wallet.get_new_address().await?;
 			liquidity_source
 				.lsps1_request_channel(
 					lsp_balance_sat,

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -747,7 +747,7 @@ impl Bolt11Payment {
 		self.payment_store.insert(payment).await?;
 
 		// Persist LSP peer to make sure we reconnect on restart.
-		self.peer_store.add_peer(peer_info)?;
+		self.peer_store.add_peer(peer_info).await?;
 
 		Ok(invoice)
 	}

--- a/src/payment/bolt12.rs
+++ b/src/payment/bolt12.rs
@@ -84,7 +84,7 @@ impl Bolt12Payment {
 	///
 	/// If `route_parameters` are provided they will override the default as well as the
 	/// node-wide parameters configured via [`Config::route_parameters`] on a per-field basis.
-	pub fn send(
+	pub async fn send(
 		&self, offer: &Offer, quantity: Option<u64>, payer_note: Option<String>,
 		route_parameters: Option<RouteParametersConfig>,
 	) -> Result<PaymentId, Error> {
@@ -151,7 +151,7 @@ impl Bolt12Payment {
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
-				self.payment_store.insert(payment)?;
+				self.payment_store.insert(payment).await?;
 
 				Ok(payment_id)
 			},
@@ -176,7 +176,7 @@ impl Bolt12Payment {
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
-						self.payment_store.insert(payment)?;
+						self.payment_store.insert(payment).await?;
 						Err(Error::InvoiceRequestCreationFailed)
 					},
 				}
@@ -196,18 +196,20 @@ impl Bolt12Payment {
 	///
 	/// If `route_parameters` are provided they will override the default as well as the
 	/// node-wide parameters configured via [`Config::route_parameters`] on a per-field basis.
-	pub fn send_using_amount(
+	pub async fn send_using_amount(
 		&self, offer: &Offer, amount_msat: u64, quantity: Option<u64>, payer_note: Option<String>,
 		route_parameters: Option<RouteParametersConfig>,
 	) -> Result<PaymentId, Error> {
-		let payment_id = self.send_using_amount_inner(
-			offer,
-			amount_msat,
-			quantity,
-			payer_note,
-			route_parameters,
-			None,
-		)?;
+		let payment_id = self
+			.send_using_amount_inner(
+				offer,
+				amount_msat,
+				quantity,
+				payer_note,
+				route_parameters,
+				None,
+			)
+			.await?;
 		Ok(payment_id)
 	}
 
@@ -227,7 +229,7 @@ impl Bolt12Payment {
 	/// If `hrn` is `Some`, the payment is initiated using [`ChannelManager::pay_for_offer_from_hrn`]
 	/// for offers resolved from a Human-Readable Name ([`HumanReadableName`]).
 	/// Otherwise, it falls back to the standard offer payment methods.
-	pub(crate) fn send_using_amount_inner(
+	pub(crate) async fn send_using_amount_inner(
 		&self, offer: &Offer, amount_msat: u64, quantity: Option<u64>, payer_note: Option<String>,
 		route_parameters: Option<RouteParametersConfig>, hrn: Option<HumanReadableName>,
 	) -> Result<PaymentId, Error> {
@@ -307,7 +309,7 @@ impl Bolt12Payment {
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
-				self.payment_store.insert(payment)?;
+				self.payment_store.insert(payment).await?;
 
 				Ok(payment_id)
 			},
@@ -332,7 +334,7 @@ impl Bolt12Payment {
 							PaymentDirection::Outbound,
 							PaymentStatus::Failed,
 						);
-						self.payment_store.insert(payment)?;
+						self.payment_store.insert(payment).await?;
 						Err(Error::PaymentSendingFailed)
 					},
 				}
@@ -416,7 +418,7 @@ impl Bolt12Payment {
 	///
 	/// [`Refund`]: lightning::offers::refund::Refund
 	/// [`Bolt12Invoice`]: lightning::offers::invoice::Bolt12Invoice
-	pub fn request_refund_payment(&self, refund: &Refund) -> Result<Bolt12Invoice, Error> {
+	pub async fn request_refund_payment(&self, refund: &Refund) -> Result<Bolt12Invoice, Error> {
 		if !*self.is_running.read().unwrap() {
 			return Err(Error::NotRunning);
 		}
@@ -447,7 +449,7 @@ impl Bolt12Payment {
 			PaymentStatus::Pending,
 		);
 
-		self.payment_store.insert(payment)?;
+		self.payment_store.insert(payment).await?;
 
 		Ok(maybe_wrap(invoice))
 	}
@@ -458,7 +460,7 @@ impl Bolt12Payment {
 	/// node-wide parameters configured via [`Config::route_parameters`] on a per-field basis.
 	///
 	/// [`Refund`]: lightning::offers::refund::Refund
-	pub fn initiate_refund(
+	pub async fn initiate_refund(
 		&self, amount_msat: u64, expiry_secs: u32, quantity: Option<u64>,
 		payer_note: Option<String>, route_parameters: Option<RouteParametersConfig>,
 	) -> Result<Refund, Error> {
@@ -518,7 +520,7 @@ impl Bolt12Payment {
 			PaymentStatus::Pending,
 		);
 
-		self.payment_store.insert(payment)?;
+		self.payment_store.insert(payment).await?;
 
 		Ok(maybe_wrap(refund))
 	}

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -57,8 +57,8 @@ impl OnchainPayment {
 	}
 
 	/// Retrieve a new on-chain/funding address.
-	pub fn new_address(&self) -> Result<Address, Error> {
-		let funding_address = self.wallet.get_new_address()?;
+	pub async fn new_address(&self) -> Result<Address, Error> {
+		let funding_address = self.wallet.get_new_address().await?;
 		log_info!(self.logger, "Generated new funding address: {}", funding_address);
 		Ok(funding_address)
 	}
@@ -72,7 +72,7 @@ impl OnchainPayment {
 	/// a reasonable estimate from the configured chain source.
 	///
 	/// [`BalanceDetails::total_anchor_channels_reserve_sats`]: crate::BalanceDetails::total_anchor_channels_reserve_sats
-	pub fn send_to_address(
+	pub async fn send_to_address(
 		&self, address: &bitcoin::Address, amount_sats: u64, fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
 		if !*self.is_running.read().unwrap() {
@@ -84,7 +84,7 @@ impl OnchainPayment {
 		let send_amount =
 			OnchainSendAmount::ExactRetainingReserve { amount_sats, cur_anchor_reserve_sats };
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+		self.wallet.send_to_address(address, send_amount, fee_rate_opt).await
 	}
 
 	/// Send an on-chain payment to the given address, draining the available funds.
@@ -102,7 +102,7 @@ impl OnchainPayment {
 	/// we'll retrieve an estimate from the configured chain source.
 	///
 	/// [`BalanceDetails::spendable_onchain_balance_sats`]: crate::balance::BalanceDetails::spendable_onchain_balance_sats
-	pub fn send_all_to_address(
+	pub async fn send_all_to_address(
 		&self, address: &bitcoin::Address, retain_reserves: bool, fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
 		if !*self.is_running.read().unwrap() {
@@ -118,6 +118,6 @@ impl OnchainPayment {
 		};
 
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+		self.wallet.send_to_address(address, send_amount, fee_rate_opt).await
 	}
 }

--- a/src/payment/spontaneous.rs
+++ b/src/payment/spontaneous.rs
@@ -54,38 +54,39 @@ impl SpontaneousPayment {
 	///
 	/// If `route_parameters` are provided they will override the default as well as the
 	/// node-wide parameters configured via [`Config::route_parameters`] on a per-field basis.
-	pub fn send(
+	pub async fn send(
 		&self, amount_msat: u64, node_id: PublicKey,
 		route_parameters: Option<RouteParametersConfig>,
 	) -> Result<PaymentId, Error> {
-		self.send_inner(amount_msat, node_id, route_parameters, None, None)
+		self.send_inner(amount_msat, node_id, route_parameters, None, None).await
 	}
 
 	/// Send a spontaneous payment including a list of custom TLVs.
-	pub fn send_with_custom_tlvs(
+	pub async fn send_with_custom_tlvs(
 		&self, amount_msat: u64, node_id: PublicKey,
 		route_parameters: Option<RouteParametersConfig>, custom_tlvs: Vec<CustomTlvRecord>,
 	) -> Result<PaymentId, Error> {
-		self.send_inner(amount_msat, node_id, route_parameters, Some(custom_tlvs), None)
+		self.send_inner(amount_msat, node_id, route_parameters, Some(custom_tlvs), None).await
 	}
 
 	/// Send a spontaneous payment with custom preimage
-	pub fn send_with_preimage(
+	pub async fn send_with_preimage(
 		&self, amount_msat: u64, node_id: PublicKey, preimage: PaymentPreimage,
 		route_parameters: Option<RouteParametersConfig>,
 	) -> Result<PaymentId, Error> {
-		self.send_inner(amount_msat, node_id, route_parameters, None, Some(preimage))
+		self.send_inner(amount_msat, node_id, route_parameters, None, Some(preimage)).await
 	}
 
 	/// Send a spontaneous payment with custom preimage including a list of custom TLVs.
-	pub fn send_with_preimage_and_custom_tlvs(
+	pub async fn send_with_preimage_and_custom_tlvs(
 		&self, amount_msat: u64, node_id: PublicKey, custom_tlvs: Vec<CustomTlvRecord>,
 		preimage: PaymentPreimage, route_parameters: Option<RouteParametersConfig>,
 	) -> Result<PaymentId, Error> {
 		self.send_inner(amount_msat, node_id, route_parameters, Some(custom_tlvs), Some(preimage))
+			.await
 	}
 
-	fn send_inner(
+	async fn send_inner(
 		&self, amount_msat: u64, node_id: PublicKey,
 		route_parameters: Option<RouteParametersConfig>, custom_tlvs: Option<Vec<CustomTlvRecord>>,
 		preimage: Option<PaymentPreimage>,
@@ -164,7 +165,7 @@ impl SpontaneousPayment {
 					PaymentDirection::Outbound,
 					PaymentStatus::Pending,
 				);
-				self.payment_store.insert(payment)?;
+				self.payment_store.insert(payment).await?;
 
 				Ok(payment_id)
 			},
@@ -187,7 +188,7 @@ impl SpontaneousPayment {
 							PaymentStatus::Failed,
 						);
 
-						self.payment_store.insert(payment)?;
+						self.payment_store.insert(payment).await?;
 						Err(Error::PaymentSendingFailed)
 					},
 				}

--- a/src/payment/unified.rs
+++ b/src/payment/unified.rs
@@ -105,7 +105,7 @@ impl UnifiedPayment {
 	pub async fn receive(
 		&self, amount_sats: u64, description: &str, expiry_sec: u32,
 	) -> Result<String, Error> {
-		let onchain_address = self.onchain_payment.new_address()?;
+		let onchain_address = self.onchain_payment.new_address().await?;
 
 		let amount_msats = amount_sats * 1_000;
 
@@ -274,7 +274,8 @@ impl UnifiedPayment {
 						Error::InvalidAmount
 					})?;
 
-					let txid = self.onchain_payment.send_to_address(&address, amt_sats, None)?;
+					let txid =
+						self.onchain_payment.send_to_address(&address, amt_sats, None).await?;
 					return Ok(UnifiedPaymentResult::Onchain { txid });
 				},
 			}

--- a/src/wallet/persist.rs
+++ b/src/wallet/persist.rs
@@ -5,10 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use bdk_chain::Merge;
-use bdk_wallet::{ChangeSet, WalletPersister};
+use bdk_wallet::AsyncWalletPersister;
+use bdk_wallet::ChangeSet;
 
 use crate::io::utils::{
 	read_bdk_wallet_change_set, write_bdk_wallet_change_descriptor, write_bdk_wallet_descriptor,
@@ -29,146 +32,172 @@ impl KVStoreWalletPersister {
 	}
 }
 
-impl WalletPersister for KVStoreWalletPersister {
+impl AsyncWalletPersister for KVStoreWalletPersister {
 	type Error = std::io::Error;
 
-	fn initialize(persister: &mut Self) -> Result<ChangeSet, Self::Error> {
-		// Return immediately if we have already been initialized.
-		if let Some(latest_change_set) = persister.latest_change_set.as_ref() {
-			return Ok(latest_change_set.clone());
-		}
+	fn initialize<'a>(
+		persister: &'a mut Self,
+	) -> Pin<Box<dyn Future<Output = Result<ChangeSet, Self::Error>> + Send + 'a>>
+	where
+		Self: 'a,
+	{
+		Box::pin(async move {
+			// Return immediately if we have already been initialized.
+			if let Some(latest_change_set) = persister.latest_change_set.as_ref() {
+				return Ok(latest_change_set.clone());
+			}
 
-		let change_set_opt = read_bdk_wallet_change_set(&*persister.kv_store, &*persister.logger)?;
+			let change_set_opt =
+				read_bdk_wallet_change_set(&*persister.kv_store, &*persister.logger).await?;
 
-		let change_set = match change_set_opt {
-			Some(persisted_change_set) => persisted_change_set,
-			None => {
-				// BDK docs state: "The implementation must return all data currently stored in the
-				// persister. If there is no data, return an empty changeset (using
-				// ChangeSet::default())."
-				ChangeSet::default()
-			},
-		};
-		persister.latest_change_set = Some(change_set.clone());
-		Ok(change_set)
+			let change_set = match change_set_opt {
+				Some(persisted_change_set) => persisted_change_set,
+				None => {
+					// BDK docs state: "The implementation must return all data currently stored in
+					// the persister. If there is no data, return an empty changeset (using
+					// ChangeSet::default())."
+					ChangeSet::default()
+				},
+			};
+			persister.latest_change_set = Some(change_set.clone());
+			Ok(change_set)
+		})
 	}
 
-	fn persist(persister: &mut Self, change_set: &ChangeSet) -> Result<(), Self::Error> {
-		if change_set.is_empty() {
-			return Ok(());
-		}
-
-		// We're allowed to fail here if we're not initialized, BDK docs state: "This method can fail if the
-		// persister is not initialized."
-		let latest_change_set = persister.latest_change_set.as_mut().ok_or_else(|| {
-			std::io::Error::new(
-				std::io::ErrorKind::Other,
-				"Wallet must be initialized before calling persist",
-			)
-		})?;
-
-		// Check that we'd never accidentally override any persisted data if the change set doesn't
-		// match our descriptor/change_descriptor/network.
-		if let Some(descriptor) = change_set.descriptor.as_ref() {
-			if latest_change_set.descriptor.is_some()
-				&& latest_change_set.descriptor.as_ref() != Some(descriptor)
-			{
-				debug_assert!(false, "Wallet descriptor must never change");
-				log_error!(
-					persister.logger,
-					"Wallet change set doesn't match persisted descriptor. This should never happen."
-				);
-				return Err(std::io::Error::new(
-					std::io::ErrorKind::InvalidData,
-					"Wallet change set doesn't match persisted descriptor. This should never happen."
-				));
-			} else {
-				latest_change_set.descriptor = Some(descriptor.clone());
-				write_bdk_wallet_descriptor(&descriptor, &*persister.kv_store, &*persister.logger)?;
+	fn persist<'a>(
+		persister: &'a mut Self, change_set: &'a ChangeSet,
+	) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'a>>
+	where
+		Self: 'a,
+	{
+		Box::pin(async move {
+			if change_set.is_empty() {
+				return Ok(());
 			}
-		}
 
-		if let Some(change_descriptor) = change_set.change_descriptor.as_ref() {
-			if latest_change_set.change_descriptor.is_some()
-				&& latest_change_set.change_descriptor.as_ref() != Some(change_descriptor)
-			{
-				debug_assert!(false, "Wallet change_descriptor must never change");
-				log_error!(
-					persister.logger,
-					"Wallet change set doesn't match persisted change_descriptor. This should never happen."
-				);
-				return Err(std::io::Error::new(
-					std::io::ErrorKind::InvalidData,
-					"Wallet change set doesn't match persisted change_descriptor. This should never happen."
-				));
-			} else {
-				latest_change_set.change_descriptor = Some(change_descriptor.clone());
-				write_bdk_wallet_change_descriptor(
-					&change_descriptor,
+			// We're allowed to fail here if we're not initialized, BDK docs state: "This method
+			// can fail if the persister is not initialized."
+			let latest_change_set = persister.latest_change_set.as_mut().ok_or_else(|| {
+				std::io::Error::new(
+					std::io::ErrorKind::Other,
+					"Wallet must be initialized before calling persist",
+				)
+			})?;
+
+			// Check that we'd never accidentally override any persisted data if the change set
+			// doesn't match our descriptor/change_descriptor/network.
+			if let Some(descriptor) = change_set.descriptor.as_ref() {
+				if latest_change_set.descriptor.is_some()
+					&& latest_change_set.descriptor.as_ref() != Some(descriptor)
+				{
+					debug_assert!(false, "Wallet descriptor must never change");
+					log_error!(
+						persister.logger,
+						"Wallet change set doesn't match persisted descriptor. This should never happen."
+					);
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						"Wallet change set doesn't match persisted descriptor. This should never happen."
+					));
+				} else {
+					latest_change_set.descriptor = Some(descriptor.clone());
+					write_bdk_wallet_descriptor(
+						&descriptor,
+						&*persister.kv_store,
+						&*persister.logger,
+					)
+					.await?;
+				}
+			}
+
+			if let Some(change_descriptor) = change_set.change_descriptor.as_ref() {
+				if latest_change_set.change_descriptor.is_some()
+					&& latest_change_set.change_descriptor.as_ref() != Some(change_descriptor)
+				{
+					debug_assert!(false, "Wallet change_descriptor must never change");
+					log_error!(
+						persister.logger,
+						"Wallet change set doesn't match persisted change_descriptor. This should never happen."
+					);
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						"Wallet change set doesn't match persisted change_descriptor. This should never happen."
+					));
+				} else {
+					latest_change_set.change_descriptor = Some(change_descriptor.clone());
+					write_bdk_wallet_change_descriptor(
+						&change_descriptor,
+						&*persister.kv_store,
+						&*persister.logger,
+					)
+					.await?;
+				}
+			}
+
+			if let Some(network) = change_set.network {
+				if latest_change_set.network.is_some() && latest_change_set.network != Some(network)
+				{
+					debug_assert!(false, "Wallet network must never change");
+					log_error!(
+						persister.logger,
+						"Wallet change set doesn't match persisted network. This should never happen."
+					);
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidData,
+						"Wallet change set doesn't match persisted network. This should never happen.",
+					));
+				} else {
+					latest_change_set.network = Some(network);
+					write_bdk_wallet_network(&network, &*persister.kv_store, &*persister.logger)
+						.await?;
+				}
+			}
+
+			debug_assert!(
+				latest_change_set.descriptor.is_some()
+					&& latest_change_set.change_descriptor.is_some()
+					&& latest_change_set.network.is_some(),
+				"descriptor, change_descriptor, and network are mandatory ChangeSet fields"
+			);
+
+			// Merge and persist the sub-changesets individually if necessary.
+			//
+			// According to the BDK team the individual sub-changesets can be persisted
+			// individually/non-atomically, "(h)owever, the localchain tip is used by block-by-block
+			// chain sources as a reference as to where to sync from, so I would persist that last",
+			// "I would write in this order: indexer, tx_graph, local_chain", which is why we follow
+			// this particular order.
+			if !change_set.indexer.is_empty() {
+				latest_change_set.indexer.merge(change_set.indexer.clone());
+				write_bdk_wallet_indexer(
+					&latest_change_set.indexer,
 					&*persister.kv_store,
-					&*persister.logger,
-				)?;
+					Arc::clone(&persister.logger),
+				)
+				.await?;
 			}
-		}
 
-		if let Some(network) = change_set.network {
-			if latest_change_set.network.is_some() && latest_change_set.network != Some(network) {
-				debug_assert!(false, "Wallet network must never change");
-				log_error!(
-					persister.logger,
-					"Wallet change set doesn't match persisted network. This should never happen."
-				);
-				return Err(std::io::Error::new(
-					std::io::ErrorKind::InvalidData,
-					"Wallet change set doesn't match persisted network. This should never happen.",
-				));
-			} else {
-				latest_change_set.network = Some(network);
-				write_bdk_wallet_network(&network, &*persister.kv_store, &*persister.logger)?;
+			if !change_set.tx_graph.is_empty() {
+				latest_change_set.tx_graph.merge(change_set.tx_graph.clone());
+				write_bdk_wallet_tx_graph(
+					&latest_change_set.tx_graph,
+					&*persister.kv_store,
+					Arc::clone(&persister.logger),
+				)
+				.await?;
 			}
-		}
 
-		debug_assert!(
-			latest_change_set.descriptor.is_some()
-				&& latest_change_set.change_descriptor.is_some()
-				&& latest_change_set.network.is_some(),
-			"descriptor, change_descriptor, and network are mandatory ChangeSet fields"
-		);
+			if !change_set.local_chain.is_empty() {
+				latest_change_set.local_chain.merge(change_set.local_chain.clone());
+				write_bdk_wallet_local_chain(
+					&latest_change_set.local_chain,
+					&*persister.kv_store,
+					Arc::clone(&persister.logger),
+				)
+				.await?;
+			}
 
-		// Merge and persist the sub-changesets individually if necessary.
-		//
-		// According to the BDK team the individual sub-changesets can be persisted
-		// individually/non-atomically, "(h)owever, the localchain tip is used by block-by-block
-		// chain sources as a reference as to where to sync from, so I would persist that last", "I
-		// would write in this order: indexer, tx_graph, local_chain", which is why we follow this
-		// particular order.
-		if !change_set.indexer.is_empty() {
-			latest_change_set.indexer.merge(change_set.indexer.clone());
-			write_bdk_wallet_indexer(
-				&latest_change_set.indexer,
-				&*persister.kv_store,
-				Arc::clone(&persister.logger),
-			)?;
-		}
-
-		if !change_set.tx_graph.is_empty() {
-			latest_change_set.tx_graph.merge(change_set.tx_graph.clone());
-			write_bdk_wallet_tx_graph(
-				&latest_change_set.tx_graph,
-				&*persister.kv_store,
-				Arc::clone(&persister.logger),
-			)?;
-		}
-
-		if !change_set.local_chain.is_empty() {
-			latest_change_set.local_chain.merge(change_set.local_chain.clone());
-			write_bdk_wallet_local_chain(
-				&latest_change_set.local_chain,
-				&*persister.kv_store,
-				Arc::clone(&persister.logger),
-			)?;
-		}
-
-		Ok(())
+			Ok(())
+		})
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -660,6 +660,7 @@ pub async fn open_channel_push_amt(
 				push_amount_msat,
 				None,
 			)
+			.await
 			.unwrap();
 	} else {
 		node_a
@@ -670,6 +671,7 @@ pub async fn open_channel_push_amt(
 				push_amount_msat,
 				None,
 			)
+			.await
 			.unwrap();
 	}
 	assert!(node_a.list_peers().iter().find(|c| { c.node_id == node_b.node_id() }).is_some());
@@ -748,6 +750,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 			Some(push_msat),
 			None,
 		)
+		.await
 		.unwrap();
 
 	assert_eq!(node_a.list_peers().first().unwrap().node_id, node_b.node_id());
@@ -1166,9 +1169,9 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	println!("\nB close_channel (force: {})", force_close);
 	if force_close {
 		tokio::time::sleep(Duration::from_secs(1)).await;
-		node_a.force_close_channel(&user_channel_id_a, node_b.node_id(), None).unwrap();
+		node_a.force_close_channel(&user_channel_id_a, node_b.node_id(), None).await.unwrap();
 	} else {
-		node_a.close_channel(&user_channel_id_a, node_b.node_id()).unwrap();
+		node_a.close_channel(&user_channel_id_a, node_b.node_id()).await.unwrap();
 	}
 
 	expect_event!(node_a, ChannelClosed);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -688,8 +688,8 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	node_a: TestNode, node_b: TestNode, bitcoind: &BitcoindClient, electrsd: &E, allow_0conf: bool,
 	expect_anchor_channel: bool, force_close: bool,
 ) {
-	let addr_a = node_a.onchain_payment().new_address().unwrap();
-	let addr_b = node_b.onchain_payment().new_address().unwrap();
+	let addr_a = node_a.onchain_payment().new_address().await.unwrap();
+	let addr_b = node_b.onchain_payment().new_address().await.unwrap();
 
 	let premine_amount_sat = if expect_anchor_channel { 2_125_000 } else { 2_100_000 };
 
@@ -1122,9 +1122,9 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	generate_blocks_and_wait(&bitcoind, electrsd, 1).await;
 
 	println!("\nB splices out to pay A");
-	let addr_a = node_a.onchain_payment().new_address().unwrap();
+	let addr_a = node_a.onchain_payment().new_address().await.unwrap();
 	let splice_out_sat = funding_amount_sat / 2;
-	node_b.splice_out(&user_channel_id_b, node_a.node_id(), &addr_a, splice_out_sat).unwrap();
+	node_b.splice_out(&user_channel_id_b, node_a.node_id(), &addr_a, splice_out_sat).await.unwrap();
 
 	expect_splice_pending_event!(node_a, node_b.node_id());
 	expect_splice_pending_event!(node_b, node_a.node_id());
@@ -1146,7 +1146,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 
 	println!("\nA splices in the splice-out payment from B");
 	let splice_in_sat = splice_out_sat;
-	node_a.splice_in(&user_channel_id_a, node_b.node_id(), splice_in_sat).unwrap();
+	node_a.splice_in(&user_channel_id_a, node_b.node_id(), splice_in_sat).await.unwrap();
 
 	expect_splice_pending_event!(node_a, node_b.node_id());
 	expect_splice_pending_event!(node_b, node_a.node_id());

--- a/tests/integration_tests_cln.rs
+++ b/tests/integration_tests_cln.rs
@@ -90,6 +90,7 @@ async fn test_cln() {
 	let funding_amount_sat = 1_000_000;
 
 	node.open_channel(cln_node_id, cln_address, funding_amount_sat, Some(500_000_000), None)
+		.await
 		.unwrap();
 
 	let funding_txo = common::expect_channel_pending_event!(node, cln_node_id);
@@ -121,7 +122,7 @@ async fn test_cln() {
 	cln_client.pay(&ldk_invoice.to_string(), Default::default()).unwrap();
 	common::expect_event!(node, PaymentReceived);
 
-	node.close_channel(&user_channel_id, cln_node_id).unwrap();
+	node.close_channel(&user_channel_id, cln_node_id).await.unwrap();
 	common::expect_event!(node, ChannelClosed);
 	node.stop().unwrap();
 }

--- a/tests/integration_tests_lnd.rs
+++ b/tests/integration_tests_lnd.rs
@@ -71,6 +71,7 @@ async fn test_lnd() {
 	let funding_amount_sat = 1_000_000;
 
 	node.open_channel(lnd_node_id, lnd_address, funding_amount_sat, Some(500_000_000), None)
+		.await
 		.unwrap();
 
 	let funding_txo = common::expect_channel_pending_event!(node, lnd_node_id);
@@ -117,7 +118,7 @@ async fn test_lnd() {
 	lnd.pay_invoice(&ldk_invoice.to_string()).await;
 	common::expect_event!(node, PaymentReceived);
 
-	node.close_channel(&user_channel_id, lnd_node_id).unwrap();
+	node.close_channel(&user_channel_id, lnd_node_id).await.unwrap();
 	common::expect_event!(node, ChannelClosed);
 	node.stop().unwrap();
 }

--- a/tests/reorg_test.rs
+++ b/tests/reorg_test.rs
@@ -126,9 +126,9 @@ proptest! {
 				let funding = nodes_funding_tx.get(&node.node_id()).expect("Funding tx not exist");
 
 				if force_close {
-					node.force_close_channel(&user_channel_id, next_node.node_id(), None).unwrap();
+					node.force_close_channel(&user_channel_id, next_node.node_id(), None).await.unwrap();
 				} else {
-					node.close_channel(&user_channel_id, next_node.node_id()).unwrap();
+					node.close_channel(&user_channel_id, next_node.node_id()).await.unwrap();
 				}
 
 				expect_event!(node, ChannelClosed);

--- a/tests/reorg_test.rs
+++ b/tests/reorg_test.rs
@@ -51,8 +51,10 @@ proptest! {
 			}
 
 			let amount_sat = 2_100_000;
-			let addr_nodes =
-				nodes.iter().map(|node| node.onchain_payment().new_address().unwrap()).collect::<Vec<_>>();
+			let mut addr_nodes = Vec::new();
+			for node in &nodes {
+				addr_nodes.push(node.onchain_payment().new_address().await.unwrap());
+			}
 			premine_and_distribute_funds(bitcoind, electrs, addr_nodes, Amount::from_sat(amount_sat)).await;
 
 			macro_rules! sync_wallets {


### PR DESCRIPTION
**This changeset was generated with the help of AI tooling (Claude Code) to get an impression of the work involved in migrating to fully async persistence. It is not intended to be merged as-is.**

This branch migrates all persistence operations in ldk-node from the synchronous `KVStoreSync` trait to LDK's async `KVStore` trait, eliminating blocking I/O from the runtime entirely.

The migration is broken into 8 incremental commits, each converting one subsystem and propagating async through its callers:

- **Use async ChainMonitor persister via `new_async_beta`**: Switch from `MonitorUpdatingPersister` to `MonitorUpdatingPersisterAsync`, using a single async persister for both startup reads and runtime persistence. Introduces `DynStoreRef` to work around higher-ranked lifetime issues with `Arc<dyn DynStoreTrait>`.

- **Convert `write_node_metrics` to async `KVStore`**: Split in-memory mutations from async persist calls to avoid holding write locks across `.await` points.

- **Convert `DataStore` persistence to async `KVStore`**: The largest commit, propagating async through all payment modules (bolt11, bolt12, spontaneous, unified), event handling, wallet, and chain sync. Uses the pattern of doing in-memory work under a lock, dropping the lock, then awaiting the persist.

- **Convert `PeerStore` persistence to async `KVStore`**: Makes peer management operations async, restructuring event handlers to avoid holding non-Send locks across await points.

- **Convert `StaticInvoiceStore` persistence to async `KVStore`**: Straightforward async conversion of static invoice read/write operations.

- **Convert BDK wallet persistence to `AsyncWalletPersister`**: Converts the BDK wallet layer from sync `WalletPersister` to `AsyncWalletPersister`, switching the persister to a `tokio::sync::Mutex`. Uses `block_in_place`+`block_on` for sync trait impls (`Listen`, `SignerProvider`).

- **Convert `export_pathfinding_scores` to async `KVStore`**.

- **Remove `KVStoreSync` from core traits and store implementations**: Final cleanup removing the `SyncAndAsyncKVStore` supertrait, all `KVStoreSync` impls from `SqliteStore`/`VssStore`/`InMemoryStore`, and the sync test infrastructure. Simplifies `DynStoreTrait` to async-only methods.

Across 31 files, 1301 insertions and 1516 deletions, the key recurring patterns are:
- Do in-memory work under lock, drop lock, then `.await` the persist
- Use `block_in_place`+`block_on` where sync trait boundaries require it (e.g., `Listen`, `SignerProvider`)
- Wrap `SqliteStore` calls in `async { ... .await }` inside `block_on` to ensure the tokio runtime context is available for `spawn_blocking`
