### PR TITLE
Expose ChannelCounterparty and ReserveType in ChannelDetails

### DIFF
--- a/bindings/python/src/ldk_node/test_ldk_node.py
+++ b/bindings/python/src/ldk_node/test_ldk_node.py
@@ -121,6 +121,29 @@ def expect_event(node, expected_event_type):
     return event 
 
 
+def assert_feature_helpers_return_bool(test_case, features):
+    feature_methods = [
+        method_name for method_name in dir(features)
+        if method_name.startswith("supports_") or method_name.startswith("requires_")
+    ]
+
+    test_case.assertGreater(len(feature_methods), 0)
+    for method_name in feature_methods:
+        with test_case.subTest(method_name=method_name):
+            test_case.assertIsInstance(getattr(features, method_name)(), bool)
+
+
+def node_features_exposed(test_case, node_features):
+    test_case.assertIsInstance(node_features, NodeFeatures)
+    assert_feature_helpers_return_bool(test_case, node_features)
+
+
+def init_features_exposed(test_case, init_features):
+    test_case.assertIsInstance(init_features, InitFeatures)
+    assert_feature_helpers_return_bool(test_case, init_features)
+    test_case.assertIsInstance(init_features.initial_routing_sync(), bool)
+
+
 
 class TestLdkNode(unittest.TestCase):
     def setUp(self):
@@ -152,6 +175,10 @@ class TestLdkNode(unittest.TestCase):
         node_2.start()
         node_id_2 = node_2.node_id()
         print("Node ID 2:", node_id_2)
+
+        # Check node-announcement features exposed through NodeStatus.
+        for node in [node_1, node_2]:
+            node_features_exposed(self, node.status().node_features)
 
         address_1 = node_1.onchain_payment().new_address()
         txid_1 = send_to_address(address_1, 100000)
@@ -199,6 +226,10 @@ class TestLdkNode(unittest.TestCase):
         print("funding_txo:", funding_txid)
 
         channel_ready_event_2 = expect_event(node_2, Event.CHANNEL_READY)
+
+        # Check negotiated init features exposed through ChannelDetails.
+        for channel in [node_1.list_channels()[0], node_2.list_channels()[0]]:
+            init_features_exposed(self, channel.counterparty.features)
 
         description = Bolt11InvoiceDescription.DIRECT("asdf")
         invoice = node_2.bolt11_payment().receive(2500000, description, 9217)

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -1526,6 +1526,7 @@ pub struct NodeFeatures {
 	pub(crate) inner: LdkNodeFeatures,
 }
 
+#[uniffi::export]
 impl NodeFeatures {
 	/// Constructs node features from big-endian BOLT 9 encoded bytes.
 	#[uniffi::constructor]
@@ -1816,10 +1817,12 @@ impl From<LdkNodeFeatures> for NodeFeatures {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Debug, Eq)]
 pub struct InitFeatures {
 	pub(crate) inner: LdkInitFeatures,
 }
 
