### PR TITLE
Update RGS URLs in docs to use v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fn main() {
 	builder.set_network(Network::Testnet);
 	builder.set_chain_source_esplora("https://blockstream.info/testnet/api".to_string(), None);
 	builder.set_gossip_source_rgs(
-		"https://rapidsync.lightningdevkit.org/testnet/snapshot".to_string(),
+		"https://rapidsync.lightningdevkit.org/testnet/v2/snapshot".to_string(),
 	);
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! 	builder.set_network(Network::Testnet);
 //! 	builder.set_chain_source_esplora("https://blockstream.info/testnet/api".to_string(), None);
 //! 	builder.set_gossip_source_rgs(
-//! 		"https://rapidsync.lightningdevkit.org/testnet/snapshot".to_string(),
+//! 		"https://rapidsync.lightningdevkit.org/testnet/v2/snapshot".to_string(),
 //! 	);
 //!
 //! 	let mnemonic = generate_entropy_mnemonic(None);


### PR DESCRIPTION
We shipped RGS v2 a while back, overdue that we update the docs to point to the 'new' URLs.