### PR TITLE
Fix flaky async_payment test due to non-deterministic event ordering

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -98,6 +98,34 @@ macro_rules! expect_channel_ready_event {
 
 pub(crate) use expect_channel_ready_event;
 
+macro_rules! expect_channel_ready_events {
+	($node:expr, $counterparty_node_id_a:expr, $counterparty_node_id_b:expr) => {{
+		let mut ids = Vec::new();
+		for _ in 0..2 {
+			match $node.next_event_async().await {
+				ref e @ Event::ChannelReady { counterparty_node_id, .. } => {
+					println!("{} got event {:?}", $node.node_id(), e);
+					ids.push(counterparty_node_id);
+					$node.event_handled().unwrap();
+				},
+				ref e => {
+					panic!("{} got unexpected event!: {:?}", std::stringify!($node), e);
+				},
+			}
+		}
+		assert!(
+			ids.contains(&Some($counterparty_node_id_a))
+				&& ids.contains(&Some($counterparty_node_id_b)),
+			"Expected ChannelReady events from {:?} and {:?}, but got {:?}",
+			$counterparty_node_id_a,
+			$counterparty_node_id_b,
+			ids
+		);
+	}};
+}
+
+pub(crate) use expect_channel_ready_events;
+
 macro_rules! expect_splice_pending_event {
 	($node:expr, $counterparty_node_id:expr) => {{
 		match $node.next_event_async().await {

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -18,12 +18,13 @@ use bitcoin::{Address, Amount, ScriptBuf, Txid};
 use common::logging::{init_log_logger, validate_log_entry, MultiNodeLogger, TestLogWriter};
 use common::{
 	bump_fee_and_broadcast, distribute_funds_unconfirmed, do_channel_full_cycle,
-	expect_channel_pending_event, expect_channel_ready_event, expect_event,
-	expect_payment_claimable_event, expect_payment_received_event, expect_payment_successful_event,
-	expect_splice_pending_event, generate_blocks_and_wait, open_channel, open_channel_push_amt,
-	premine_and_distribute_funds, premine_blocks, prepare_rbf, random_chain_source, random_config,
-	random_listening_addresses, setup_bitcoind_and_electrsd, setup_builder, setup_node,
-	setup_two_nodes, wait_for_tx, TestChainSource, TestStoreType, TestSyncStore,
+	expect_channel_pending_event, expect_channel_ready_event, expect_channel_ready_events,
+	expect_event, expect_payment_claimable_event, expect_payment_received_event,
+	expect_payment_successful_event, expect_splice_pending_event, generate_blocks_and_wait,
+	open_channel, open_channel_push_amt, premine_and_distribute_funds, premine_blocks, prepare_rbf,
+	random_chain_source, random_config, random_listening_addresses, setup_bitcoind_and_electrsd,
+	setup_builder, setup_node, setup_two_nodes, wait_for_tx, TestChainSource, TestStoreType,
+	TestSyncStore,
 };
 use ldk_node::config::{AsyncPaymentsRole, EsploraSyncConfig};
 use ldk_node::entropy::NodeEntropy;
@@ -1343,10 +1344,16 @@ async fn async_payment() {
 	node_receiver.sync_wallets().unwrap();
 
 	expect_channel_ready_event!(node_sender, node_sender_lsp.node_id());
-	expect_channel_ready_event!(node_sender_lsp, node_sender.node_id());
-	expect_channel_ready_event!(node_sender_lsp, node_receiver_lsp.node_id());
-	expect_channel_ready_event!(node_receiver_lsp, node_sender_lsp.node_id());
-	expect_channel_ready_event!(node_receiver_lsp, node_receiver.node_id());
+	expect_channel_ready_events!(
+		node_sender_lsp,
+		node_sender.node_id(),
+		node_receiver_lsp.node_id()
+	);
+	expect_channel_ready_events!(
+		node_receiver_lsp,
+		node_sender_lsp.node_id(),
+		node_receiver.node_id()
+	);
 	expect_channel_ready_event!(node_receiver, node_receiver_lsp.node_id());
 
 	let has_node_announcements = |node: &ldk_node::Node| {


### PR DESCRIPTION
node_sender_lsp and node_receiver_lsp each have two channels, so they receive two ChannelReady events whose order depends on timing. The test previously consumed these events in a fixed order, which could fail when the events arrive in the opposite order.

Reproduced locally by swapping the assertion order at line 1346-1347, which fails deterministically since the "normal" local ordering is the opposite of the one expected by the swapped assertions.

Add an expect_channel_ready_events\! macro that consumes two ChannelReady events and asserts both expected counterparties are present regardless of arrival order.

Fixes #798 