### PR TITLE
Expose Display, Debug, and Eq for HRN bindings

### DIFF
--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -382,7 +382,8 @@ impl std::fmt::Display for Offer {
 /// This struct can also be used for LN-Address recipients.
 ///
 /// [Homograph Attacks]: https://en.wikipedia.org/wiki/IDN_homograph_attack
-#[derive(uniffi::Object)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq)]
 pub struct HumanReadableName {
 	pub(crate) inner: LdkHumanReadableName,
 }
@@ -436,6 +437,12 @@ impl Deref for HumanReadableName {
 impl AsRef<LdkHumanReadableName> for HumanReadableName {
 	fn as_ref(&self) -> &LdkHumanReadableName {
 		self.deref()
+	}
+}
+
+impl std::fmt::Display for HumanReadableName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.inner)
 	}
 }
 
@@ -1986,5 +1993,22 @@ mod tests {
 		assert_eq!(ldk_invoice.encode(), wrapped_invoice.encode());
 
 		assert_eq!(ldk_invoice.signable_hash().to_vec(), wrapped_invoice.signable_hash());
+	}
+
+	#[test]
+	fn test_hrn_traits() {
+		let encoded = "alice@lightning.space";
+		let hrn1 = HumanReadableName::from_encoded(encoded).unwrap();
+		let hrn2 = HumanReadableName::from_encoded(encoded).unwrap();
+
+		assert_eq!(hrn1.to_string(), "₿alice@lightning.space");
+
+		assert_eq!(hrn1, hrn2);
+
+		let debug_output = format!("{:?}", hrn1);
+		assert!(debug_output.contains("HumanReadableName"));
+
+		let hrn3 = hrn1;
+		assert_eq!(hrn1, hrn3);
 	}
 }


### PR DESCRIPTION
### Description
Post-LDK 0.2 (which has `Display` implementation for `HumanReadableName` - https://github.com/lightningdevkit/rust-lightning/pull/3829), we need to ensure that the human-readable naming conventions present in the rust-lightning struct are accessible via the language bindings here. This PR updates the `HumanReadableName` wrapper to export core traits via `UniFFI`.

### Changes
- Updated `HumanReadableName` wrapper struct to derive `Clone, Copy, Debug, Hash, PartialEq, Eq`.
- Added `#[uniffi::export(Debug, Display, Eq)]` to the wrapper struct definition.
- Implemented `std::fmt::Display` for the wrapper by delegating to the 
  inner `LdkHumanReadableName` implementation (ensuring the ₿ prefix is preserved).
- Added a comprehensive test case verifying:
    - BIP-353 string formatting (`Display`).
    - Object equality (`Eq`).
    - Debug string generation (`Debug`).
    - Copy semantics.

Fixes: #579 