### PR TITLE
Bump test dependencies and reorganize Docker files

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4
@@ -34,7 +34,7 @@ jobs:
         if: "(steps.cache-bitcoind.outputs.cache-hit != 'true' || steps.cache-electrs.outputs.cache-hit != 'true')"
         run: |
           source ./scripts/download_bitcoind_electrs.sh
-          mkdir bin
+          mkdir -p bin
           mv "$BITCOIND_EXE" bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
           mv "$ELECTRS_EXE" bin/electrs-${{ runner.os }}-${{ runner.arch }}
       - name: Set bitcoind/electrs environment variables

--- a/.github/workflows/cln-integration.yml
+++ b/.github/workflows/cln-integration.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install -y socat
 
       - name: Start bitcoind, electrs, and lightningd
-        run: docker compose -f docker-compose-cln.yml up -d
+        run: docker compose -p ldk-node -f tests/docker/docker-compose-cln.yml up -d
 
       - name: Forward lightningd RPC socket
         run: |

--- a/.github/workflows/lnd-integration.yml
+++ b/.github/workflows/lnd-integration.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "LND_DATA_DIR=$(mktemp -d)" >> $GITHUB_ENV
 
       - name: Start bitcoind, electrs, and LND
-        run: docker compose -f docker-compose-lnd.yml up -d
+        run: docker compose -p ldk-node -f tests/docker/docker-compose-lnd.yml up -d
         env:
           LND_DATA_DIR: ${{ env.LND_DATA_DIR }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4
@@ -64,7 +64,7 @@ jobs:
         if: "matrix.platform != 'windows-latest' && (steps.cache-bitcoind.outputs.cache-hit != 'true' || steps.cache-electrs.outputs.cache-hit != 'true')"
         run: |
           source ./scripts/download_bitcoind_electrs.sh
-          mkdir bin
+          mkdir -p bin
           mv "$BITCOIND_EXE" bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
           mv "$ELECTRS_EXE" bin/electrs-${{ runner.os }}-${{ runner.arch }}
       - name: Set bitcoind/electrs environment variables

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,17 +94,17 @@ ldk-node-062 = { package = "ldk-node", version = "=0.6.2" }
 ldk-node-070 = { package = "ldk-node", version = "=0.7.0" }
 
 [target.'cfg(not(no_download))'.dev-dependencies]
-electrsd = { version = "0.36.1", default-features = false, features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }
+electrsd = { version = "0.36.1", default-features = false, features = ["legacy", "esplora_a33e97e1", "corepc-node_29_0"] }
 
 [target.'cfg(no_download)'.dev-dependencies]
 electrsd = { version = "0.36.1", default-features = false, features = ["legacy"] }
-corepc-node = { version = "0.10.0", default-features = false, features = ["27_2"] }
+corepc-node = { version = "0.10.1", default-features = false, features = ["29_0"] }
 
 [target.'cfg(cln_test)'.dev-dependencies]
 clightningrpc = { version = "0.3.0-beta.8", default-features = false }
 
 [target.'cfg(lnd_test)'.dev-dependencies]
-lnd_grpc_rust = { version = "2.10.0", default-features = false }
+lnd_grpc_rust = { version = "2.14.0", default-features = false }
 tokio = { version = "1.37", features = ["fs"] }
 
 [build-dependencies]

--- a/scripts/download_bitcoind_electrs.sh
+++ b/scripts/download_bitcoind_electrs.sh
@@ -10,17 +10,17 @@ HOST_PLATFORM="$(rustc --version --verbose | grep "host:" | awk '{ print $2 }')"
 ELECTRS_DL_ENDPOINT="https://github.com/RCasatta/electrsd/releases/download/electrs_releases"
 ELECTRS_VERSION="esplora_a33e97e1a1fc63fa9c20a116bb92579bbf43b254"
 BITCOIND_DL_ENDPOINT="https://bitcoincore.org/bin/"
-BITCOIND_VERSION="27.2"
+BITCOIND_VERSION="29.0"
 if [[ "$HOST_PLATFORM" == *linux* ]]; then
 	ELECTRS_DL_FILE_NAME=electrs_linux_"$ELECTRS_VERSION".zip
 	ELECTRS_DL_HASH="865e26a96e8df77df01d96f2f569dcf9622fc87a8d99a9b8fe30861a4db9ddf1"
 	BITCOIND_DL_FILE_NAME=bitcoin-"$BITCOIND_VERSION"-x86_64-linux-gnu.tar.gz
-	BITCOIND_DL_HASH="acc223af46c178064c132b235392476f66d486453ddbd6bca6f1f8411547da78"
+	BITCOIND_DL_HASH="a681e4f6ce524c338a105f214613605bac6c33d58c31dc5135bbc02bc458bb6c"
 elif [[ "$HOST_PLATFORM" == *darwin* ]]; then
 	ELECTRS_DL_FILE_NAME=electrs_macos_"$ELECTRS_VERSION".zip
 	ELECTRS_DL_HASH="2d5ff149e8a2482d3658e9b386830dfc40c8fbd7c175ca7cbac58240a9505bcd"
 	BITCOIND_DL_FILE_NAME=bitcoin-"$BITCOIND_VERSION"-x86_64-apple-darwin.tar.gz
-	BITCOIND_DL_HASH="6ebc56ca1397615d5a6df2b5cf6727b768e3dcac320c2d5c2f321dcaabc7efa2"
+	BITCOIND_DL_HASH="5bb824fc86a15318d6a83a1b821ff4cd4b3d3d0e1ec3d162b805ccf7cae6fca8"
 else
 	printf "\n\n"
 	echo "Unsupported platform: $HOST_PLATFORM Exiting.."

--- a/tests/docker/docker-compose-cln.yml
+++ b/tests/docker/docker-compose-cln.yml
@@ -1,6 +1,6 @@
 services:
   bitcoin:
-    image: blockstream/bitcoind:27.2
+    image: blockstream/bitcoind:29.1
     platform: linux/amd64
     command:
       [
@@ -48,7 +48,7 @@ services:
       - bitcoin-electrs
 
   cln:
-    image: blockstream/lightningd:v23.08
+    image: elementsproject/lightningd:v25.12.1
     platform: linux/amd64
     depends_on:
       bitcoin:
@@ -60,7 +60,6 @@ services:
         "--bitcoin-rpcuser=user",
         "--bitcoin-rpcpassword=pass",
         "--regtest",
-        "--experimental-anchors",
       ]
     ports:
       - "19846:19846"

--- a/tests/docker/docker-compose-lnd.yml
+++ b/tests/docker/docker-compose-lnd.yml
@@ -1,6 +1,6 @@
 services:
   bitcoin:
-    image: blockstream/bitcoind:27.2
+    image: blockstream/bitcoind:29.1
     platform: linux/amd64
     command:
       [
@@ -52,7 +52,7 @@ services:
       - bitcoin-electrs
 
   lnd:
-    image: lightninglabs/lnd:v0.18.5-beta
+    image: lightninglabs/lnd:v0.20.1-beta
     container_name: ldk-node-lnd
     depends_on:
       - bitcoin

--- a/tests/integration_tests_cln.rs
+++ b/tests/integration_tests_cln.rs
@@ -121,7 +121,18 @@ async fn test_cln() {
 	cln_client.pay(&ldk_invoice.to_string(), Default::default()).unwrap();
 	common::expect_event!(node, PaymentReceived);
 
-	node.close_channel(&user_channel_id, cln_node_id).unwrap();
+	// Retry close until monitor updates settle (avoids flaky sleep).
+	for i in 0..10 {
+		match node.close_channel(&user_channel_id, cln_node_id) {
+			Ok(()) => break,
+			Err(e) => {
+				if i == 9 {
+					panic!("close_channel failed after 10 attempts: {:?}", e);
+				}
+				std::thread::sleep(std::time::Duration::from_secs(1));
+			},
+		}
+	}
 	common::expect_event!(node, ChannelClosed);
 	node.stop().unwrap();
 }


### PR DESCRIPTION
Test dependency updates:
- bitcoind/corepc-node: 27.2 → 29.0 (corepc-node 0.10.0 → 0.10.1)
- lnd_grpc_rust: 2.10.0 → 2.14.0
- Docker CLN: v23.08 → v25.12.1 (elementsproject/lightningd)
- Docker LND: v0.18.5-beta → v0.20.1-beta
- Docker bitcoind (CLN/LND compose): 27.2 → 29.1
- Download script: bitcoind 29.0 with updated SHA256 hashes

Organization:
- Move docker-compose files to `tests/docker/` (resolves #855)

Closes #855 and Prerequisite for #839 (interop-test-harness).