### PR TITLE
Expose node-invariant features via NodeStatus

### DIFF
--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -44,6 +44,7 @@ pub use lightning_liquidity::lsps0::ser::LSPSDateTime;
 pub use lightning_liquidity::lsps1::msgs::{
 	LSPS1ChannelInfo, LSPS1OrderId, LSPS1OrderParams, LSPS1PaymentState,
 };
+use lightning_types::features::NodeFeatures as LdkNodeFeatures;
 pub use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 pub use lightning_types::string::UntrustedString;
 use vss_client::headers::{
@@ -1517,6 +1518,301 @@ pub enum ClosureReason {
 		/// The required feerate we enforce.
 		required_feerate_sat_per_kw: u32,
 	},
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Debug, Eq)]
+pub struct NodeFeatures {
+	pub(crate) inner: LdkNodeFeatures,
+}
+
+impl NodeFeatures {
+	/// Constructs node features from big-endian BOLT 9 encoded bytes.
+	#[uniffi::constructor]
+	pub fn from_bytes(bytes: &[u8]) -> Self {
+		Self { inner: LdkNodeFeatures::from_be_bytes(bytes.to_vec()) }
+	}
+
+	/// Returns the BOLT 9 big-endian encoded representation of these features.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.inner.encode()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_data_loss_protect`.
+	pub fn supports_data_loss_protect(&self) -> bool {
+		self.inner.supports_data_loss_protect()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_data_loss_protect`.
+	pub fn requires_data_loss_protect(&self) -> bool {
+		self.inner.requires_data_loss_protect()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_upfront_shutdown_script`.
+	pub fn supports_upfront_shutdown_script(&self) -> bool {
+		self.inner.supports_upfront_shutdown_script()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_upfront_shutdown_script`.
+	pub fn requires_upfront_shutdown_script(&self) -> bool {
+		self.inner.requires_upfront_shutdown_script()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `gossip_queries`.
+	pub fn supports_gossip_queries(&self) -> bool {
+		self.inner.supports_gossip_queries()
+	}
+
+	/// Whether this node's `node_announcement` requires `gossip_queries`.
+	pub fn requires_gossip_queries(&self) -> bool {
+		self.inner.requires_gossip_queries()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `var_onion_optin`.
+	pub fn supports_variable_length_onion(&self) -> bool {
+		self.inner.supports_variable_length_onion()
+	}
+
+	/// Whether this node's `node_announcement` requires `var_onion_optin`.
+	pub fn requires_variable_length_onion(&self) -> bool {
+		self.inner.requires_variable_length_onion()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_static_remotekey`.
+	pub fn supports_static_remote_key(&self) -> bool {
+		self.inner.supports_static_remote_key()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_static_remotekey`.
+	pub fn requires_static_remote_key(&self) -> bool {
+		self.inner.requires_static_remote_key()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `payment_secret`.
+	pub fn supports_payment_secret(&self) -> bool {
+		self.inner.supports_payment_secret()
+	}
+
+	/// Whether this node's `node_announcement` requires `payment_secret`.
+	pub fn requires_payment_secret(&self) -> bool {
+		self.inner.requires_payment_secret()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `basic_mpp`.
+	pub fn supports_basic_mpp(&self) -> bool {
+		self.inner.supports_basic_mpp()
+	}
+
+	/// Whether this node's `node_announcement` requires `basic_mpp`.
+	pub fn requires_basic_mpp(&self) -> bool {
+		self.inner.requires_basic_mpp()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_support_large_channel`.
+	pub fn supports_wumbo(&self) -> bool {
+		self.inner.supports_wumbo()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_support_large_channel`.
+	pub fn requires_wumbo(&self) -> bool {
+		self.inner.requires_wumbo()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_anchors_nonzero_fee_htlc_tx`.
+	pub fn supports_anchors_nonzero_fee_htlc_tx(&self) -> bool {
+		self.inner.supports_anchors_nonzero_fee_htlc_tx()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_anchors_nonzero_fee_htlc_tx`.
+	pub fn requires_anchors_nonzero_fee_htlc_tx(&self) -> bool {
+		self.inner.requires_anchors_nonzero_fee_htlc_tx()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_anchors_zero_fee_htlc_tx`.
+	pub fn supports_anchors_zero_fee_htlc_tx(&self) -> bool {
+		self.inner.supports_anchors_zero_fee_htlc_tx()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_anchors_zero_fee_htlc_tx`.
+	pub fn requires_anchors_zero_fee_htlc_tx(&self) -> bool {
+		self.inner.requires_anchors_zero_fee_htlc_tx()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_route_blinding`.
+	pub fn supports_route_blinding(&self) -> bool {
+		self.inner.supports_route_blinding()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_route_blinding`.
+	pub fn requires_route_blinding(&self) -> bool {
+		self.inner.requires_route_blinding()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `opt_shutdown_anysegwit`.
+	pub fn supports_shutdown_anysegwit(&self) -> bool {
+		self.inner.supports_shutdown_anysegwit()
+	}
+
+	/// Whether this node's `node_announcement` requires `opt_shutdown_anysegwit`.
+	pub fn requires_shutdown_anysegwit(&self) -> bool {
+		self.inner.requires_shutdown_anysegwit()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_dual_fund`.
+	pub fn supports_dual_fund(&self) -> bool {
+		self.inner.supports_dual_fund()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_dual_fund`.
+	pub fn requires_dual_fund(&self) -> bool {
+		self.inner.requires_dual_fund()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_taproot`.
+	pub fn supports_taproot(&self) -> bool {
+		self.inner.supports_taproot()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_taproot`.
+	pub fn requires_taproot(&self) -> bool {
+		self.inner.requires_taproot()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_quiesce`.
+	pub fn supports_quiescence(&self) -> bool {
+		self.inner.supports_quiescence()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_quiesce`.
+	pub fn requires_quiescence(&self) -> bool {
+		self.inner.requires_quiescence()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_onion_messages`.
+	pub fn supports_onion_messages(&self) -> bool {
+		self.inner.supports_onion_messages()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_onion_messages`.
+	pub fn requires_onion_messages(&self) -> bool {
+		self.inner.requires_onion_messages()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_provide_storage`.
+	pub fn supports_provide_storage(&self) -> bool {
+		self.inner.supports_provide_storage()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_provide_storage`.
+	pub fn requires_provide_storage(&self) -> bool {
+		self.inner.requires_provide_storage()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_channel_type`.
+	pub fn supports_channel_type(&self) -> bool {
+		self.inner.supports_channel_type()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_channel_type`.
+	pub fn requires_channel_type(&self) -> bool {
+		self.inner.requires_channel_type()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_scid_alias`.
+	pub fn supports_scid_privacy(&self) -> bool {
+		self.inner.supports_scid_privacy()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_scid_alias`.
+	pub fn requires_scid_privacy(&self) -> bool {
+		self.inner.requires_scid_privacy()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_zeroconf`.
+	pub fn supports_zero_conf(&self) -> bool {
+		self.inner.supports_zero_conf()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_zeroconf`.
+	pub fn requires_zero_conf(&self) -> bool {
+		self.inner.requires_zero_conf()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `keysend`.
+	pub fn supports_keysend(&self) -> bool {
+		self.inner.supports_keysend()
+	}
+
+	/// Whether this node's `node_announcement` requires `keysend`.
+	pub fn requires_keysend(&self) -> bool {
+		self.inner.requires_keysend()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_trampoline`.
+	pub fn supports_trampoline_routing(&self) -> bool {
+		self.inner.supports_trampoline_routing()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_trampoline`.
+	pub fn requires_trampoline_routing(&self) -> bool {
+		self.inner.requires_trampoline_routing()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_simple_close`.
+	pub fn supports_simple_close(&self) -> bool {
+		self.inner.supports_simple_close()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_simple_close`.
+	pub fn requires_simple_close(&self) -> bool {
+		self.inner.requires_simple_close()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_splice`.
+	pub fn supports_splicing(&self) -> bool {
+		self.inner.supports_splicing()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_splice`.
+	pub fn requires_splicing(&self) -> bool {
+		self.inner.requires_splicing()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for `option_zero_fee_commitments`.
+	pub fn supports_anchor_zero_fee_commitments(&self) -> bool {
+		self.inner.supports_anchor_zero_fee_commitments()
+	}
+
+	/// Whether this node's `node_announcement` requires `option_zero_fee_commitments`.
+	pub fn requires_anchor_zero_fee_commitments(&self) -> bool {
+		self.inner.requires_anchor_zero_fee_commitments()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for HTLC hold.
+	pub fn supports_htlc_hold(&self) -> bool {
+		self.inner.supports_htlc_hold()
+	}
+
+	/// Whether this node's `node_announcement` requires HTLC hold.
+	pub fn requires_htlc_hold(&self) -> bool {
+		self.inner.requires_htlc_hold()
+	}
+
+	/// Whether this node's `node_announcement` advertises support for DNS resolution.
+	pub fn supports_dns_resolution(&self) -> bool {
+		self.inner.supports_dns_resolution()
+	}
+
+	/// Whether this node's `node_announcement` requires DNS resolution.
+	pub fn requires_dns_resolution(&self) -> bool {
+		self.inner.requires_dns_resolution()
+	}
+}
+
+impl From<LdkNodeFeatures> for NodeFeatures {
+	fn from(features: LdkNodeFeatures) -> Self {
+		Self { inner: features }
+	}
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(cycle_tests)]
 use std::{any::Any, sync::Weak};
 
+use crate::ffi::maybe_wrap;
 pub use balance::{BalanceDetails, LightningBalance, PendingSweepBalance};
 pub use bip39;
 pub use bitcoin;
@@ -151,7 +152,8 @@ use lightning::ln::chan_utils::FUNDING_TRANSACTION_WITNESS_WEIGHT;
 use lightning::ln::channel_state::ChannelDetails as LdkChannelDetails;
 pub use lightning::ln::channel_state::ChannelShutdownState;
 use lightning::ln::channelmanager::PaymentId;
-use lightning::ln::msgs::SocketAddress;
+use lightning::ln::msgs::{BaseMessageHandler, SocketAddress};
+use lightning::ln::peer_handler::CustomMessageHandler;
 use lightning::routing::gossip::NodeAlias;
 use lightning::sign::EntropySource;
 use lightning::util::persist::KVStoreSync;
@@ -160,6 +162,7 @@ use lightning_background_processor::process_events_async;
 pub use lightning_invoice;
 pub use lightning_liquidity;
 pub use lightning_types;
+use lightning_types::features::NodeFeatures as LdkNodeFeatures;
 use liquidity::{LSPS1Liquidity, LiquiditySource};
 use lnurl_auth::LnurlAuth;
 use logger::{log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
@@ -182,6 +185,11 @@ pub use vss_client;
 
 use crate::scoring::setup_background_pathfinding_scores_sync;
 use crate::wallet::FundingAmount;
+
+#[cfg(not(feature = "uniffi"))]
+type NodeFeatures = LdkNodeFeatures;
+#[cfg(feature = "uniffi")]
+type NodeFeatures = Arc<crate::ffi::NodeFeatures>;
 
 #[cfg(feature = "uniffi")]
 uniffi::include_scaffolding!("ldk_node");
@@ -775,6 +783,7 @@ impl Node {
 			locked_node_metrics.latest_pathfinding_scores_sync_timestamp;
 		let latest_node_announcement_broadcast_timestamp =
 			locked_node_metrics.latest_node_announcement_broadcast_timestamp;
+		let node_features = maybe_wrap(self.node_features());
 
 		NodeStatus {
 			is_running,
@@ -786,6 +795,7 @@ impl Node {
 			latest_rgs_snapshot_timestamp,
 			latest_pathfinding_scores_sync_timestamp,
 			latest_node_announcement_broadcast_timestamp,
+			node_features,
 		}
 	}
 
@@ -2053,6 +2063,28 @@ impl Node {
 			Error::PersistenceFailed
 		})
 	}
+
+	/// Return the features used in node announcement.
+	fn node_features(&self) -> LdkNodeFeatures {
+		let gossip_features = match self.gossip_source.as_gossip_sync() {
+			lightning_background_processor::GossipSync::P2P(p2p_gossip_sync) => {
+				p2p_gossip_sync.provided_node_features()
+			},
+			lightning_background_processor::GossipSync::Rapid(_) => LdkNodeFeatures::empty(),
+			lightning_background_processor::GossipSync::None => {
+				unreachable!("We must always have a gossip sync!")
+			},
+		};
+		self.channel_manager.node_features()
+			| self.chain_monitor.provided_node_features()
+			| self.onion_messenger.provided_node_features()
+			| gossip_features
+			| self
+				.liquidity_source
+				.as_ref()
+				.map(|ls| ls.liquidity_manager().provided_node_features())
+				.unwrap_or_else(LdkNodeFeatures::empty)
+	}
 }
 
 impl Drop for Node {
@@ -2114,6 +2146,8 @@ pub struct NodeStatus {
 	///
 	/// Will be `None` if we have no public channels or we haven't broadcasted yet.
 	pub latest_node_announcement_broadcast_timestamp: Option<u64>,
+	/// The features advertised in this node's `node_announcement` message.
+	pub node_features: NodeFeatures,
 }
 
 /// Status fields that are persisted across restarts.


### PR DESCRIPTION
## What this PR does
For users interested in features announced in `node_announcement`, we make node_features available via `Node::status()`. 

The plan is to modify `ldk-server`'s `handle_get_node_info_request` and make features available on `GetNodeInfoResponse` so that the node's supported features are available to any requesting client. 

`lnrpc` and `cln-grpc` make these fields available in the response to `get_node_info`.

This is in relation to an exploratory `sim-ln` [PR](https://github.com/enigbe/sim-ln/pull/1) seeking to support/integrate `ldk-node/server`.