### PR TITLE
Adapt to `lightning-block-sync` API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ default = []
 #lightning-macros = { version = "0.2.0" }
 #lightning-dns-resolver = { version = "0.3.0" }
 
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["std"] }
-lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["std"] }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["tokio"] }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["rest-client", "rpc-client", "tokio"] }
-lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["std"] }
-lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
-lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6" }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["rest-client", "rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
 
 bdk_chain = { version = "0.23.0", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["async-https-rustls", "tokio"]}
@@ -81,13 +81,13 @@ async-trait = { version = "0.1", default-features = false }
 vss-client = { package = "vss-client-ng", version = "0.5" }
 prost = { version = "0.11.6", default-features = false}
 #bitcoin-payment-instructions = { version = "0.6" }
-bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "a7b32d5fded9bb45f73bf82e6d7187adf705171c" }
+bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "340c535a600f7c43bef4c9f910edac4085f2e70c" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "38a62c32454d3eac22578144c479dbf9a6d9bff6", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std", "_test_utils"] }
 rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -233,12 +233,6 @@ enum NodeError {
 
 typedef dictionary NodeStatus;
 
-[Remote]
-dictionary BestBlock {
-	BlockHash block_hash;
-	u32 height;
-};
-
 typedef enum BuildError;
 
 [Trait, WithForeign]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,7 +22,7 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
 use bitcoin_payment_instructions::dns_resolver::DNSHrnResolver;
 use bitcoin_payment_instructions::onion_message_resolver::LDKOnionMessageDNSSECHrnResolver;
-use lightning::chain::{chainmonitor, BestBlock};
+use lightning::chain::{chainmonitor, BestBlock as BlockLocator};
 use lightning::ln::channelmanager::{self, ChainParameters, ChannelManagerReadArgs};
 use lightning::ln::msgs::{RoutingMessageHandler, SocketAddress};
 use lightning::ln::peer_handler::{IgnoringMessageHandler, MessageHandler};
@@ -1696,7 +1696,7 @@ fn build_with_store_internal(
 				channel_monitor_references,
 			);
 			let (_best_block, channel_manager) =
-				<(BestBlock, ChannelManager)>::read(&mut &*reader, read_args).map_err(|e| {
+				<(BlockLocator, ChannelManager)>::read(&mut &*reader, read_args).map_err(|e| {
 					log_error!(logger, "Failed to read channel manager from store: {}", e);
 					BuildError::ReadFailed
 				})?;
@@ -1704,7 +1704,7 @@ fn build_with_store_internal(
 		} else {
 			// We're starting a fresh node.
 			let best_block =
-				chain_tip_opt.unwrap_or_else(|| BestBlock::from_network(config.network));
+				chain_tip_opt.unwrap_or_else(|| BlockLocator::from_network(config.network));
 
 			let chain_params = ChainParameters { network: config.network.into(), best_block };
 			channelmanager::ChannelManager::new(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -19,7 +19,7 @@ use bdk_wallet::{KeychainKind, Wallet as BdkWallet};
 use bitcoin::bip32::{ChildNumber, Xpriv};
 use bitcoin::key::Secp256k1;
 use bitcoin::secp256k1::PublicKey;
-use bitcoin::{BlockHash, Network};
+use bitcoin::Network;
 use bitcoin_payment_instructions::dns_resolver::DNSHrnResolver;
 use bitcoin_payment_instructions::onion_message_resolver::LDKOnionMessageDNSSECHrnResolver;
 use lightning::chain::{chainmonitor, BestBlock};
@@ -1695,8 +1695,8 @@ fn build_with_store_internal(
 				user_config,
 				channel_monitor_references,
 			);
-			let (_hash, channel_manager) =
-				<(BlockHash, ChannelManager)>::read(&mut &*reader, read_args).map_err(|e| {
+			let (_best_block, channel_manager) =
+				<(BestBlock, ChannelManager)>::read(&mut &*reader, read_args).map_err(|e| {
 					log_error!(logger, "Failed to read channel manager from store: {}", e);
 					BuildError::ReadFailed
 				})?;

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -25,7 +25,7 @@ use lightning_block_sync::poll::{ChainPoller, ChainTip, ValidatedBlockHeader};
 use lightning_block_sync::rest::RestClient;
 use lightning_block_sync::rpc::{RpcClient, RpcClientError};
 use lightning_block_sync::{
-	BlockData, BlockHeaderData, BlockSource, BlockSourceError, BlockSourceErrorKind, Cache,
+	BlockData, BlockHeaderData, BlockSource, BlockSourceError, BlockSourceErrorKind, HeaderCache,
 	SpvClient,
 };
 use serde::Serialize;
@@ -49,7 +49,6 @@ const CHAIN_POLLING_TIMEOUT_SECS: u64 = 10;
 
 pub(super) struct BitcoindChainSource {
 	api_client: Arc<BitcoindClient>,
-	header_cache: tokio::sync::Mutex<BoundedHeaderCache>,
 	latest_chain_tip: RwLock<Option<ValidatedBlockHeader>>,
 	wallet_polling_status: Mutex<WalletSyncStatus>,
 	fee_estimator: Arc<OnchainFeeEstimator>,
@@ -72,12 +71,10 @@ impl BitcoindChainSource {
 			rpc_password.clone(),
 		));
 
-		let header_cache = tokio::sync::Mutex::new(BoundedHeaderCache::new());
 		let latest_chain_tip = RwLock::new(None);
 		let wallet_polling_status = Mutex::new(WalletSyncStatus::Completed);
 		Self {
 			api_client,
-			header_cache,
 			latest_chain_tip,
 			wallet_polling_status,
 			fee_estimator,
@@ -103,13 +100,11 @@ impl BitcoindChainSource {
 			rpc_password,
 		));
 
-		let header_cache = tokio::sync::Mutex::new(BoundedHeaderCache::new());
 		let latest_chain_tip = RwLock::new(None);
 		let wallet_polling_status = Mutex::new(WalletSyncStatus::Completed);
 
 		Self {
 			api_client,
-			header_cache,
 			latest_chain_tip,
 			wallet_polling_status,
 			fee_estimator,
@@ -153,14 +148,14 @@ impl BitcoindChainSource {
 				return;
 			}
 
-			let channel_manager_best_block_hash = channel_manager.current_best_block().block_hash;
-			let sweeper_best_block_hash = output_sweeper.current_best_block().block_hash;
-			let onchain_wallet_best_block_hash = onchain_wallet.current_best_block().block_hash;
+			let onchain_wallet_best_block = onchain_wallet.current_best_block();
+			let channel_manager_best_block = channel_manager.current_best_block();
+			let sweeper_best_block = output_sweeper.current_best_block();
 
 			let mut chain_listeners = vec![
-				(onchain_wallet_best_block_hash, &*onchain_wallet as &(dyn Listen + Send + Sync)),
-				(channel_manager_best_block_hash, &*channel_manager as &(dyn Listen + Send + Sync)),
-				(sweeper_best_block_hash, &*output_sweeper as &(dyn Listen + Send + Sync)),
+				(onchain_wallet_best_block, &*onchain_wallet as &(dyn Listen + Send + Sync)),
+				(channel_manager_best_block, &*channel_manager as &(dyn Listen + Send + Sync)),
+				(sweeper_best_block, &*output_sweeper as &(dyn Listen + Send + Sync)),
 			];
 
 			// TODO: Eventually we might want to see if we can synchronize `ChannelMonitor`s
@@ -168,31 +163,28 @@ impl BitcoindChainSource {
 			// trivial as we load them on initialization (in the `Builder`) and only gain
 			// network access during `start`. For now, we just make sure we get the worst known
 			// block hash and sychronize them via `ChainMonitor`.
-			if let Some(worst_channel_monitor_block_hash) = chain_monitor
+			if let Some(worst_channel_monitor_best_block) = chain_monitor
 				.list_monitors()
 				.iter()
 				.flat_map(|channel_id| chain_monitor.get_monitor(*channel_id))
 				.map(|m| m.current_best_block())
 				.min_by_key(|b| b.height)
-				.map(|b| b.block_hash)
 			{
 				chain_listeners.push((
-					worst_channel_monitor_block_hash,
+					worst_channel_monitor_best_block,
 					&*chain_monitor as &(dyn Listen + Send + Sync),
 				));
 			}
 
-			let mut locked_header_cache = self.header_cache.lock().await;
 			let now = SystemTime::now();
 			match synchronize_listeners(
 				self.api_client.as_ref(),
 				self.config.network,
-				&mut *locked_header_cache,
 				chain_listeners.clone(),
 			)
 			.await
 			{
-				Ok(chain_tip) => {
+				Ok((_header_cache, chain_tip)) => {
 					{
 						let elapsed_ms = now.elapsed().map(|d| d.as_millis()).unwrap_or(0);
 						log_info!(
@@ -400,7 +392,6 @@ impl BitcoindChainSource {
 		let chain_tip =
 			if let Some(tip) = latest_chain_tip_opt { tip } else { self.poll_chain_tip().await? };
 
-		let mut locked_header_cache = self.header_cache.lock().await;
 		let chain_poller = ChainPoller::new(Arc::clone(&self.api_client), self.config.network);
 		let chain_listener = ChainListener {
 			onchain_wallet: Arc::clone(&onchain_wallet),
@@ -409,7 +400,7 @@ impl BitcoindChainSource {
 			output_sweeper,
 		};
 		let mut spv_client =
-			SpvClient::new(chain_tip, chain_poller, &mut *locked_header_cache, &chain_listener);
+			SpvClient::new(chain_tip, chain_poller, HeaderCache::new(), &chain_listener);
 
 		let now = SystemTime::now();
 		match spv_client.poll_best_tip().await {
@@ -1348,46 +1339,6 @@ pub(crate) struct MempoolEntry {
 pub(crate) enum FeeRateEstimationMode {
 	Economical,
 	Conservative,
-}
-
-const MAX_HEADER_CACHE_ENTRIES: usize = 100;
-
-pub(crate) struct BoundedHeaderCache {
-	header_map: HashMap<BlockHash, ValidatedBlockHeader>,
-	recently_seen: VecDeque<BlockHash>,
-}
-
-impl BoundedHeaderCache {
-	pub(crate) fn new() -> Self {
-		let header_map = HashMap::new();
-		let recently_seen = VecDeque::new();
-		Self { header_map, recently_seen }
-	}
-}
-
-impl Cache for BoundedHeaderCache {
-	fn look_up(&self, block_hash: &BlockHash) -> Option<&ValidatedBlockHeader> {
-		self.header_map.get(block_hash)
-	}
-
-	fn block_connected(&mut self, block_hash: BlockHash, block_header: ValidatedBlockHeader) {
-		self.recently_seen.push_back(block_hash);
-		self.header_map.insert(block_hash, block_header);
-
-		if self.header_map.len() >= MAX_HEADER_CACHE_ENTRIES {
-			// Keep dropping old entries until we've actually removed a header entry.
-			while let Some(oldest_entry) = self.recently_seen.pop_front() {
-				if self.header_map.remove(&oldest_entry).is_some() {
-					break;
-				}
-			}
-		}
-	}
-
-	fn block_disconnected(&mut self, block_hash: &BlockHash) -> Option<ValidatedBlockHeader> {
-		self.recently_seen.retain(|e| e != block_hash);
-		self.header_map.remove(block_hash)
-	}
 }
 
 pub(crate) struct ChainListener {

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -16,7 +16,7 @@ use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bitcoin::{BlockHash, FeeRate, Network, OutPoint, Transaction, Txid};
 use lightning::chain::chaininterface::ConfirmationTarget as LdkConfirmationTarget;
-use lightning::chain::{BestBlock, Listen};
+use lightning::chain::{BestBlock as BlockLocator, Listen};
 use lightning::util::ser::Writeable;
 use lightning_block_sync::gossip::UtxoSource;
 use lightning_block_sync::http::{HttpClientError, JsonResponse};
@@ -325,7 +325,7 @@ impl BitcoindChainSource {
 		}
 	}
 
-	pub(super) async fn poll_best_block(&self) -> Result<BestBlock, Error> {
+	pub(super) async fn poll_best_block(&self) -> Result<BlockLocator, Error> {
 		self.poll_chain_tip().await.map(|tip| tip.to_best_block())
 	}
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use bitcoin::{Script, Txid};
-use lightning::chain::{BestBlock, Filter};
+use lightning::chain::{BestBlock as BlockLocator, Filter};
 
 use crate::chain::bitcoind::{BitcoindChainSource, UtxoSourceClient};
 use crate::chain::electrum::ElectrumChainSource;
@@ -101,7 +101,7 @@ impl ChainSource {
 		fee_estimator: Arc<OnchainFeeEstimator>, tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>, config: Arc<Config>, logger: Arc<Logger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
-	) -> Result<(Self, Option<BestBlock>), ()> {
+	) -> Result<(Self, Option<BlockLocator>), ()> {
 		let esplora_chain_source = EsploraChainSource::new(
 			server_url,
 			headers,
@@ -122,7 +122,7 @@ impl ChainSource {
 		fee_estimator: Arc<OnchainFeeEstimator>, tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>, config: Arc<Config>, logger: Arc<Logger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
-	) -> (Self, Option<BestBlock>) {
+	) -> (Self, Option<BlockLocator>) {
 		let electrum_chain_source = ElectrumChainSource::new(
 			server_url,
 			sync_config,
@@ -142,7 +142,7 @@ impl ChainSource {
 		fee_estimator: Arc<OnchainFeeEstimator>, tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>, config: Arc<Config>, logger: Arc<Logger>,
 		node_metrics: Arc<RwLock<NodeMetrics>>,
-	) -> (Self, Option<BestBlock>) {
+	) -> (Self, Option<BlockLocator>) {
 		let bitcoind_chain_source = BitcoindChainSource::new_rpc(
 			rpc_host,
 			rpc_port,
@@ -165,7 +165,7 @@ impl ChainSource {
 		fee_estimator: Arc<OnchainFeeEstimator>, tx_broadcaster: Arc<Broadcaster>,
 		kv_store: Arc<DynStore>, config: Arc<Config>, rest_client_config: BitcoindRestClientConfig,
 		logger: Arc<Logger>, node_metrics: Arc<RwLock<NodeMetrics>>,
-	) -> (Self, Option<BestBlock>) {
+	) -> (Self, Option<BlockLocator>) {
 		let bitcoind_chain_source = BitcoindChainSource::new_rest(
 			rpc_host,
 			rpc_port,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ pub use balance::{BalanceDetails, LightningBalance, PendingSweepBalance};
 pub use bip39;
 pub use bitcoin;
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::BlockHash;
 #[cfg(feature = "uniffi")]
 pub use bitcoin::FeeRate;
 #[cfg(not(feature = "uniffi"))]
@@ -145,7 +146,7 @@ use gossip::GossipSource;
 use graph::NetworkGraph;
 use io::utils::update_and_persist_node_metrics;
 pub use lightning;
-use lightning::chain::BestBlock;
+use lightning::chain::BestBlock as BlockLocator;
 use lightning::impl_writeable_tlv_based;
 use lightning::ln::chan_utils::FUNDING_TRANSACTION_WITNESS_WEIGHT;
 use lightning::ln::channel_state::ChannelDetails as LdkChannelDetails;
@@ -2053,6 +2054,22 @@ impl Node {
 impl Drop for Node {
 	fn drop(&mut self) {
 		let _ = self.stop();
+	}
+}
+
+/// The best known block as identified by its hash and height.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct BestBlock {
+	/// The block's hash.
+	pub block_hash: BlockHash,
+	/// The height at which the block was confirmed.
+	pub height: u32,
+}
+
+impl From<BlockLocator> for BestBlock {
+	fn from(locator: BlockLocator) -> Self {
+		Self { block_hash: locator.block_hash, height: locator.height }
 	}
 }
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -138,7 +138,15 @@ impl Wallet {
 
 	pub(crate) fn current_best_block(&self) -> BestBlock {
 		let checkpoint = self.inner.lock().expect("lock").latest_checkpoint();
-		BestBlock { block_hash: checkpoint.hash(), height: checkpoint.height() }
+		let mut current_block = Some(checkpoint.clone());
+		let previous_blocks = std::array::from_fn(|_| {
+			let child = current_block.take()?;
+			// BDK's checkpoint chain may be sparse; only accept contiguous parents.
+			let parent = child.prev().filter(|cp| cp.height() + 1 == child.height())?;
+			current_block = Some(parent.clone());
+			Some(parent.hash())
+		});
+		BestBlock { block_hash: checkpoint.hash(), height: checkpoint.height(), previous_blocks }
 	}
 
 	pub(crate) fn apply_update(&self, update: impl Into<Update>) -> Result<(), Error> {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -35,7 +35,7 @@ use lightning::chain::chaininterface::{
 	BroadcasterInterface, INCREMENTAL_RELAY_FEE_SAT_PER_1000_WEIGHT,
 };
 use lightning::chain::channelmonitor::ANTI_REORG_DELAY;
-use lightning::chain::{BestBlock, ClaimId, Listen};
+use lightning::chain::{BestBlock as BlockLocator, ClaimId, Listen};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::funding::FundingTxInput;
 use lightning::ln::inbound_payment::ExpandedKey;
@@ -136,7 +136,7 @@ impl Wallet {
 			.collect()
 	}
 
-	pub(crate) fn current_best_block(&self) -> BestBlock {
+	pub(crate) fn current_best_block(&self) -> BlockLocator {
 		let checkpoint = self.inner.lock().expect("lock").latest_checkpoint();
 		let mut current_block = Some(checkpoint.clone());
 		let previous_blocks = std::array::from_fn(|_| {
@@ -146,7 +146,7 @@ impl Wallet {
 			current_block = Some(parent.clone());
 			Some(parent.hash())
 		});
-		BestBlock { block_hash: checkpoint.hash(), height: checkpoint.height(), previous_blocks }
+		BlockLocator { block_hash: checkpoint.hash(), height: checkpoint.height(), previous_blocks }
 	}
 
 	pub(crate) fn apply_update(&self, update: impl Into<Update>) -> Result<(), Error> {
@@ -1499,7 +1499,7 @@ impl Listen for Wallet {
 		};
 	}
 
-	fn blocks_disconnected(&self, _fork_point_block: BestBlock) {
+	fn blocks_disconnected(&self, _fork_point_block: BlockLocator) {
 		// This is a no-op as we don't have to tell BDK about disconnections. According to the BDK
 		// team, it's sufficient in case of a reorg to always connect blocks starting from the last
 		// point of disagreement.


### PR DESCRIPTION
Update to use the new `HeaderCache` type instead of implementing the `Cache` trait, pass `BestBlock` instead of `BlockHash` to synchronize_listeners, and pass `HeaderCache` by value to `SpvClient::new`.

Also adapt to `BestBlock` gaining a `previous_blocks` field and `ChannelManager` deserialization returning `BestBlock` instead of `BlockHash`.

These changes are from https://github.com/lightningdevkit/rust-lightning/pull/4266.