### PR TITLE
Switch to expose `FeeRate::from_sat_per_vb_u32` in bindings

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -156,8 +156,8 @@ typedef interface OnchainPayment;
 interface FeeRate {
 	[Name=from_sat_per_kwu]
 	constructor(u64 sat_kwu);
-	[Name=from_sat_per_vb_unchecked]
-	constructor(u64 sat_vb);
+	[Name=from_sat_per_vb_u32]
+	constructor(u32 sat_vb);
 	u64 to_sat_per_kwu();
 	u64 to_sat_per_vb_floor();
 	u64 to_sat_per_vb_ceil();


### PR DESCRIPTION
Previously, we exposed the `FeeRate::from_sat_per_vb_unchecked` constructor, which however was now marked deprecated with `bitcoin-units` v0.1.3 (see
https://docs.rs/bitcoin-units/0.1.3/bitcoin_units/fee_rate/struct.FeeRate.html#method.from_sat_per_vb_unchecked).

Here, we switch to `from_sat_per_vb_u32`, also fixing our CI job that started to fail on the deprecation warning.