+#[uniffi::export]
 impl InitFeatures {
 	/// Constructs init features from big-endian BOLT 9 encoded bytes.
 	#[uniffi::constructor]
@@ -1832,209 +1835,259 @@ impl InitFeatures {
 		self.inner.encode()
 	}
 
-	/// Whether the peer supports `option_static_remotekey`.
-	///
-	/// This ensures the non-broadcaster's output pays directly to their specified key,
-	/// simplifying recovery if a channel is force-closed.
+	/// Whether the peer's `init` message advertises support for `option_static_remotekey`.
 	pub fn supports_static_remote_key(&self) -> bool {
 		self.inner.supports_static_remote_key()
 	}
 
-	/// Whether the peer supports `option_anchors_zero_fee_htlc_tx`.
-	///
-	/// Anchor channels allow fee-bumping commitment transactions after broadcast,
-	/// improving on-chain fee management.
+	/// Whether the peer's `init` message requires `option_static_remotekey`.
+	pub fn requires_static_remote_key(&self) -> bool {
+		self.inner.requires_static_remote_key()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_anchors_zero_fee_htlc_tx`.
 	pub fn supports_anchors_zero_fee_htlc_tx(&self) -> bool {
 		self.inner.supports_anchors_zero_fee_htlc_tx()
 	}
 
-	/// Whether the peer supports `option_anchors_nonzero_fee_htlc_tx`.
-	///
-	/// The initial version of anchor outputs, which was later found to be
-	/// vulnerable and superseded by `option_anchors_zero_fee_htlc_tx`.
+	/// Whether the peer's `init` message requires `option_anchors_zero_fee_htlc_tx`.
+	pub fn requires_anchors_zero_fee_htlc_tx(&self) -> bool {
+		self.inner.requires_anchors_zero_fee_htlc_tx()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_anchors_nonzero_fee_htlc_tx`.
 	pub fn supports_anchors_nonzero_fee_htlc_tx(&self) -> bool {
 		self.inner.supports_anchors_nonzero_fee_htlc_tx()
 	}
 
-	/// Whether the peer supports `option_support_large_channel`.
-	///
-	/// When supported, channels larger than 2^24 satoshis (≈0.168 BTC) may be opened.
+	/// Whether the peer's `init` message requires `option_anchors_nonzero_fee_htlc_tx`.
+	pub fn requires_anchors_nonzero_fee_htlc_tx(&self) -> bool {
+		self.inner.requires_anchors_nonzero_fee_htlc_tx()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_support_large_channel`.
 	pub fn supports_wumbo(&self) -> bool {
 		self.inner.supports_wumbo()
 	}
 
-	/// Whether the peer supports `option_route_blinding`.
-	///
-	/// Route blinding allows the recipient to hide their node identity and
-	/// last-hop channel from the sender.
+	/// Whether the peer's `init` message requires `option_support_large_channel`.
+	pub fn requires_wumbo(&self) -> bool {
+		self.inner.requires_wumbo()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_route_blinding`.
 	pub fn supports_route_blinding(&self) -> bool {
 		self.inner.supports_route_blinding()
 	}
 
-	/// Whether the peer supports `option_onion_messages`.
-	///
-	/// Onion messages enable communication over the Lightning Network without
-	/// requiring a payment, used by BOLT 12 offers and async payments.
+	/// Whether the peer's `init` message requires `option_route_blinding`.
+	pub fn requires_route_blinding(&self) -> bool {
+		self.inner.requires_route_blinding()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_onion_messages`.
 	pub fn supports_onion_messages(&self) -> bool {
 		self.inner.supports_onion_messages()
 	}
 
-	/// Whether the peer supports `option_scid_alias`.
-	///
-	/// When supported, the peer will only forward using short channel ID aliases,
-	/// preventing the real channel UTXO from being revealed during routing.
+	/// Whether the peer's `init` message requires `option_onion_messages`.
+	pub fn requires_onion_messages(&self) -> bool {
+		self.inner.requires_onion_messages()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_scid_alias`.
 	pub fn supports_scid_privacy(&self) -> bool {
 		self.inner.supports_scid_privacy()
 	}
 
-	/// Whether the peer supports `option_zeroconf`.
-	///
-	/// Zero-conf channels can be used immediately without waiting for
-	/// on-chain funding confirmations.
+	/// Whether the peer's `init` message requires `option_scid_alias`.
+	pub fn requires_scid_privacy(&self) -> bool {
+		self.inner.requires_scid_privacy()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_zeroconf`.
 	pub fn supports_zero_conf(&self) -> bool {
 		self.inner.supports_zero_conf()
 	}
 
-	/// Whether the peer supports `option_dual_fund`.
-	///
-	/// Dual-funded channels allow both parties to contribute funds
-	/// to the channel opening transaction.
+	/// Whether the peer's `init` message requires `option_zeroconf`.
+	pub fn requires_zero_conf(&self) -> bool {
+		self.inner.requires_zero_conf()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_dual_fund`.
 	pub fn supports_dual_fund(&self) -> bool {
 		self.inner.supports_dual_fund()
 	}
 
-	/// Whether the peer supports `option_quiesce`.
-	///
-	/// Quiescence is a prerequisite for splicing, allowing both sides to
-	/// pause HTLC activity before modifying the funding transaction.
+	/// Whether the peer's `init` message requires `option_dual_fund`.
+	pub fn requires_dual_fund(&self) -> bool {
+		self.inner.requires_dual_fund()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_quiesce`.
 	pub fn supports_quiescence(&self) -> bool {
 		self.inner.supports_quiescence()
 	}
 
-	/// Whether the peer supports `option_data_loss_protect`.
-	///
-	/// Allows a node that has fallen behind (e.g., restored from backup)
-	/// to detect that it is out of date and close the channel safely.
+	/// Whether the peer's `init` message requires `option_quiesce`.
+	pub fn requires_quiescence(&self) -> bool {
+		self.inner.requires_quiescence()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_data_loss_protect`.
 	pub fn supports_data_loss_protect(&self) -> bool {
 		self.inner.supports_data_loss_protect()
 	}
 
-	/// Whether the peer supports `option_upfront_shutdown_script`.
-	///
-	/// Commits to a shutdown scriptpubkey when opening a channel,
-	/// preventing a compromised key from redirecting closing funds.
+	/// Whether the peer's `init` message requires `option_data_loss_protect`.
+	pub fn requires_data_loss_protect(&self) -> bool {
+		self.inner.requires_data_loss_protect()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_upfront_shutdown_script`.
 	pub fn supports_upfront_shutdown_script(&self) -> bool {
 		self.inner.supports_upfront_shutdown_script()
 	}
 
-	/// Whether the peer supports `gossip_queries`.
-	///
-	/// Indicates the peer has useful gossip to share and supports
-	/// gossip query messages for synchronization.
+	/// Whether the peer's `init` message requires `option_upfront_shutdown_script`.
+	pub fn requires_upfront_shutdown_script(&self) -> bool {
+		self.inner.requires_upfront_shutdown_script()
+	}
+
+	/// Whether the peer's `init` message advertises support for `gossip_queries`.
 	pub fn supports_gossip_queries(&self) -> bool {
 		self.inner.supports_gossip_queries()
 	}
 
-	/// Whether the peer supports `var_onion_optin`.
-	///
-	/// Requires variable-length routing onion payloads, which is
-	/// assumed to be supported by all modern Lightning nodes.
+	/// Whether the peer's `init` message requires `gossip_queries`.
+	pub fn requires_gossip_queries(&self) -> bool {
+		self.inner.requires_gossip_queries()
+	}
+
+	/// Whether the peer's `init` message advertises support for `var_onion_optin`.
 	pub fn supports_variable_length_onion(&self) -> bool {
 		self.inner.supports_variable_length_onion()
 	}
 
-	/// Whether the peer supports `payment_secret`.
-	///
-	/// Payment secrets prevent forwarding nodes from probing
-	/// payment recipients. Assumed to be supported by all modern nodes.
+	/// Whether the peer's `init` message requires `var_onion_optin`.
+	pub fn requires_variable_length_onion(&self) -> bool {
+		self.inner.requires_variable_length_onion()
+	}
+
+	/// Whether the peer's `init` message advertises support for `payment_secret`.
 	pub fn supports_payment_secret(&self) -> bool {
 		self.inner.supports_payment_secret()
 	}
 
-	/// Whether the peer supports `basic_mpp`.
-	///
-	/// Multi-part payments allow splitting a payment across multiple
-	/// routes for improved reliability and liquidity utilization.
+	/// Whether the peer's `init` message requires `payment_secret`.
+	pub fn requires_payment_secret(&self) -> bool {
+		self.inner.requires_payment_secret()
+	}
+
+	/// Whether the peer's `init` message advertises support for `basic_mpp`.
 	pub fn supports_basic_mpp(&self) -> bool {
 		self.inner.supports_basic_mpp()
 	}
 
-	/// Whether the peer supports `opt_shutdown_anysegwit`.
-	///
-	/// Allows future segwit versions in the shutdown script,
-	/// enabling closing to Taproot or later output types.
+	/// Whether the peer's `init` message requires `basic_mpp`.
+	pub fn requires_basic_mpp(&self) -> bool {
+		self.inner.requires_basic_mpp()
+	}
+
+	/// Whether the peer's `init` message advertises support for `opt_shutdown_anysegwit`.
 	pub fn supports_shutdown_anysegwit(&self) -> bool {
 		self.inner.supports_shutdown_anysegwit()
 	}
 
-	/// Whether the peer supports `option_channel_type`.
-	///
-	/// Supports explicit channel type negotiation during channel opening.
+	/// Whether the peer's `init` message requires `opt_shutdown_anysegwit`.
+	pub fn requires_shutdown_anysegwit(&self) -> bool {
+		self.inner.requires_shutdown_anysegwit()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_channel_type`.
 	pub fn supports_channel_type(&self) -> bool {
 		self.inner.supports_channel_type()
 	}
 
-	/// Whether the peer supports `option_trampoline`.
-	///
-	/// Trampoline routing allows lightweight nodes to delegate
-	/// pathfinding to an intermediate trampoline node.
+	/// Whether the peer's `init` message requires `option_channel_type`.
+	pub fn requires_channel_type(&self) -> bool {
+		self.inner.requires_channel_type()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_trampoline`.
 	pub fn supports_trampoline_routing(&self) -> bool {
 		self.inner.supports_trampoline_routing()
 	}
 
-	/// Whether the peer supports `option_simple_close`.
-	///
-	/// Simplified closing negotiation reduces the number of
-	/// round trips needed for a cooperative channel close.
+	/// Whether the peer's `init` message requires `option_trampoline`.
+	pub fn requires_trampoline_routing(&self) -> bool {
+		self.inner.requires_trampoline_routing()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_simple_close`.
 	pub fn supports_simple_close(&self) -> bool {
 		self.inner.supports_simple_close()
 	}
 
-	/// Whether the peer supports `option_splice`.
-	///
-	/// Splicing allows replacing the funding transaction with a new one,
-	/// enabling on-the-fly capacity changes without closing the channel.
+	/// Whether the peer's `init` message requires `option_simple_close`.
+	pub fn requires_simple_close(&self) -> bool {
+		self.inner.requires_simple_close()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_splice`.
 	pub fn supports_splicing(&self) -> bool {
 		self.inner.supports_splicing()
 	}
 
-	/// Whether the peer supports `option_provide_storage`.
-	///
-	/// Indicates the node offers to store encrypted backup data
-	/// on behalf of its peers.
+	/// Whether the peer's `init` message requires `option_splice`.
+	pub fn requires_splicing(&self) -> bool {
+		self.inner.requires_splicing()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_provide_storage`.
 	pub fn supports_provide_storage(&self) -> bool {
 		self.inner.supports_provide_storage()
 	}
 
-	/// Whether the peer set `initial_routing_sync`.
-	///
-	/// Indicates the sending node needs a complete routing information dump.
-	/// Per BOLT #9, this feature has no even (required) bit.
+	/// Whether the peer's `init` message requires `option_provide_storage`.
+	pub fn requires_provide_storage(&self) -> bool {
+		self.inner.requires_provide_storage()
+	}
+
+	/// Whether the peer's `init` message set `initial_routing_sync`.
 	pub fn initial_routing_sync(&self) -> bool {
 		self.inner.initial_routing_sync()
 	}
 
-	/// Whether the peer supports `option_taproot`.
-	///
-	/// Taproot channels use MuSig2-based multisig for funding outputs,
-	/// improving privacy and efficiency.
+	/// Whether the peer's `init` message advertises support for `option_taproot`.
 	pub fn supports_taproot(&self) -> bool {
 		self.inner.supports_taproot()
 	}
 
-	/// Whether the peer supports `option_zero_fee_commitments`.
-	///
-	/// A channel type which always uses zero transaction fee on commitment
-	/// transactions, combined with anchor outputs.
+	/// Whether the peer's `init` message requires `option_taproot`.
+	pub fn requires_taproot(&self) -> bool {
+		self.inner.requires_taproot()
+	}
+
+	/// Whether the peer's `init` message advertises support for `option_zero_fee_commitments`.
 	pub fn supports_anchor_zero_fee_commitments(&self) -> bool {
 		self.inner.supports_anchor_zero_fee_commitments()
 	}
 
-	/// Whether the peer supports HTLC hold.
-	///
-	/// Supports holding HTLCs and forwarding on receipt of an onion message.
+	/// Whether the peer's `init` message requires `option_zero_fee_commitments`.
+	pub fn requires_anchor_zero_fee_commitments(&self) -> bool {
+		self.inner.requires_anchor_zero_fee_commitments()
+	}
+
+	/// Whether the peer's `init` message advertises support for HTLC hold.
 	pub fn supports_htlc_hold(&self) -> bool {
 		self.inner.supports_htlc_hold()
+	}
+
+	/// Whether the peer's `init` message requires HTLC hold.
+	pub fn requires_htlc_hold(&self) -> bool {
+		self.inner.requires_htlc_hold()
 	}
 }
 

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -25,7 +25,7 @@ pub use bitcoin::{Address, BlockHash, Network, OutPoint, ScriptBuf, Txid};
 pub use lightning::chain::channelmonitor::BalanceSource;
 use lightning::events::PaidBolt12Invoice as LdkPaidBolt12Invoice;
 pub use lightning::events::{ClosureReason, PaymentFailureReason};
-use lightning::ln::channel_state::ChannelShutdownState;
+use lightning::ln::channel_state::{ChannelShutdownState, CounterpartyForwardingInfo};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::msgs::DecodeError;
 pub use lightning::ln::types::ChannelId;
@@ -44,7 +44,7 @@ pub use lightning_liquidity::lsps0::ser::LSPSDateTime;
 pub use lightning_liquidity::lsps1::msgs::{
 	LSPS1ChannelInfo, LSPS1OrderId, LSPS1OrderParams, LSPS1PaymentState,
 };
-use lightning_types::features::NodeFeatures as LdkNodeFeatures;
+use lightning_types::features::{InitFeatures as LdkInitFeatures, NodeFeatures as LdkNodeFeatures};
 pub use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 pub use lightning_types::string::UntrustedString;
 use vss_client::headers::{
@@ -1813,6 +1813,246 @@ impl From<LdkNodeFeatures> for NodeFeatures {
 	fn from(features: LdkNodeFeatures) -> Self {
 		Self { inner: features }
 	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+pub struct InitFeatures {
+	pub(crate) inner: LdkInitFeatures,
+}
+
+impl InitFeatures {
+	/// Constructs init features from big-endian BOLT 9 encoded bytes.
+	#[uniffi::constructor]
+	pub fn from_bytes(bytes: &[u8]) -> Self {
+		Self { inner: LdkInitFeatures::from_be_bytes(bytes.to_vec()).into() }
+	}
+
+	/// Returns the BOLT 9 big-endian encoded representation of these features.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.inner.encode()
+	}
+
+	/// Whether the peer supports `option_static_remotekey`.
+	///
+	/// This ensures the non-broadcaster's output pays directly to their specified key,
+	/// simplifying recovery if a channel is force-closed.
+	pub fn supports_static_remote_key(&self) -> bool {
+		self.inner.supports_static_remote_key()
+	}
+
+	/// Whether the peer supports `option_anchors_zero_fee_htlc_tx`.
+	///
+	/// Anchor channels allow fee-bumping commitment transactions after broadcast,
+	/// improving on-chain fee management.
+	pub fn supports_anchors_zero_fee_htlc_tx(&self) -> bool {
+		self.inner.supports_anchors_zero_fee_htlc_tx()
+	}
+
+	/// Whether the peer supports `option_anchors_nonzero_fee_htlc_tx`.
+	///
+	/// The initial version of anchor outputs, which was later found to be
+	/// vulnerable and superseded by `option_anchors_zero_fee_htlc_tx`.
+	pub fn supports_anchors_nonzero_fee_htlc_tx(&self) -> bool {
+		self.inner.supports_anchors_nonzero_fee_htlc_tx()
+	}
+
+	/// Whether the peer supports `option_support_large_channel`.
+	///
+	/// When supported, channels larger than 2^24 satoshis (≈0.168 BTC) may be opened.
+	pub fn supports_wumbo(&self) -> bool {
+		self.inner.supports_wumbo()
+	}
+
+	/// Whether the peer supports `option_route_blinding`.
+	///
+	/// Route blinding allows the recipient to hide their node identity and
+	/// last-hop channel from the sender.
+	pub fn supports_route_blinding(&self) -> bool {
+		self.inner.supports_route_blinding()
+	}
+
+	/// Whether the peer supports `option_onion_messages`.
+	///
+	/// Onion messages enable communication over the Lightning Network without
+	/// requiring a payment, used by BOLT 12 offers and async payments.
+	pub fn supports_onion_messages(&self) -> bool {
+		self.inner.supports_onion_messages()
+	}
+
+	/// Whether the peer supports `option_scid_alias`.
+	///
+	/// When supported, the peer will only forward using short channel ID aliases,
+	/// preventing the real channel UTXO from being revealed during routing.
+	pub fn supports_scid_privacy(&self) -> bool {
+		self.inner.supports_scid_privacy()
+	}
+
+	/// Whether the peer supports `option_zeroconf`.
+	///
+	/// Zero-conf channels can be used immediately without waiting for
+	/// on-chain funding confirmations.
+	pub fn supports_zero_conf(&self) -> bool {
+		self.inner.supports_zero_conf()
+	}
+
+	/// Whether the peer supports `option_dual_fund`.
+	///
+	/// Dual-funded channels allow both parties to contribute funds
+	/// to the channel opening transaction.
+	pub fn supports_dual_fund(&self) -> bool {
+		self.inner.supports_dual_fund()
+	}
+
+	/// Whether the peer supports `option_quiesce`.
+	///
+	/// Quiescence is a prerequisite for splicing, allowing both sides to
+	/// pause HTLC activity before modifying the funding transaction.
+	pub fn supports_quiescence(&self) -> bool {
+		self.inner.supports_quiescence()
+	}
+
+	/// Whether the peer supports `option_data_loss_protect`.
+	///
+	/// Allows a node that has fallen behind (e.g., restored from backup)
+	/// to detect that it is out of date and close the channel safely.
+	pub fn supports_data_loss_protect(&self) -> bool {
+		self.inner.supports_data_loss_protect()
+	}
+
+	/// Whether the peer supports `option_upfront_shutdown_script`.
+	///
+	/// Commits to a shutdown scriptpubkey when opening a channel,
+	/// preventing a compromised key from redirecting closing funds.
+	pub fn supports_upfront_shutdown_script(&self) -> bool {
+		self.inner.supports_upfront_shutdown_script()
+	}
+
+	/// Whether the peer supports `gossip_queries`.
+	///
+	/// Indicates the peer has useful gossip to share and supports
+	/// gossip query messages for synchronization.
+	pub fn supports_gossip_queries(&self) -> bool {
+		self.inner.supports_gossip_queries()
+	}
+
+	/// Whether the peer supports `var_onion_optin`.
+	///
+	/// Requires variable-length routing onion payloads, which is
+	/// assumed to be supported by all modern Lightning nodes.
+	pub fn supports_variable_length_onion(&self) -> bool {
+		self.inner.supports_variable_length_onion()
+	}
+
+	/// Whether the peer supports `payment_secret`.
+	///
+	/// Payment secrets prevent forwarding nodes from probing
+	/// payment recipients. Assumed to be supported by all modern nodes.
+	pub fn supports_payment_secret(&self) -> bool {
+		self.inner.supports_payment_secret()
+	}
+
+	/// Whether the peer supports `basic_mpp`.
+	///
+	/// Multi-part payments allow splitting a payment across multiple
+	/// routes for improved reliability and liquidity utilization.
+	pub fn supports_basic_mpp(&self) -> bool {
+		self.inner.supports_basic_mpp()
+	}
+
+	/// Whether the peer supports `opt_shutdown_anysegwit`.
+	///
+	/// Allows future segwit versions in the shutdown script,
+	/// enabling closing to Taproot or later output types.
+	pub fn supports_shutdown_anysegwit(&self) -> bool {
+		self.inner.supports_shutdown_anysegwit()
+	}
+
+	/// Whether the peer supports `option_channel_type`.
+	///
+	/// Supports explicit channel type negotiation during channel opening.
+	pub fn supports_channel_type(&self) -> bool {
+		self.inner.supports_channel_type()
+	}
+
+	/// Whether the peer supports `option_trampoline`.
+	///
+	/// Trampoline routing allows lightweight nodes to delegate
+	/// pathfinding to an intermediate trampoline node.
+	pub fn supports_trampoline_routing(&self) -> bool {
+		self.inner.supports_trampoline_routing()
+	}
+
+	/// Whether the peer supports `option_simple_close`.
+	///
+	/// Simplified closing negotiation reduces the number of
+	/// round trips needed for a cooperative channel close.
+	pub fn supports_simple_close(&self) -> bool {
+		self.inner.supports_simple_close()
+	}
+
+	/// Whether the peer supports `option_splice`.
+	///
+	/// Splicing allows replacing the funding transaction with a new one,
+	/// enabling on-the-fly capacity changes without closing the channel.
+	pub fn supports_splicing(&self) -> bool {
+		self.inner.supports_splicing()
+	}
+
+	/// Whether the peer supports `option_provide_storage`.
+	///
+	/// Indicates the node offers to store encrypted backup data
+	/// on behalf of its peers.
+	pub fn supports_provide_storage(&self) -> bool {
+		self.inner.supports_provide_storage()
+	}
+
+	/// Whether the peer set `initial_routing_sync`.
+	///
+	/// Indicates the sending node needs a complete routing information dump.
+	/// Per BOLT #9, this feature has no even (required) bit.
+	pub fn initial_routing_sync(&self) -> bool {
+		self.inner.initial_routing_sync()
+	}
+
+	/// Whether the peer supports `option_taproot`.
+	///
+	/// Taproot channels use MuSig2-based multisig for funding outputs,
+	/// improving privacy and efficiency.
+	pub fn supports_taproot(&self) -> bool {
+		self.inner.supports_taproot()
+	}
+
+	/// Whether the peer supports `option_zero_fee_commitments`.
+	///
+	/// A channel type which always uses zero transaction fee on commitment
+	/// transactions, combined with anchor outputs.
+	pub fn supports_anchor_zero_fee_commitments(&self) -> bool {
+		self.inner.supports_anchor_zero_fee_commitments()
+	}
+
+	/// Whether the peer supports HTLC hold.
+	///
+	/// Supports holding HTLCs and forwarding on receipt of an onion message.
+	pub fn supports_htlc_hold(&self) -> bool {
+		self.inner.supports_htlc_hold()
+	}
+}
+
+impl From<LdkInitFeatures> for InitFeatures {
+	fn from(ldk_init: LdkInitFeatures) -> Self {
+		Self { inner: ldk_init }
+	}
+}
+/// Information needed for constructing an invoice route hint for this channel.
+#[uniffi::remote(Record)]
+pub struct CounterpartyForwardingInfo {
+	/// Base routing fee in millisatoshis.
+	pub fee_base_msat: u32,
+	/// Amount in millionths of a satoshi the channel will charge per transferred satoshi.
+	pub fee_proportional_millionths: u32,
+	/// The minimum difference in cltv_expiry between an ingoing HTLC and its outgoing counterpart,
+	/// such that the outgoing HTLC is forwardable to this counterparty.
+	pub cltv_expiry_delta: u16,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,9 @@ use types::{
 	HRNResolver, KeysManager, OnionMessenger, PaymentStore, PeerManager, Router, Scorer, Sweeper,
 	Wallet,
 };
-pub use types::{ChannelCounterparty, ChannelDetails, CustomTlvRecord, PeerDetails, UserChannelId};
+pub use types::{
+	ChannelCounterparty, ChannelDetails, CustomTlvRecord, PeerDetails, ReserveType, UserChannelId,
+};
 pub use vss_client;
 
 use crate::ffi::maybe_wrap;
@@ -1145,7 +1147,11 @@ impl Node {
 
 	/// Retrieve a list of known channels.
 	pub fn list_channels(&self) -> Vec<ChannelDetails> {
-		self.channel_manager.list_channels().into_iter().map(|c| c.into()).collect()
+		self.channel_manager
+			.list_channels()
+			.into_iter()
+			.map(|c| ChannelDetails::from_ldk(c, self.config.anchor_channels_config.as_ref()))
+			.collect()
 	}
 
 	/// Connect to a node on the peer-to-peer network.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ use types::{
 	HRNResolver, KeysManager, OnionMessenger, PaymentStore, PeerManager, Router, Scorer, Sweeper,
 	Wallet,
 };
-pub use types::{ChannelDetails, CustomTlvRecord, PeerDetails, UserChannelId};
+pub use types::{ChannelCounterparty, ChannelDetails, CustomTlvRecord, PeerDetails, UserChannelId};
 pub use vss_client;
 
 use crate::ffi::maybe_wrap;

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,7 +40,7 @@ use lightning_net_tokio::SocketDescriptor;
 
 use crate::chain::bitcoind::UtxoSourceClient;
 use crate::chain::ChainSource;
-use crate::config::ChannelConfig;
+use crate::config::{AnchorChannelsConfig, ChannelConfig};
 use crate::data_store::DataStore;
 use crate::fee_estimator::OnchainFeeEstimator;
 use crate::ffi::maybe_wrap;
@@ -380,6 +380,47 @@ pub struct ChannelCounterparty {
 	pub outbound_htlc_maximum_msat: Option<u64>,
 }
 
+/// Describes the reserve behavior of a channel based on its type and trust configuration.
+///
+/// This captures the combination of the channel's on-chain construction (anchor outputs vs legacy
+/// static_remote_key) and whether the counterparty is in our trusted peers list. It tells the
+/// user what reserve obligations exist for this channel without exposing internal protocol details.
+///
+/// See [`AnchorChannelsConfig`] for how reserve behavior is configured.
+///
+/// [`AnchorChannelsConfig`]: crate::config::AnchorChannelsConfig
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum ReserveType {
+	/// An anchor outputs channel where we maintain a per-channel on-chain reserve for fee
+	/// bumping force-close transactions.
+	///
+	/// Anchor channels allow either party to fee-bump commitment transactions via CPFP
+	/// at broadcast time. Because the pre-signed commitment fee may be insufficient under
+	/// current fee conditions, the broadcaster must supply additional funds (hence adaptive)
+	/// through an anchor output spend. The reserve ensures sufficient on-chain funds are
+	/// available to cover this.
+	///
+	/// This is the default for anchor channels when the counterparty is not in
+	/// [`trusted_peers_no_reserve`].
+	///
+	/// [`trusted_peers_no_reserve`]: crate::config::AnchorChannelsConfig::trusted_peers_no_reserve
+	Adaptive,
+	/// An anchor outputs channel where we do not maintain any reserve, because the counterparty
+	/// is in our [`trusted_peers_no_reserve`] list.
+	///
+	/// In this mode, we trust the counterparty to broadcast a valid commitment transaction on
+	/// our behalf and do not set aside funds for fee bumping.
+	///
+	/// [`trusted_peers_no_reserve`]: crate::config::AnchorChannelsConfig::trusted_peers_no_reserve
+	TrustedPeersNoReserve,
+	/// A legacy (pre-anchor) channel using only `option_static_remotekey`.
+	///
+	/// These channels do not use anchor outputs and therefore do not require an on-chain reserve
+	/// for fee bumping. Commitment transaction fees are pre-committed at channel open time.
+	Legacy,
+}
+
 /// Details of a channel as returned by [`Node::list_channels`].
 ///
 /// When a channel is spliced, most fields continue to refer to the original pre-splice channel
@@ -544,10 +585,42 @@ pub struct ChannelDetails {
 	///
 	/// Will be `None` for objects serialized with LDK Node v0.1 and earlier.
 	pub channel_shutdown_state: Option<ChannelShutdownState>,
+	/// The type of on-chain reserve maintained for this channel.
+	///
+	/// Will be `None` until channel negotiation has completed and determined whether
+	/// this channel uses anchor or legacy reserve behavior.
+	///
+	/// See [`ReserveType`] for details on how reserves differ between anchor and legacy channels.
+	pub reserve_type: Option<ReserveType>,
 }
 
-impl From<LdkChannelDetails> for ChannelDetails {
-	fn from(value: LdkChannelDetails) -> Self {
+impl ChannelDetails {
+	pub(crate) fn from_ldk(
+		value: LdkChannelDetails, anchor_channels_config: Option<&AnchorChannelsConfig>,
+	) -> Self {
+		let reserve_type = value.channel_type.as_ref().map(|channel_type| {
+			if channel_type.supports_anchors_zero_fee_htlc_tx() {
+				if let Some(config) = anchor_channels_config {
+					if config.trusted_peers_no_reserve.contains(&value.counterparty.node_id) {
+						ReserveType::TrustedPeersNoReserve
+					} else {
+						ReserveType::Adaptive
+					}
+				} else {
+					// Edge case: if `AnchorChannelsConfig` was previously set and later
+					// removed, we can no longer distinguish whether this anchor channel's
+					// reserve was `Adaptive` or `TrustedPeersNoReserve`. We default to
+					// `Adaptive` here, which may incorrectly override a prior
+					// `TrustedPeersNoReserve` designation. This is acceptable since
+					// unsetting `AnchorChannelsConfig` on a node with existing anchor
+					// channels is not an expected operation.
+					ReserveType::Adaptive
+				}
+			} else {
+				ReserveType::Legacy
+			}
+		});
+
 		ChannelDetails {
 			channel_id: value.channel_id,
 			counterparty: ChannelCounterparty {
@@ -590,6 +663,7 @@ impl From<LdkChannelDetails> for ChannelDetails {
 				.map(|c| c.into())
 				.expect("value is set for objects serialized with LDK v0.0.109+"),
 			channel_shutdown_state: value.channel_shutdown_state,
+			reserve_type,
 		}
 	}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,7 +20,9 @@ use bitcoin_payment_instructions::hrn_resolution::{
 use bitcoin_payment_instructions::onion_message_resolver::LDKOnionMessageDNSSECHrnResolver;
 use lightning::chain::chainmonitor;
 use lightning::impl_writeable_tlv_based;
-use lightning::ln::channel_state::{ChannelDetails as LdkChannelDetails, ChannelShutdownState};
+use lightning::ln::channel_state::{
+	ChannelDetails as LdkChannelDetails, ChannelShutdownState, CounterpartyForwardingInfo,
+};
 use lightning::ln::msgs::{RoutingMessageHandler, SocketAddress};
 use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::ln::types::ChannelId;
@@ -41,10 +43,16 @@ use crate::chain::ChainSource;
 use crate::config::ChannelConfig;
 use crate::data_store::DataStore;
 use crate::fee_estimator::OnchainFeeEstimator;
+use crate::ffi::maybe_wrap;
 use crate::logger::Logger;
 use crate::message_handler::NodeCustomMessageHandler;
 use crate::payment::{PaymentDetails, PendingPaymentDetails};
 use crate::runtime::RuntimeSpawner;
+
+#[cfg(not(feature = "uniffi"))]
+type InitFeatures = lightning::types::features::InitFeatures;
+#[cfg(feature = "uniffi")]
+type InitFeatures = Arc<crate::ffi::InitFeatures>;
 
 pub(crate) trait DynStoreTrait: Send + Sync {
 	fn read_async(
@@ -341,6 +349,37 @@ impl fmt::Display for UserChannelId {
 	}
 }
 
+/// Channel parameters which apply to our counterparty. These are split out from [`ChannelDetails`]
+/// to better separate parameters.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct ChannelCounterparty {
+	/// The node_id of our counterparty
+	pub node_id: PublicKey,
+	/// The Features the channel counterparty provided upon last connection.
+	/// Useful for routing as it is the most up-to-date copy of the counterparty's features and
+	/// many routing-relevant features are present in the init context.
+	pub features: InitFeatures,
+	/// The value, in satoshis, that must always be held in the channel for our counterparty. This
+	/// value ensures that if our counterparty broadcasts a revoked state, we can punish them by
+	/// claiming at least this value on chain.
+	///
+	/// This value is not included in [`inbound_capacity_msat`] as it can never be spent.
+	///
+	/// [`inbound_capacity_msat`]: ChannelDetails::inbound_capacity_msat
+	pub unspendable_punishment_reserve: u64,
+	/// Information on the fees and requirements that the counterparty requires when forwarding
+	/// payments to us through this channel.
+	pub forwarding_info: Option<CounterpartyForwardingInfo>,
+	/// The smallest value HTLC (in msat) the remote peer will accept, for this channel.
+	///
+	/// Will be `None` before we have received the `OpenChannel` or `AcceptChannel` message
+	/// from the remote peer.
+	pub outbound_htlc_minimum_msat: Option<u64>,
+	/// The largest value HTLC (in msat) the remote peer currently will accept, for this channel.
+	pub outbound_htlc_maximum_msat: Option<u64>,
+}
+
 /// Details of a channel as returned by [`Node::list_channels`].
 ///
 /// When a channel is spliced, most fields continue to refer to the original pre-splice channel
@@ -357,8 +396,8 @@ pub struct ChannelDetails {
 	/// Note that this means this value is *not* persistent - it can change once during the
 	/// lifetime of the channel.
 	pub channel_id: ChannelId,
-	/// The node ID of our the channel's counterparty.
-	pub counterparty_node_id: PublicKey,
+	/// Parameters which apply to our counterparty. See individual fields for more information.
+	pub counterparty: ChannelCounterparty,
 	/// The channel's funding transaction output, if we've negotiated the funding transaction with
 	/// our counterparty already.
 	///
@@ -474,28 +513,6 @@ pub struct ChannelDetails {
 	/// The difference in the CLTV value between incoming HTLCs and an outbound HTLC forwarded over
 	/// the channel.
 	pub cltv_expiry_delta: Option<u16>,
-	/// The value, in satoshis, that must always be held in the channel for our counterparty. This
-	/// value ensures that if our counterparty broadcasts a revoked state, we can punish them by
-	/// claiming at least this value on chain.
-	///
-	/// This value is not included in [`inbound_capacity_msat`] as it can never be spent.
-	///
-	/// [`inbound_capacity_msat`]: ChannelDetails::inbound_capacity_msat
-	pub counterparty_unspendable_punishment_reserve: u64,
-	/// The smallest value HTLC (in msat) the remote peer will accept, for this channel.
-	///
-	/// This field is only `None` before we have received either the `OpenChannel` or
-	/// `AcceptChannel` message from the remote peer.
-	pub counterparty_outbound_htlc_minimum_msat: Option<u64>,
-	/// The largest value HTLC (in msat) the remote peer currently will accept, for this channel.
-	pub counterparty_outbound_htlc_maximum_msat: Option<u64>,
-	/// Base routing fee in millisatoshis.
-	pub counterparty_forwarding_info_fee_base_msat: Option<u32>,
-	/// Proportional fee, in millionths of a satoshi the channel will charge per transferred satoshi.
-	pub counterparty_forwarding_info_fee_proportional_millionths: Option<u32>,
-	/// The minimum difference in CLTV expiry between an ingoing HTLC and its outgoing counterpart,
-	/// such that the outgoing HTLC is forwardable to this counterparty.
-	pub counterparty_forwarding_info_cltv_expiry_delta: Option<u16>,
 	/// The available outbound capacity for sending a single HTLC to the remote peer. This is
 	/// similar to [`ChannelDetails::outbound_capacity_msat`] but it may be further restricted by
 	/// the current state and per-HTLC limit(s). This is intended for use when routing, allowing us
@@ -533,7 +550,14 @@ impl From<LdkChannelDetails> for ChannelDetails {
 	fn from(value: LdkChannelDetails) -> Self {
 		ChannelDetails {
 			channel_id: value.channel_id,
-			counterparty_node_id: value.counterparty.node_id,
+			counterparty: ChannelCounterparty {
+				node_id: value.counterparty.node_id,
+				features: maybe_wrap(value.counterparty.features),
+				unspendable_punishment_reserve: value.counterparty.unspendable_punishment_reserve,
+				forwarding_info: value.counterparty.forwarding_info,
+				outbound_htlc_minimum_msat: value.counterparty.outbound_htlc_minimum_msat,
+				outbound_htlc_maximum_msat: value.counterparty.outbound_htlc_maximum_msat,
+			},
 			funding_txo: value.funding_txo.map(|o| o.into_bitcoin_outpoint()),
 			funding_redeem_script: value.funding_redeem_script,
 			short_channel_id: value.short_channel_id,
@@ -554,26 +578,6 @@ impl From<LdkChannelDetails> for ChannelDetails {
 			is_usable: value.is_usable,
 			is_announced: value.is_announced,
 			cltv_expiry_delta: value.config.map(|c| c.cltv_expiry_delta),
-			counterparty_unspendable_punishment_reserve: value
-				.counterparty
-				.unspendable_punishment_reserve,
-			counterparty_outbound_htlc_minimum_msat: value.counterparty.outbound_htlc_minimum_msat,
-			counterparty_outbound_htlc_maximum_msat: value.counterparty.outbound_htlc_maximum_msat,
-			counterparty_forwarding_info_fee_base_msat: value
-				.counterparty
-				.forwarding_info
-				.as_ref()
-				.map(|f| f.fee_base_msat),
-			counterparty_forwarding_info_fee_proportional_millionths: value
-				.counterparty
-				.forwarding_info
-				.as_ref()
-				.map(|f| f.fee_proportional_millionths),
-			counterparty_forwarding_info_cltv_expiry_delta: value
-				.counterparty
-				.forwarding_info
-				.as_ref()
-				.map(|f| f.cltv_expiry_delta),
 			next_outbound_htlc_limit_msat: value.next_outbound_htlc_limit_msat,
 			next_outbound_htlc_minimum_msat: value.next_outbound_htlc_minimum_msat,
 			force_close_spend_delay: value.force_close_spend_delay,

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -2242,7 +2242,7 @@ async fn lsps2_client_trusts_lsp() {
 		client_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == service_node_id)
+			.find(|c| c.counterparty.node_id == service_node_id)
 			.unwrap()
 			.confirmations,
 		Some(0)
@@ -2251,7 +2251,7 @@ async fn lsps2_client_trusts_lsp() {
 		service_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == client_node_id)
+			.find(|c| c.counterparty.node_id == client_node_id)
 			.unwrap()
 			.confirmations,
 		Some(0)
@@ -2286,7 +2286,7 @@ async fn lsps2_client_trusts_lsp() {
 		client_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == service_node_id)
+			.find(|c| c.counterparty.node_id == service_node_id)
 			.unwrap()
 			.confirmations,
 		Some(6)
@@ -2295,7 +2295,7 @@ async fn lsps2_client_trusts_lsp() {
 		service_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == client_node_id)
+			.find(|c| c.counterparty.node_id == client_node_id)
 			.unwrap()
 			.confirmations,
 		Some(6)
@@ -2415,7 +2415,7 @@ async fn lsps2_lsp_trusts_client_but_client_does_not_claim() {
 		client_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == service_node_id)
+			.find(|c| c.counterparty.node_id == service_node_id)
 			.unwrap()
 			.confirmations,
 		Some(6)
@@ -2424,7 +2424,7 @@ async fn lsps2_lsp_trusts_client_but_client_does_not_claim() {
 		service_node
 			.list_channels()
 			.iter()
-			.find(|c| c.counterparty_node_id == client_node_id)
+			.find(|c| c.counterparty.node_id == client_node_id)
 			.unwrap()
 			.confirmations,
 		Some(6)
@@ -2910,7 +2910,7 @@ async fn open_channel_with_all_with_anchors() {
 	assert_eq!(channels.len(), 1);
 	let channel = &channels[0];
 	assert!(channel.channel_value_sats > premine_amount_sat - anchor_reserve_sat - 500);
-	assert_eq!(channel.counterparty_node_id, node_b.node_id());
+	assert_eq!(channel.counterparty.node_id, node_b.node_id());
 	assert_eq!(channel.funding_txo.unwrap(), funding_txo);
 
 	node_a.stop().unwrap();
@@ -2961,7 +2961,7 @@ async fn open_channel_with_all_without_anchors() {
 	assert_eq!(channels.len(), 1);
 	let channel = &channels[0];
 	assert!(channel.channel_value_sats > premine_amount_sat - 500);
-	assert_eq!(channel.counterparty_node_id, node_b.node_id());
+	assert_eq!(channel.counterparty.node_id, node_b.node_id());
 	assert_eq!(channel.funding_txo.unwrap(), funding_txo);
 
 	node_a.stop().unwrap();

--- a/tests/upgrade_downgrade_tests.rs
+++ b/tests/upgrade_downgrade_tests.rs
@@ -385,7 +385,7 @@ async fn wait_for_v070_usable_channel(node: &ldk_node_070::Node, counterparty_no
 
 fn assert_current_channel_ready(node: &CurrentNode, counterparty_node_id: PublicKey) {
 	let channels = node.list_channels();
-	let channel = channels.iter().find(|c| c.counterparty_node_id == counterparty_node_id).unwrap();
+	let channel = channels.iter().find(|c| c.counterparty.node_id == counterparty_node_id).unwrap();
 	assert_eq!(channel.channel_value_sats, CHANNEL_AMOUNT_SAT);
 	assert!(channel.is_channel_ready);
 }


### PR DESCRIPTION
## What this PR does

In #305, we needed a way to expose channel type and the channel reserve without leaking implementation details not useful to users. The related discussion in #141 proposed a `ReserveType` abstraction that bakes in both in a user-relevant way. This PR introduces the said enumeration to `ChannelDetails` with the following variants: 
- `Legacy`: signifying pre-anchor channel types where on-chain fees paying for broadcast transactions following channel closure were pre-determined 
- `TrustedPeersNoReserve`: for anchor type channels with trusted peers 
- `Adaptive`: indicating anchor channel with adaptive reserve, reflecting dynamic best-effort attempt at fee-bumping.
(see  @jkczyz's [suggestion](https://github.com/lightningdevkit/ldk-node/pull/141#discussion_r1629979502)) 

We modify the `ChannelDetails` constructor to accept an optional anchor channels config to address the challenge of users cross-referencing the channel details and config to determine if counterparties are trusted.

Additionally, following [recommendation](https://github.com/lightningdevkit/ldk-node/pull/810#pullrequestreview-3865820819) in #810 about negotiated features, this PR exposes per-peer `InitFeatures`, and as a consequence, modifies `ChannelDetails` by replacing the flattened `counterparty_*` with `ChannelCounterparty` that encapsulates them and mirror LDK's. 

## Issue Addressed 
Closes #305. 
Builds on discussions and recommendations from #141 and #810.