### PR TITLE
wallet: expose next unused address

### DIFF
--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -64,6 +64,13 @@ impl OnchainPayment {
 		Ok(funding_address)
 	}
 
+	/// Retrieve the next unused on-chain/funding address.
+	pub fn next_address(&self) -> Result<Address, Error> {
+		let funding_address = self.wallet.get_next_address()?;
+		log_info!(self.logger, "Generated next funding address: {}", funding_address);
+		Ok(funding_address)
+	}
+
 	/// Send an on-chain payment to the given address.
 	///
 	/// This will respect any on-chain reserve we need to keep, i.e., won't allow to cut into

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -473,6 +473,18 @@ impl Wallet {
 		Ok(address_info.address)
 	}
 
+	pub(crate) fn get_next_address(&self) -> Result<bitcoin::Address, Error> {
+		let mut locked_wallet = self.inner.lock().unwrap();
+		let mut locked_persister = self.persister.lock().unwrap();
+
+		let address_info = locked_wallet.next_unused_address(KeychainKind::External);
+		locked_wallet.persist(&mut locked_persister).map_err(|e| {
+			log_error!(self.logger, "Failed to persist wallet: {}", e);
+			Error::PersistenceFailed
+		})?;
+		Ok(address_info.address)
+	}
+
 	pub(crate) fn get_new_internal_address(&self) -> Result<bitcoin::Address, Error> {
 		let mut locked_wallet = self.inner.lock().unwrap();
 		let mut locked_persister = self.persister.lock().unwrap();


### PR DESCRIPTION
I had an issue funding a node due to the existing `get_new_address` behavior:

- Call `get_new_address()` on a timer / loop when reporting the status of the node.
- After some # of calls, send funds to the returned address.
- On-chain balance isn't detected by the node.

IIUC, this is due to the gap limit here: https://github.com/lightningdevkit/ldk-node/blob/7ad0d630a4cd22c5527eadda843e8b80155daac1/src/chain/electrum.rs#L471

After manually recovering the funds with Sparrow and sending them to the first unused address, funds were picked up successfully.

The `next_unused_address` behavior seems much less surprising so I've added it here + used it successfully with my nodes. Even if it's not recommended in the doc examples for creating a channel, a doc note similar to what's on the `bdk_wallet` page may be useful.