### PR TITLE
DRY up batched `KVStore` reads utility methods

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -59,9 +59,8 @@ use crate::fee_estimator::OnchainFeeEstimator;
 use crate::gossip::GossipSource;
 use crate::io::sqlite_store::SqliteStore;
 use crate::io::utils::{
-	read_event_queue, read_external_pathfinding_scores_from_cache, read_network_graph,
-	read_node_metrics, read_output_sweeper, read_payments, read_peer_info, read_pending_payments,
-	read_scorer,
+	read_all_objects, read_event_queue, read_external_pathfinding_scores_from_cache,
+	read_network_graph, read_node_metrics, read_output_sweeper, read_peer_info, read_scorer,
 };
 use crate::io::vss_store::VssStoreBuilder;
 use crate::io::{
@@ -1279,9 +1278,19 @@ fn build_with_store_internal(
 	let (payment_store_res, node_metris_res, pending_payment_store_res) =
 		runtime.block_on(async move {
 			tokio::join!(
-				read_payments(&*kv_store_ref, Arc::clone(&logger_ref)),
+				read_all_objects(
+					&*kv_store_ref,
+					PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
+					PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+					Arc::clone(&logger_ref),
+				),
 				read_node_metrics(&*kv_store_ref, Arc::clone(&logger_ref)),
-				read_pending_payments(&*kv_store_ref, Arc::clone(&logger_ref))
+				read_all_objects(
+					&*kv_store_ref,
+					PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
+					PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+					Arc::clone(&logger_ref),
+				)
 			)
 		});
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,9 +76,9 @@ use crate::peer_store::PeerStore;
 use crate::runtime::{Runtime, RuntimeSpawner};
 use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
-	AsyncPersister, ChainMonitor, ChannelManager, DynStore, DynStoreRef, DynStoreWrapper,
-	GossipSync, Graph, KeysManager, MessageRouter, OnionMessenger, PaymentStore, PeerManager,
-	PendingPaymentStore, SyncAndAsyncKVStore,
+	AsyncPersister, BatchingStore, ChainMonitor, ChannelManager, DynStore, DynStoreRef,
+	DynStoreWrapper, GossipSync, Graph, KeysManager, MessageRouter, OnionMessenger, PaymentStore,
+	PeerManager, PendingPaymentStore, SyncAndAsyncKVStore,
 };
 use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
@@ -86,6 +86,7 @@ use crate::{Node, NodeMetrics};
 
 const LSPS_HARDENED_CHILD_INDEX: u32 = 577;
 const PERSISTER_MAX_PENDING_UPDATES: u64 = 100;
+const STORE_READ_BATCH_SIZE: usize = 50;
 
 #[derive(Debug, Clone)]
 enum ChainDataSourceConfig {
@@ -1265,14 +1266,18 @@ fn build_with_store_internal(
 	let tx_broadcaster = Arc::new(TransactionBroadcaster::new(Arc::clone(&logger)));
 	let fee_estimator = Arc::new(OnchainFeeEstimator::new());
 
-	let kv_store_ref = Arc::clone(&kv_store);
+	// Wrap the store with concurrency limiting for parallel initialization reads.
+	let batch_store: Arc<DynStore> =
+		Arc::new(DynStoreWrapper(BatchingStore::new(Arc::clone(&kv_store), STORE_READ_BATCH_SIZE)));
+
+	let batch_store_ref = Arc::clone(&batch_store);
 	let logger_ref = Arc::clone(&logger);
 	let (payment_store_res, node_metris_res, pending_payment_store_res) =
 		runtime.block_on(async move {
 			tokio::join!(
-				read_payments(&*kv_store_ref, Arc::clone(&logger_ref)),
-				read_node_metrics(&*kv_store_ref, Arc::clone(&logger_ref)),
-				read_pending_payments(&*kv_store_ref, Arc::clone(&logger_ref))
+				read_payments(&*batch_store_ref, Arc::clone(&logger_ref)),
+				read_node_metrics(&*batch_store_ref, Arc::clone(&logger_ref)),
+				read_pending_payments(&*batch_store_ref, Arc::clone(&logger_ref))
 			)
 		});
 
@@ -1515,12 +1520,12 @@ fn build_with_store_internal(
 	));
 
 	// Read ChannelMonitors and the NetworkGraph
-	let kv_store_ref = Arc::clone(&kv_store);
+	let batch_store_ref = Arc::clone(&batch_store);
 	let logger_ref = Arc::clone(&logger);
 	let (monitor_read_res, network_graph_res) = runtime.block_on(async {
 		tokio::join!(
 			monitor_reader.read_all_channel_monitors_with_updates_parallel(),
-			read_network_graph(&*kv_store_ref, logger_ref),
+			read_network_graph(&*batch_store_ref, logger_ref),
 		)
 	});
 
@@ -1566,7 +1571,10 @@ fn build_with_store_internal(
 		},
 	};
 
-	// Read various smaller LDK and ldk-node objects from the store
+	// Read various smaller LDK and ldk-node objects from the store.
+	// Functions that take &DynStore (borrow-only) use batch_store for throttled reads.
+	// Functions that take Arc<DynStore> (persist into runtime objects) use the original kv_store.
+	let batch_store_ref = Arc::clone(&batch_store);
 	let kv_store_ref = Arc::clone(&kv_store);
 	let logger_ref = Arc::clone(&logger);
 	let network_graph_ref = Arc::clone(&network_graph);
@@ -1587,10 +1595,10 @@ fn build_with_store_internal(
 		peer_info_res,
 	) = runtime.block_on(async move {
 		tokio::join!(
-			read_scorer(&*kv_store_ref, network_graph_ref, Arc::clone(&logger_ref)),
-			read_external_pathfinding_scores_from_cache(&*kv_store_ref, Arc::clone(&logger_ref)),
+			read_scorer(&*batch_store_ref, network_graph_ref, Arc::clone(&logger_ref)),
+			read_external_pathfinding_scores_from_cache(&*batch_store_ref, Arc::clone(&logger_ref)),
 			KVStore::read(
-				&*kv_store_ref,
+				&*batch_store_ref,
 				CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
 				CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
 				CHANNEL_MANAGER_PERSISTENCE_KEY,

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -44,11 +44,10 @@ use crate::io::{
 	NODE_METRICS_KEY, NODE_METRICS_PRIMARY_NAMESPACE, NODE_METRICS_SECONDARY_NAMESPACE,
 };
 use crate::logger::{log_error, LdkLogger, Logger};
-use crate::payment::PendingPaymentDetails;
 use crate::peer_store::PeerStore;
 use crate::types::{Broadcaster, DynStore, KeysManager, Sweeper};
 use crate::wallet::ser::{ChangeSetDeserWrapper, ChangeSetSerWrapper};
-use crate::{Error, EventQueue, NodeMetrics, PaymentDetails};
+use crate::{Error, EventQueue, NodeMetrics};
 
 pub const EXTERNAL_PATHFINDING_SCORES_CACHE_KEY: &str = "external_pathfinding_scores_cache";
 
@@ -221,21 +220,19 @@ where
 	})
 }
 
-/// Read previously persisted payments information from the store.
-pub(crate) async fn read_payments<L: Deref>(
-	kv_store: &DynStore, logger: L,
-) -> Result<Vec<PaymentDetails>, std::io::Error>
+/// Read all objects of type `T` from the given namespace, spawning reads in parallel.
+pub(crate) async fn read_all_objects<T, L>(
+	kv_store: &DynStore, primary_namespace: &str, secondary_namespace: &str, logger: L,
+) -> Result<Vec<T>, std::io::Error>
 where
+	T: Readable,
+	L: Deref,
 	L::Target: LdkLogger,
 {
+	let type_name = std::any::type_name::<T>();
 	let mut res = Vec::new();
 
-	let mut stored_keys = KVStore::list(
-		&*kv_store,
-		PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-		PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-	)
-	.await?;
+	let mut stored_keys = KVStore::list(&*kv_store, primary_namespace, secondary_namespace).await?;
 
 	const BATCH_SIZE: usize = 50;
 
@@ -244,12 +241,7 @@ where
 	// Fill JoinSet with tasks if possible
 	while set.len() < BATCH_SIZE && !stored_keys.is_empty() {
 		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
+			let fut = KVStore::read(kv_store, primary_namespace, secondary_namespace, &next_key);
 			set.spawn(fut);
 			debug_assert!(set.len() <= BATCH_SIZE);
 		}
@@ -259,37 +251,32 @@ where
 		// Exit early if we get an IO error.
 		let reader = read_res
 			.map_err(|e| {
-				log_error!(logger, "Failed to read PaymentDetails: {}", e);
+				log_error!(logger, "Failed to read {}: {}", type_name, e);
 				set.abort_all();
 				e
 			})?
 			.map_err(|e| {
-				log_error!(logger, "Failed to read PaymentDetails: {}", e);
+				log_error!(logger, "Failed to read {}: {}", type_name, e);
 				set.abort_all();
 				e
 			})?;
 
 		// Refill set for every finished future, if we still have something to do.
 		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
+			let fut = KVStore::read(kv_store, primary_namespace, secondary_namespace, &next_key);
 			set.spawn(fut);
 			debug_assert!(set.len() <= BATCH_SIZE);
 		}
 
 		// Handle result.
-		let payment = PaymentDetails::read(&mut &*reader).map_err(|e| {
-			log_error!(logger, "Failed to deserialize PaymentDetails: {}", e);
+		let object = T::read(&mut &*reader).map_err(|e| {
+			log_error!(logger, "Failed to deserialize {}: {}", type_name, e);
 			std::io::Error::new(
 				std::io::ErrorKind::InvalidData,
-				"Failed to deserialize PaymentDetails",
+				format!("Failed to deserialize {}", type_name),
 			)
 		})?;
-		res.push(payment);
+		res.push(object);
 	}
 
 	debug_assert!(set.is_empty());
@@ -630,83 +617,6 @@ pub(crate) fn read_bdk_wallet_change_set(
 	read_bdk_wallet_tx_graph(&*kv_store, logger)?.map(|tx_graph| change_set.tx_graph = tx_graph);
 	read_bdk_wallet_indexer(&*kv_store, logger)?.map(|indexer| change_set.indexer = indexer);
 	Ok(Some(change_set))
-}
-
-/// Read previously persisted pending payments information from the store.
-pub(crate) async fn read_pending_payments<L: Deref>(
-	kv_store: &DynStore, logger: L,
-) -> Result<Vec<PendingPaymentDetails>, std::io::Error>
-where
-	L::Target: LdkLogger,
-{
-	let mut res = Vec::new();
-
-	let mut stored_keys = KVStore::list(
-		&*kv_store,
-		PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-		PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-	)
-	.await?;
-
-	const BATCH_SIZE: usize = 50;
-
-	let mut set = tokio::task::JoinSet::new();
-
-	// Fill JoinSet with tasks if possible
-	while set.len() < BATCH_SIZE && !stored_keys.is_empty() {
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-	}
-
-	while let Some(read_res) = set.join_next().await {
-		// Exit early if we get an IO error.
-		let reader = read_res
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PendingPaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PendingPaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?;
-
-		// Refill set for every finished future, if we still have something to do.
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-
-		// Handle result.
-		let pending_payment = PendingPaymentDetails::read(&mut &*reader).map_err(|e| {
-			log_error!(logger, "Failed to deserialize PendingPaymentDetails: {}", e);
-			std::io::Error::new(
-				std::io::ErrorKind::InvalidData,
-				"Failed to deserialize PendingPaymentDetails",
-			)
-		})?;
-		res.push(pending_payment);
-	}
-
-	debug_assert!(set.is_empty());
-	debug_assert!(stored_keys.is_empty());
-
-	Ok(res)
 }
 
 #[cfg(test)]

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -221,6 +221,48 @@ where
 	})
 }
 
