### PR TITLE
Replace `rand` with `getrandom` and `KeysManager` entropy in non-test…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ bip39 = { version = "2.0.0", features = ["rand"] }
 bip21 = { version = "0.5", features = ["std"], default-features = false }
 
 base64 = { version = "0.22.1", default-features = false, features = ["std"] }
-rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
+getrandom = { version = "0.3", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tokio = { version = "1.37", default-features = false, features = [ "rt-multi-thread", "time", "sync", "macros" ] }
 esplora-client = { version = "0.12", default-features = false, features = ["tokio", "async-https-rustls"] }
@@ -85,6 +85,7 @@ winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
 lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "b6c17c593a5d7bacb18fe3b9f69074a0596ae8f0", features = ["std", "_test_utils"] }
+rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"
 criterion = { version = "0.7.0", features = ["async_tokio"] }

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -35,8 +35,6 @@ use lightning::util::persist::{
 };
 use lightning::util::ser::{Readable, ReadableArgs, Writeable};
 use lightning_types::string::PrintableString;
-use rand::rngs::OsRng;
-use rand::TryRngCore;
 
 use super::*;
 use crate::chain::ChainSource;
@@ -72,7 +70,7 @@ pub(crate) fn read_or_generate_seed_file(
 		Ok(key)
 	} else {
 		let mut key = [0; WALLET_KEYS_SEED_LEN];
-		OsRng.try_fill_bytes(&mut key).map_err(|_| {
+		getrandom::fill(&mut key).map_err(|_| {
 			std::io::Error::new(std::io::ErrorKind::Other, "Failed to generate seed bytes")
 		})?;
 

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -20,6 +20,7 @@ use lightning::ln::channelmanager::{InterceptId, MIN_FINAL_CLTV_EXPIRY_DELTA};
 use lightning::ln::msgs::SocketAddress;
 use lightning::ln::types::ChannelId;
 use lightning::routing::router::{RouteHint, RouteHintHop};
+use lightning::sign::EntropySource;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, InvoiceBuilder, RoutingFees};
 use lightning_liquidity::events::LiquidityEvent;
 use lightning_liquidity::lsps0::ser::{LSPSDateTime, LSPSRequestId};
@@ -35,7 +36,6 @@ use lightning_liquidity::lsps2::service::LSPS2ServiceConfig as LdkLSPS2ServiceCo
 use lightning_liquidity::lsps2::utils::compute_opening_fee;
 use lightning_liquidity::{LiquidityClientConfig, LiquidityServiceConfig};
 use lightning_types::payment::PaymentHash;
-use rand::Rng;
 use tokio::sync::oneshot;
 
 use crate::builder::BuildError;
@@ -641,7 +641,9 @@ where
 						return;
 					};
 
-					let user_channel_id: u128 = rand::rng().random();
+					let user_channel_id: u128 = u128::from_ne_bytes(
+						self.keys_manager.get_secure_random_bytes()[..16].try_into().unwrap(),
+					);
 					let intercept_scid = self.channel_manager.get_intercept_scid();
 
 					if let Some(payment_size_msat) = payment_size_msat {


### PR DESCRIPTION
… code

`rand` is basically just a way to wrap `getrandom` with a chacha stream plus a bag of unrelated random utilities. Given we already have a way to wrap `getrandom` with a chacha stream, there's no point in relying on `rand` for it, so we simply drop it here.

Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>