### PR TITLE
Drop `max_inbound_htlc_value_in_flight_percent_of_channel `

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ default = []
 #lightning-macros = { version = "0.2.0" }
 #lightning-dns-resolver = { version = "0.3.0" }
 
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
-lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["tokio"] }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["rest-client", "rpc-client", "tokio"] }
-lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std"] }
-lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
-lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133" }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["rest-client", "rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
+lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144" }
 
 bdk_chain = { version = "0.23.0", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["async-https-rustls", "tokio"]}
@@ -81,13 +81,13 @@ async-trait = { version = "0.1", default-features = false }
 vss-client = { package = "vss-client-ng", version = "0.5" }
 prost = { version = "0.11.6", default-features = false}
 #bitcoin-payment-instructions = { version = "0.6" }
-bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "340c535a600f7c43bef4c9f910edac4085f2e70c" }
+bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "679dac50cc0d81ec4d31da94b93d467e5308f16a" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "044f3fab42e3085edecd40f0c9b369093edb7133", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "369a2cf9c8ef810deea0cd2b4cf6ed0691b78144", features = ["std", "_test_utils"] }
 rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1657,11 +1657,6 @@ fn build_with_store_internal(
 
 		// If we act as an LSPS2 service, we allow forwarding to unannounced channels.
 		user_config.accept_forwards_to_priv_channels = true;
-
-		// If we act as an LSPS2 service, set the HTLC-value-in-flight to 100% of the channel value
-		// to ensure we can forward the initial payment.
-		user_config.channel_handshake_config.max_inbound_htlc_value_in_flight_percent_of_channel =
-			100;
 	}
 
 	if let Some(role) = async_payments_role {

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,9 +26,7 @@ use lightning::ln::channelmanager::{PaymentId, TrustedChannelFeatures};
 use lightning::ln::types::ChannelId;
 use lightning::routing::gossip::NodeId;
 use lightning::sign::EntropySource;
-use lightning::util::config::{
-	ChannelConfigOverrides, ChannelConfigUpdate, ChannelHandshakeConfigUpdate,
-};
+use lightning::util::config::{ChannelConfigOverrides, ChannelConfigUpdate};
 use lightning::util::errors::APIError;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
@@ -1273,20 +1271,24 @@ where
 					if lsp_node_id == counterparty_node_id {
 						// When we're an LSPS2 client, allow claiming underpaying HTLCs as the LSP will skim off some fee. We'll
 						// check that they don't take too much before claiming.
-						//
-						// We also set maximum allowed inbound HTLC value in flight
-						// to 100%. We should eventually be able to set this on a per-channel basis, but for
-						// now we just bump the default for all channels.
 						channel_override_config = Some(ChannelConfigOverrides {
-							handshake_overrides: Some(ChannelHandshakeConfigUpdate {
-								max_inbound_htlc_value_in_flight_percent_of_channel: Some(100),
-								..Default::default()
-							}),
 							update_overrides: Some(ChannelConfigUpdate {
 								accept_underpaying_htlcs: Some(true),
 								..Default::default()
 							}),
+							..Default::default()
 						});
+
+						// LSPS2 channels are unannounced; rely on LDK's default of 100%
+						// inbound HTLC value-in-flight so the LSP can forward the initial
+						// payment in full.
+						debug_assert_eq!(
+							self.channel_manager
+								.get_current_config()
+								.channel_handshake_config
+								.unannounced_channel_max_inbound_htlc_value_in_flight_percentage,
+							100
+						);
 					}
 				}
 				let res = if allow_0conf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1195,13 +1195,16 @@ impl Node {
 		let mut user_config = default_user_config(&self.config);
 		user_config.channel_handshake_config.announce_for_forwarding = announce_for_forwarding;
 		user_config.channel_config = (channel_config.unwrap_or_default()).clone().into();
-		// We set the max inflight to 100% for private channels.
-		// FIXME: LDK will default to this behavior soon, too, at which point we should drop this
-		// manual override.
+
+		// Unannounced channels rely on LDK's default of 100% inbound HTLC value-in-flight
+		// to support large initial payments via LSPS2.
 		if !announce_for_forwarding {
-			user_config
-				.channel_handshake_config
-				.max_inbound_htlc_value_in_flight_percent_of_channel = 100;
+			debug_assert_eq!(
+				user_config
+					.channel_handshake_config
+					.unannounced_channel_max_inbound_htlc_value_in_flight_percentage,
+				100
+			);
 		}
 
 		let push_msat = push_to_counterparty_msat.unwrap_or(0);

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -781,13 +781,16 @@ where
 
 				let mut config = self.channel_manager.get_current_config().clone();
 
-				// We set these LSP-specific values during Node building, here we're making sure it's actually set.
+				// If we act as an LSPS2 service, the HTLC-value-in-flight must be 100% of the
+				// channel value to ensure we can forward the initial payment. That cap only
+				// applies to unannounced channels, so the channel must also be unannounced.
 				debug_assert_eq!(
 					config
 						.channel_handshake_config
-						.max_inbound_htlc_value_in_flight_percent_of_channel,
+						.unannounced_channel_max_inbound_htlc_value_in_flight_percentage,
 					100
 				);
+				debug_assert!(!config.channel_handshake_config.announce_for_forwarding);
 				debug_assert!(config.accept_forwards_to_priv_channels);
 
 				// We set the forwarding fee to 0 for now as we're getting paid by the channel fee.


### PR DESCRIPTION
The `max_inbound_htlc_value_in_flight_percent_of_channel` config setting was used when acting as an LSPS2 service in order to forward the initial payment. However, upstream divided the config setting into two for announced and unannounced channels, the latter defaulting to 100%.

Based on #874.