+/// Read all objects of type `T` from the given namespace, spawning reads in parallel.
+///
+/// Concurrency is expected to be limited externally (e.g., via [`BatchingStore`]).
+///
+/// [`BatchingStore`]: crate::types::BatchingStore
+pub(crate) async fn read_all_objects<T, L>(
+	kv_store: &DynStore, primary_namespace: &str, secondary_namespace: &str, logger: L,
+) -> Result<Vec<T>, std::io::Error>
+where
+	T: Readable,
+	L: Deref,
+	L::Target: LdkLogger,
+{
+	let keys = KVStore::list(&*kv_store, primary_namespace, secondary_namespace).await?;
+
+	let mut set = tokio::task::JoinSet::new();
+	for key in keys {
+		set.spawn(KVStore::read(kv_store, primary_namespace, secondary_namespace, &key));
+	}
+
+	let mut results = Vec::with_capacity(set.len());
+	while let Some(res) = set.join_next().await {
+		let bytes = res
+			.map_err(|e| {
+				log_error!(logger, "Failed to join read task: {}", e);
+				e
+			})?
+			.map_err(|e| {
+				log_error!(logger, "Failed to read object: {}", e);
+				e
+			})?;
+		results.push(T::read(&mut &*bytes).map_err(|e| {
+			log_error!(logger, "Failed to deserialize object: {}", e);
+			std::io::Error::new(
+				std::io::ErrorKind::InvalidData,
+				format!("Failed to deserialize: {}", e),
+			)
+		})?);
+	}
+	Ok(results)
+}
+
 /// Read previously persisted payments information from the store.
 pub(crate) async fn read_payments<L: Deref>(
 	kv_store: &DynStore, logger: L,
@@ -228,74 +270,13 @@ pub(crate) async fn read_payments<L: Deref>(
 where
 	L::Target: LdkLogger,
 {
-	let mut res = Vec::new();
-
-	let mut stored_keys = KVStore::list(
-		&*kv_store,
+	read_all_objects(
+		kv_store,
 		PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
 		PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+		logger,
 	)
-	.await?;
-
-	const BATCH_SIZE: usize = 50;
-
-	let mut set = tokio::task::JoinSet::new();
-
-	// Fill JoinSet with tasks if possible
-	while set.len() < BATCH_SIZE && !stored_keys.is_empty() {
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-	}
-
-	while let Some(read_res) = set.join_next().await {
-		// Exit early if we get an IO error.
-		let reader = read_res
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?;
-
-		// Refill set for every finished future, if we still have something to do.
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-
-		// Handle result.
-		let payment = PaymentDetails::read(&mut &*reader).map_err(|e| {
-			log_error!(logger, "Failed to deserialize PaymentDetails: {}", e);
-			std::io::Error::new(
-				std::io::ErrorKind::InvalidData,
-				"Failed to deserialize PaymentDetails",
-			)
-		})?;
-		res.push(payment);
-	}
-
-	debug_assert!(set.is_empty());
-	debug_assert!(stored_keys.is_empty());
-
-	Ok(res)
+	.await
 }
 
 /// Read `OutputSweeper` state from the store.
@@ -632,74 +613,13 @@ pub(crate) async fn read_pending_payments<L: Deref>(
 where
 	L::Target: LdkLogger,
 {
-	let mut res = Vec::new();
-
-	let mut stored_keys = KVStore::list(
-		&*kv_store,
+	read_all_objects(
+		kv_store,
 		PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
 		PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+		logger,
 	)
-	.await?;
-
-	const BATCH_SIZE: usize = 50;
-
-	let mut set = tokio::task::JoinSet::new();
-
-	// Fill JoinSet with tasks if possible
-	while set.len() < BATCH_SIZE && !stored_keys.is_empty() {
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-	}
-
-	while let Some(read_res) = set.join_next().await {
-		// Exit early if we get an IO error.
-		let reader = read_res
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PendingPaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?
-			.map_err(|e| {
-				log_error!(logger, "Failed to read PendingPaymentDetails: {}", e);
-				set.abort_all();
-				e
-			})?;
-
-		// Refill set for every finished future, if we still have something to do.
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(
-				&*kv_store,
-				PENDING_PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
-				PENDING_PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
-				&next_key,
-			);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
-		}
-
-		// Handle result.
-		let pending_payment = PendingPaymentDetails::read(&mut &*reader).map_err(|e| {
-			log_error!(logger, "Failed to deserialize PendingPaymentDetails: {}", e);
-			std::io::Error::new(
-				std::io::ErrorKind::InvalidData,
-				"Failed to deserialize PendingPaymentDetails",
-			)
-		})?;
-		res.push(pending_payment);
-	}
-
-	debug_assert!(set.is_empty());
-	debug_assert!(stored_keys.is_empty());
-
-	Ok(res)
+	.await
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,6 +218,113 @@ impl<T: SyncAndAsyncKVStore + Send + Sync> DynStoreTrait for DynStoreWrapper<T> 
 	}
 }
 
+/// A [`KVStore`] wrapper that limits the number of concurrent async I/O operations using a
+/// semaphore. Sync methods pass through without throttling.
+///
+/// This is used during node initialization to cap the number of inflight reads across all
+/// parallel readers to a single configurable limit.
+pub(crate) struct BatchingStore {
+	inner: Arc<DynStore>,
+	semaphore: Arc<tokio::sync::Semaphore>,
+}
+
+impl BatchingStore {
+	pub(crate) fn new(inner: Arc<DynStore>, max_concurrent: usize) -> Self {
+		Self { inner, semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent)) }
+	}
+}
+
+impl KVStore for BatchingStore {
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> impl Future<Output = Result<Vec<u8>, bitcoin::io::Error>> + Send + 'static {
+		let inner = Arc::clone(&self.inner);
+		let semaphore = Arc::clone(&self.semaphore);
+		let primary_namespace = primary_namespace.to_string();
+		let secondary_namespace = secondary_namespace.to_string();
+		let key = key.to_string();
+		async move {
+			let _permit = semaphore.acquire_owned().await.map_err(|e| {
+				bitcoin::io::Error::new(bitcoin::io::ErrorKind::Other, format!("{}", e))
+			})?;
+			inner.read_async(&primary_namespace, &secondary_namespace, &key).await
+		}
+	}
+
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> impl Future<Output = Result<(), bitcoin::io::Error>> + Send + 'static {
+		let inner = Arc::clone(&self.inner);
+		let semaphore = Arc::clone(&self.semaphore);
+		let primary_namespace = primary_namespace.to_string();
+		let secondary_namespace = secondary_namespace.to_string();
+		let key = key.to_string();
+		async move {
+			let _permit = semaphore.acquire_owned().await.map_err(|e| {
+				bitcoin::io::Error::new(bitcoin::io::ErrorKind::Other, format!("{}", e))
+			})?;
+			inner.write_async(&primary_namespace, &secondary_namespace, &key, buf).await
+		}
+	}
+
+	fn remove(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool,
+	) -> impl Future<Output = Result<(), bitcoin::io::Error>> + Send + 'static {
+		let inner = Arc::clone(&self.inner);
+		let semaphore = Arc::clone(&self.semaphore);
+		let primary_namespace = primary_namespace.to_string();
+		let secondary_namespace = secondary_namespace.to_string();
+		let key = key.to_string();
+		async move {
+			let _permit = semaphore.acquire_owned().await.map_err(|e| {
+				bitcoin::io::Error::new(bitcoin::io::ErrorKind::Other, format!("{}", e))
+			})?;
+			inner.remove_async(&primary_namespace, &secondary_namespace, &key, lazy).await
+		}
+	}
+
+	fn list(
+		&self, primary_namespace: &str, secondary_namespace: &str,
+	) -> impl Future<Output = Result<Vec<String>, bitcoin::io::Error>> + Send + 'static {
+		let inner = Arc::clone(&self.inner);
+		let semaphore = Arc::clone(&self.semaphore);
+		let primary_namespace = primary_namespace.to_string();
+		let secondary_namespace = secondary_namespace.to_string();
+		async move {
+			let _permit = semaphore.acquire_owned().await.map_err(|e| {
+				bitcoin::io::Error::new(bitcoin::io::ErrorKind::Other, format!("{}", e))
+			})?;
+			inner.list_async(&primary_namespace, &secondary_namespace).await
+		}
+	}
+}
+
+impl KVStoreSync for BatchingStore {
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> Result<Vec<u8>, bitcoin::io::Error> {
+		DynStoreTrait::read(&*self.inner, primary_namespace, secondary_namespace, key)
+	}
+
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> Result<(), bitcoin::io::Error> {
+		DynStoreTrait::write(&*self.inner, primary_namespace, secondary_namespace, key, buf)
+	}
+
+	fn remove(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool,
+	) -> Result<(), bitcoin::io::Error> {
+		DynStoreTrait::remove(&*self.inner, primary_namespace, secondary_namespace, key, lazy)
+	}
+
+	fn list(
+		&self, primary_namespace: &str, secondary_namespace: &str,
+	) -> Result<Vec<String>, bitcoin::io::Error> {
+		DynStoreTrait::list(&*self.inner, primary_namespace, secondary_namespace)
+	}
+}
+
 pub(crate) type AsyncPersister = MonitorUpdatingPersisterAsync<
 	DynStoreRef,
 	RuntimeSpawner,


### PR DESCRIPTION
```
DRY up batched KVStore reads with `read_all_objects` helper

The parallel `JoinSet`-based batching loop was duplicated across
`read_payments` and `read_pending_payments`. Extract it into a generic
`read_all_objects<T: Readable>` helper that callers invoke directly
with the relevant namespace constants. Per-type log messages are
preserved via `std::any::type_name::<T>()`.

Co-Authored-By: HAL 9000
```