### PR TITLE
Fix balance candidate selection during pending splices

### DIFF
--- a/src/balance.rs
+++ b/src/balance.rs
@@ -231,10 +231,16 @@ impl LightningBalance {
 				inbound_claiming_htlc_rounded_msat,
 				inbound_htlc_rounded_msat,
 			} => {
-				// unwrap safety: confirmed_balance_candidate_index is guaranteed to index into balance_candidates
-				let balance = balance_candidates
-					.get(confirmed_balance_candidate_index)
-					.expect("LDK should provide a valid confirmed balance candidate index");
+				// When confirmed_balance_candidate_index is 0, no specific alternative
+				// funding has been confirmed yet, so use the last candidate (most current
+				// splice/RBF attempt), matching LDK's claimable_amount_satoshis behavior.
+				let balance = if confirmed_balance_candidate_index != 0 {
+					&balance_candidates[confirmed_balance_candidate_index]
+				} else {
+					balance_candidates
+						.last()
+						.expect("balance_candidates always contains at least the current funding")
+				};
 
 				Self::ClaimableOnChannelClose {
 					channel_id,


### PR DESCRIPTION
Mirror LDK's sentinel logic for confirmed_balance_candidate_index in ClaimableOnChannelClose: when the index is 0 (no specific alternative funding confirmed), use the last balance candidate (most current splice/RBF attempt) instead of the first. This aligns with LDK's claimable_amount_satoshis() behavior and fixes a mismatch where total_lightning_balance_sats could differ from the sum of individual LightningBalance amounts during pending splices.

AI tools were used in preparing this commit.