### PR TITLE
Added SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security vulnerabilities for `ldk-node` are handled under the same policy as
+`rust-lightning`(LDK), on which this library is built.
+
+Please refer to the [rust-lightning's SECURITY.md](https://github.com/lightningdevkit/rust-lightning/blob/main/SECURITY.md)
+for instructions on how to responsibly disclose vulnerabilities.


### PR DESCRIPTION
Adds a SECURITY.md file as requested in #877 

The file points to rust-lightning's existing SECURITY.md policy rather than duplicating it.

Closes #877 