### PR TITLE
Move BOLT11 JIT params to payment metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Pending
+
+## Compatibility Notes
+- Pending JIT-channel payments created before upgrading may fail after upgrade because the
+  prior LSPS2 fee-limit state stored in `PaymentKind::Bolt11Jit` is not migrated.
+
 # 0.7.0 - Dec. 3, 2025
 This seventh minor release introduces numerous new features, bug fixes, and API improvements. In particular, it adds support for channel Splicing, Async Payments, as well as sourcing chain data from a Bitcoin Core REST backend.
 
@@ -419,4 +425,3 @@ integrated LDK and BDK-based wallets.
 
 **Note:** This release is still considered experimental, should not be run in
 production, and no compatibility guarantees are given until the release of 0.1.
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ default = []
 #lightning-macros = { version = "0.2.0" }
 #lightning-dns-resolver = { version = "0.3.0" }
 
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["std"] }
-lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["std"] }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["tokio"] }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["rest-client", "rpc-client", "tokio"] }
-lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["std"] }
-lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
-lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a" }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["rest-client", "rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["esplora-async-https", "time", "electrum-rustls-ring"] }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
+lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182" }
 
 bdk_chain = { version = "0.23.0", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["async-https-rustls", "tokio"]}
@@ -81,13 +81,13 @@ async-trait = { version = "0.1", default-features = false }
 vss-client = { package = "vss-client-ng", version = "0.5" }
 prost = { version = "0.11.6", default-features = false}
 #bitcoin-payment-instructions = { version = "0.6" }
-bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "c7d7ea849fcbe8cad385c93f8057cd68ecb994b7" }
+bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", rev = "ed8657dee284f987b6791cd291d0f0f18811ee76" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "10608650d455f4d535cbac73921be329d814854a", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "090e09f3992694040d3a55c1c798b3a92fb77182", features = ["std", "_test_utils"] }
 rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"

--- a/src/event.rs
+++ b/src/event.rs
@@ -50,6 +50,7 @@ use crate::payment::asynchronous::static_invoice_store::StaticInvoiceStore;
 use crate::payment::store::{
 	PaymentDetails, PaymentDetailsUpdate, PaymentDirection, PaymentKind, PaymentStatus,
 };
+use crate::payment::PaymentMetadata;
 use crate::runtime::Runtime;
 use crate::types::{
 	CustomTlvRecord, DynStore, KeysManager, OnionMessenger, PaymentStore, Sweeper, Wallet,
@@ -580,6 +581,36 @@ where
 		}
 	}
 
+	fn fail_claimable_payment(
+		&self, payment_id: PaymentId, payment_hash: &PaymentHash,
+	) -> Result<(), ReplayEvent> {
+		self.channel_manager.fail_htlc_backwards(payment_hash);
+
+		let update = PaymentDetailsUpdate {
+			hash: Some(Some(*payment_hash)),
+			status: Some(PaymentStatus::Failed),
+			..PaymentDetailsUpdate::new(payment_id)
+		};
+		match self.payment_store.update(update) {
+			Ok(_) => Ok(()),
+			Err(e) => {
+				log_error!(self.logger, "Failed to access payment store: {}", e);
+				Err(ReplayEvent())
+			},
+		}
+	}
+
+	fn lsps2_max_total_opening_fee_msat(payment_metadata: &[u8], amount_msat: u64) -> Option<u64> {
+		let metadata = PaymentMetadata::read(&mut &payment_metadata[..]).ok()?;
+		let lsps2_parameters = metadata.lsps2_parameters?;
+		lsps2_parameters.max_total_opening_fee_msat.or_else(|| {
+			lsps2_parameters.max_proportional_opening_fee_ppm_msat.and_then(|max_prop_fee| {
+				// If it's a variable amount payment, compute the actual fee.
+				compute_opening_fee(amount_msat, 0, max_prop_fee)
+			})
+		})
+	}
+
 	pub async fn handle_event(&self, event: LdkEvent) -> Result<(), ReplayEvent> {
 		match event {
 			LdkEvent::FundingGenerationReady {
@@ -693,7 +724,8 @@ where
 				..
 			} => {
 				let payment_id = PaymentId(payment_hash.0);
-				if let Some(info) = self.payment_store.get(&payment_id) {
+				let payment_info = self.payment_store.get(&payment_id);
+				if let Some(info) = payment_info.as_ref() {
 					if info.direction == PaymentDirection::Outbound {
 						log_info!(
 							self.logger,
@@ -716,14 +748,13 @@ where
 					}
 
 					if info.status == PaymentStatus::Succeeded
-						|| matches!(info.kind, PaymentKind::Spontaneous { .. })
+						|| matches!(&info.kind, PaymentKind::Spontaneous { .. })
 					{
-						let stored_preimage = match info.kind {
+						let stored_preimage = match &info.kind {
 							PaymentKind::Bolt11 { preimage, .. }
-							| PaymentKind::Bolt11Jit { preimage, .. }
 							| PaymentKind::Bolt12Offer { preimage, .. }
 							| PaymentKind::Bolt12Refund { preimage, .. }
-							| PaymentKind::Spontaneous { preimage, .. } => preimage,
+							| PaymentKind::Spontaneous { preimage, .. } => *preimage,
 							_ => None,
 						};
 
@@ -758,22 +789,28 @@ where
 							},
 						};
 					}
+				}
 
-					let max_total_opening_fee_msat = match info.kind {
-						PaymentKind::Bolt11Jit { lsp_fee_limits, .. } => {
-							lsp_fee_limits
-								.max_total_opening_fee_msat
-								.or_else(|| {
-									lsp_fee_limits.max_proportional_opening_fee_ppm_msat.and_then(
-										|max_prop_fee| {
-											// If it's a variable amount payment, compute the actual fee.
-											compute_opening_fee(amount_msat, 0, max_prop_fee)
-										},
-									)
-								})
-								.unwrap_or(0)
-						},
-						_ => 0,
+				if counterparty_skimmed_fee_msat > 0 {
+					let max_total_opening_fee_msat = match &purpose {
+						PaymentPurpose::Bolt11InvoicePayment { .. } => onion_fields
+							.as_ref()
+							.and_then(|fields| fields.payment_metadata.as_ref())
+							.and_then(|metadata| {
+								Self::lsps2_max_total_opening_fee_msat(metadata, amount_msat)
+							}),
+						_ => None,
+					};
+
+					let Some(max_total_opening_fee_msat) = max_total_opening_fee_msat else {
+						log_info!(
+							self.logger,
+							"Refusing inbound payment with hash {} as the counterparty withheld {}msat without valid BOLT11 LSPS2 payment metadata",
+							hex_utils::to_string(&payment_hash.0),
+							counterparty_skimmed_fee_msat,
+						);
+						self.fail_claimable_payment(payment_id, &payment_hash)?;
+						return Ok(());
 					};
 
 					if counterparty_skimmed_fee_msat > max_total_opening_fee_msat {
@@ -784,26 +821,13 @@ where
 							counterparty_skimmed_fee_msat,
 							max_total_opening_fee_msat,
 						);
-						self.channel_manager.fail_htlc_backwards(&payment_hash);
-
-						let update = PaymentDetailsUpdate {
-							hash: Some(Some(payment_hash)),
-							status: Some(PaymentStatus::Failed),
-							..PaymentDetailsUpdate::new(payment_id)
-						};
-						match self.payment_store.update(update) {
-							Ok(_) => return Ok(()),
-							Err(e) => {
-								log_error!(self.logger, "Failed to access payment store: {}", e);
-								return Err(ReplayEvent());
-							},
-						};
+						self.fail_claimable_payment(payment_id, &payment_hash)?;
+						return Ok(());
 					}
 
-					// If the LSP skimmed anything, update our stored payment.
-					if counterparty_skimmed_fee_msat > 0 {
-						match info.kind {
-							PaymentKind::Bolt11Jit { .. } => {
+					if let Some(info) = payment_info.as_ref() {
+						match &info.kind {
+							PaymentKind::Bolt11 { .. } => {
 								let update = PaymentDetailsUpdate {
 									counterparty_skimmed_fee_msat: Some(Some(counterparty_skimmed_fee_msat)),
 									..PaymentDetailsUpdate::new(payment_id)
@@ -816,16 +840,17 @@ where
 									},
 								};
 							}
-							_ => debug_assert!(false, "We only expect the counterparty to get away with withholding fees for JIT payments."),
+							_ => debug_assert!(false, "We only expect the counterparty to get away with withholding fees for BOLT11 payments."),
 						}
 					}
+				}
 
+				if let Some(info) = payment_info {
 					// If this is known by the store but ChannelManager doesn't know the preimage,
 					// the payment has been registered via `_for_hash` variants and needs to be manually claimed via
 					// user interaction.
 					match info.kind {
-						PaymentKind::Bolt11 { preimage, .. }
-						| PaymentKind::Bolt11Jit { preimage, .. } => {
+						PaymentKind::Bolt11 { preimage, .. } => {
 							if purpose.preimage().is_none() {
 								debug_assert!(
 									preimage.is_none(),
@@ -1890,7 +1915,57 @@ mod tests {
 
 	use super::*;
 	use crate::io::test_utils::InMemoryStore;
+	use crate::payment::store::LSPS2Parameters;
 	use crate::types::DynStoreWrapper;
+
+	#[test]
+	fn lsps2_payment_metadata_decodes_total_fee_limit() {
+		let metadata = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: Some(42_000),
+				max_proportional_opening_fee_ppm_msat: None,
+			}),
+		};
+
+		assert_eq!(
+			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+				&metadata.encode(),
+				100_000
+			),
+			Some(42_000)
+		);
+	}
+
+	#[test]
+	fn lsps2_payment_metadata_missing_or_malformed_limit_is_rejected() {
+		let empty_metadata = PaymentMetadata { lsps2_parameters: None }.encode();
+		let metadata_without_fee_limit = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: None,
+				max_proportional_opening_fee_ppm_msat: None,
+			}),
+		}
+		.encode();
+
+		assert_eq!(
+			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+				&empty_metadata,
+				100_000
+			),
+			None
+		);
+		assert_eq!(
+			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(&[0xff], 100_000),
+			None
+		);
+		assert_eq!(
+			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+				&metadata_without_fee_limit,
+				100_000
+			),
+			None
+		);
+	}
 
 	#[tokio::test]
 	async fn event_queue_persistence() {

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -1304,9 +1304,9 @@ where
 
 		// LSPS2 requires min_final_cltv_expiry_delta to be at least 2 more than usual.
 		let min_final_cltv_expiry_delta = MIN_FINAL_CLTV_EXPIRY_DELTA + 2;
-		let (payment_hash, payment_secret) = match payment_hash {
+		let (payment_hash, payment_secret, payment_metadata) = match payment_hash {
 			Some(payment_hash) => {
-				let payment_secret = self
+				let (payment_secret, payment_metadata) = self
 					.channel_manager
 					.create_inbound_payment_for_hash(
 						payment_hash,
@@ -1319,7 +1319,7 @@ where
 						log_error!(self.logger, "Failed to register inbound payment: {:?}", e);
 						Error::InvoiceCreationFailed
 					})?;
-				(payment_hash, payment_secret)
+				(payment_hash, payment_secret, payment_metadata)
 			},
 			None => self
 				.channel_manager
@@ -1353,15 +1353,21 @@ where
 			invoice_builder = invoice_builder.amount_milli_satoshis(amount_msat).basic_mpp();
 		}
 
-		invoice_builder
-			.build_signed(|hash| {
+		let invoice = if let Some(payment_metadata) = payment_metadata {
+			invoice_builder.payment_metadata(payment_metadata).build_signed(|hash| {
 				Secp256k1::new()
 					.sign_ecdsa_recoverable(hash, &self.keys_manager.get_node_secret_key())
 			})
-			.map_err(|e| {
-				log_error!(self.logger, "Failed to build and sign invoice: {}", e);
-				Error::InvoiceCreationFailed
+		} else {
+			invoice_builder.build_signed(|hash| {
+				Secp256k1::new()
+					.sign_ecdsa_recoverable(hash, &self.keys_manager.get_node_secret_key())
 			})
+		};
+		invoice.map_err(|e| {
+			log_error!(self.logger, "Failed to build and sign invoice: {}", e);
+			Error::InvoiceCreationFailed
+		})
 	}
 
 	pub(crate) async fn handle_channel_ready(

--- a/src/liquidity.rs
+++ b/src/liquidity.rs
@@ -21,6 +21,7 @@ use lightning::ln::msgs::SocketAddress;
 use lightning::ln::types::ChannelId;
 use lightning::routing::router::{RouteHint, RouteHintHop};
 use lightning::sign::EntropySource;
+use lightning::util::ser::Writeable;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, InvoiceBuilder, RoutingFees};
 use lightning_liquidity::events::LiquidityEvent;
 use lightning_liquidity::lsps0::ser::{LSPSDateTime, LSPSRequestId};
@@ -41,6 +42,8 @@ use tokio::sync::oneshot;
 use crate::builder::BuildError;
 use crate::connection::ConnectionManager;
 use crate::logger::{log_debug, log_error, log_info, LdkLogger, Logger};
+use crate::payment::store::LSPS2Parameters;
+use crate::payment::PaymentMetadata;
 use crate::runtime::Runtime;
 use crate::types::{
 	Broadcaster, ChannelManager, DynStore, KeysManager, LiquidityManager, PeerManager, Wallet,
@@ -1113,7 +1116,7 @@ where
 	pub(crate) async fn lsps2_receive_to_jit_channel(
 		&self, amount_msat: u64, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_total_lsp_fee_limit_msat: Option<u64>, payment_hash: Option<PaymentHash>,
-	) -> Result<(Bolt11Invoice, u64), Error> {
+	) -> Result<Bolt11Invoice, Error> {
 		let fee_response = self.lsps2_request_opening_fee_params().await?;
 
 		let (min_total_fee_msat, min_opening_params) = fee_response
@@ -1159,22 +1162,27 @@ where
 
 		let buy_response =
 			self.lsps2_send_buy_request(Some(amount_msat), min_opening_params).await?;
+		let lsps2_parameters = LSPS2Parameters {
+			max_total_opening_fee_msat: Some(min_total_fee_msat),
+			max_proportional_opening_fee_ppm_msat: None,
+		};
 		let invoice = self.lsps2_create_jit_invoice(
 			buy_response,
 			Some(amount_msat),
 			description,
 			expiry_secs,
 			payment_hash,
+			lsps2_parameters,
 		)?;
 
 		log_info!(self.logger, "JIT-channel invoice created: {}", invoice);
-		Ok((invoice, min_total_fee_msat))
+		Ok(invoice)
 	}
 
 	pub(crate) async fn lsps2_receive_variable_amount_to_jit_channel(
 		&self, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_proportional_lsp_fee_limit_ppm_msat: Option<u64>, payment_hash: Option<PaymentHash>,
-	) -> Result<(Bolt11Invoice, u64), Error> {
+	) -> Result<Bolt11Invoice, Error> {
 		let fee_response = self.lsps2_request_opening_fee_params().await?;
 
 		let (min_prop_fee_ppm_msat, min_opening_params) = fee_response
@@ -1207,16 +1215,21 @@ where
 		);
 
 		let buy_response = self.lsps2_send_buy_request(None, min_opening_params).await?;
+		let lsps2_parameters = LSPS2Parameters {
+			max_total_opening_fee_msat: None,
+			max_proportional_opening_fee_ppm_msat: Some(min_prop_fee_ppm_msat),
+		};
 		let invoice = self.lsps2_create_jit_invoice(
 			buy_response,
 			None,
 			description,
 			expiry_secs,
 			payment_hash,
+			lsps2_parameters,
 		)?;
 
 		log_info!(self.logger, "JIT-channel invoice created: {}", invoice);
-		Ok((invoice, min_prop_fee_ppm_msat))
+		Ok(invoice)
 	}
 
 	async fn lsps2_request_opening_fee_params(&self) -> Result<LSPS2FeeResponse, Error> {
@@ -1298,12 +1311,14 @@ where
 	fn lsps2_create_jit_invoice(
 		&self, buy_response: LSPS2BuyResponse, amount_msat: Option<u64>,
 		description: &Bolt11InvoiceDescription, expiry_secs: u32,
-		payment_hash: Option<PaymentHash>,
+		payment_hash: Option<PaymentHash>, lsps2_parameters: LSPS2Parameters,
 	) -> Result<Bolt11Invoice, Error> {
 		let lsps2_client = self.lsps2_client.as_ref().ok_or(Error::LiquiditySourceUnavailable)?;
 
 		// LSPS2 requires min_final_cltv_expiry_delta to be at least 2 more than usual.
 		let min_final_cltv_expiry_delta = MIN_FINAL_CLTV_EXPIRY_DELTA + 2;
+		let encoded_payment_metadata =
+			PaymentMetadata { lsps2_parameters: Some(lsps2_parameters) }.encode();
 		let (payment_hash, payment_secret, payment_metadata) = match payment_hash {
 			Some(payment_hash) => {
 				let (payment_secret, payment_metadata) = self
@@ -1313,7 +1328,7 @@ where
 						None,
 						expiry_secs,
 						Some(min_final_cltv_expiry_delta),
-						None,
+						Some(encoded_payment_metadata),
 					)
 					.map_err(|e| {
 						log_error!(self.logger, "Failed to register inbound payment: {:?}", e);
@@ -1323,7 +1338,12 @@ where
 			},
 			None => self
 				.channel_manager
-				.create_inbound_payment(None, expiry_secs, Some(min_final_cltv_expiry_delta), None)
+				.create_inbound_payment(
+					None,
+					expiry_secs,
+					Some(min_final_cltv_expiry_delta),
+					Some(encoded_payment_metadata),
+				)
 				.map_err(|e| {
 					log_error!(self.logger, "Failed to register inbound payment: {:?}", e);
 					Error::InvoiceCreationFailed

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -31,7 +31,7 @@ use crate::ffi::{maybe_deref, maybe_try_convert_enum, maybe_wrap};
 use crate::liquidity::LiquiditySource;
 use crate::logger::{log_error, log_info, LdkLogger, Logger};
 use crate::payment::store::{
-	LSPFeeLimits, PaymentDetails, PaymentDetailsUpdate, PaymentDirection, PaymentKind,
+	LSPS2Parameters, PaymentDetails, PaymentDetailsUpdate, PaymentDirection, PaymentKind,
 	PaymentStatus,
 };
 use crate::peer_store::{PeerInfo, PeerStore};
@@ -206,7 +206,7 @@ impl Bolt11Payment {
 		// Register payment in payment store.
 		let payment_hash = invoice.payment_hash();
 		let payment_secret = invoice.payment_secret();
-		let lsp_fee_limits = LSPFeeLimits {
+		let lsp_fee_limits = LSPS2Parameters {
 			max_total_opening_fee_msat: lsp_total_opening_fee,
 			max_proportional_opening_fee_ppm_msat: lsp_prop_opening_fee,
 		};

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -119,9 +119,14 @@ impl Bolt11Payment {
 		let preimage = if manual_claim_payment_hash.is_none() {
 			// If the user hasn't registered a custom payment hash, we're positive ChannelManager
 			// will know the preimage at this point.
+			let mut payment_metadata = invoice.payment_metadata().cloned();
 			let res = self
 				.channel_manager
-				.get_payment_preimage(payment_hash, payment_secret.clone(), None)
+				.get_payment_preimage_decrypt_metadata(
+					payment_hash,
+					payment_secret.clone(),
+					payment_metadata.as_deref_mut(),
+				)
 				.ok();
 			debug_assert!(res.is_some(), "We just let ChannelManager create an inbound payment, it can't have forgotten the preimage by now.");
 			res
@@ -206,9 +211,14 @@ impl Bolt11Payment {
 			max_proportional_opening_fee_ppm_msat: lsp_prop_opening_fee,
 		};
 		let id = PaymentId(payment_hash.0);
+		let mut payment_metadata = invoice.payment_metadata().cloned();
 		let preimage = self
 			.channel_manager
-			.get_payment_preimage(payment_hash, payment_secret.clone(), None)
+			.get_payment_preimage_decrypt_metadata(
+				payment_hash,
+				payment_secret.clone(),
+				payment_metadata.as_deref_mut(),
+			)
 			.ok();
 		let kind = PaymentKind::Bolt11Jit {
 			hash: payment_hash,

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, RwLock};
 
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
+use lightning::impl_writeable_tlv_based;
 use lightning::ln::channelmanager::{
 	Bolt11InvoiceParameters, OptionalBolt11PaymentParams, PaymentId,
 };
@@ -47,6 +48,16 @@ type Bolt11Invoice = Arc<crate::ffi::Bolt11Invoice>;
 type Bolt11InvoiceDescription = LdkBolt11InvoiceDescription;
 #[cfg(feature = "uniffi")]
 type Bolt11InvoiceDescription = crate::ffi::Bolt11InvoiceDescription;
+
+/// Metadata carried in BOLT11 invoice `payment_metadata`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PaymentMetadata {
+	pub(crate) lsps2_parameters: Option<LSPS2Parameters>,
+}
+
+impl_writeable_tlv_based!(PaymentMetadata, {
+	(0, lsps2_parameters, option),
+});
 
 /// A payment handler allowing to create and pay [BOLT 11] invoices.
 ///
@@ -137,6 +148,7 @@ impl Bolt11Payment {
 			hash: payment_hash,
 			preimage,
 			secret: Some(payment_secret.clone()),
+			counterparty_skimmed_fee_msat: None,
 		};
 		let payment = PaymentDetails::new(
 			id,
@@ -177,39 +189,32 @@ impl Bolt11Payment {
 		log_info!(self.logger, "Connected to LSP {}@{}. ", peer_info.node_id, peer_info.address);
 
 		let liquidity_source = Arc::clone(&liquidity_source);
-		let (invoice, lsp_total_opening_fee, lsp_prop_opening_fee) =
-			self.runtime.block_on(async move {
-				if let Some(amount_msat) = amount_msat {
-					liquidity_source
-						.lsps2_receive_to_jit_channel(
-							amount_msat,
-							description,
-							expiry_secs,
-							max_total_lsp_fee_limit_msat,
-							payment_hash,
-						)
-						.await
-						.map(|(invoice, total_fee)| (invoice, Some(total_fee), None))
-				} else {
-					liquidity_source
-						.lsps2_receive_variable_amount_to_jit_channel(
-							description,
-							expiry_secs,
-							max_proportional_lsp_fee_limit_ppm_msat,
-							payment_hash,
-						)
-						.await
-						.map(|(invoice, prop_fee)| (invoice, None, Some(prop_fee)))
-				}
-			})?;
+		let invoice = self.runtime.block_on(async move {
+			if let Some(amount_msat) = amount_msat {
+				liquidity_source
+					.lsps2_receive_to_jit_channel(
+						amount_msat,
+						description,
+						expiry_secs,
+						max_total_lsp_fee_limit_msat,
+						payment_hash,
+					)
+					.await
+			} else {
+				liquidity_source
+					.lsps2_receive_variable_amount_to_jit_channel(
+						description,
+						expiry_secs,
+						max_proportional_lsp_fee_limit_ppm_msat,
+						payment_hash,
+					)
+					.await
+			}
+		})?;
 
 		// Register payment in payment store.
 		let payment_hash = invoice.payment_hash();
 		let payment_secret = invoice.payment_secret();
-		let lsp_fee_limits = LSPS2Parameters {
-			max_total_opening_fee_msat: lsp_total_opening_fee,
-			max_proportional_opening_fee_ppm_msat: lsp_prop_opening_fee,
-		};
 		let id = PaymentId(payment_hash.0);
 		let mut payment_metadata = invoice.payment_metadata().cloned();
 		let preimage = self
@@ -220,12 +225,11 @@ impl Bolt11Payment {
 				payment_metadata.as_deref_mut(),
 			)
 			.ok();
-		let kind = PaymentKind::Bolt11Jit {
+		let kind = PaymentKind::Bolt11 {
 			hash: payment_hash,
 			preimage,
 			secret: Some(payment_secret.clone()),
 			counterparty_skimmed_fee_msat: None,
-			lsp_fee_limits,
 		};
 		let payment = PaymentDetails::new(
 			id,
@@ -241,6 +245,37 @@ impl Bolt11Payment {
 		self.peer_store.add_peer(peer_info)?;
 
 		Ok(invoice)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use lightning::util::ser::{Readable, Writeable};
+
+	use super::*;
+
+	#[test]
+	fn empty_metadata_roundtrips() {
+		let metadata = PaymentMetadata { lsps2_parameters: None };
+
+		let encoded = metadata.encode();
+		let decoded = PaymentMetadata::read(&mut &*encoded).unwrap();
+
+		assert_eq!(metadata, decoded);
+	}
+
+	#[test]
+	fn lsps2_parameters_roundtrip() {
+		let lsps2_parameters = LSPS2Parameters {
+			max_total_opening_fee_msat: Some(42_000),
+			max_proportional_opening_fee_ppm_msat: Some(17_000),
+		};
+		let metadata = PaymentMetadata { lsps2_parameters: Some(lsps2_parameters) };
+
+		let encoded = metadata.encode();
+		let decoded = PaymentMetadata::read(&mut &*encoded).unwrap();
+
+		assert_eq!(metadata, decoded);
 	}
 }
 
@@ -295,6 +330,7 @@ impl Bolt11Payment {
 					hash: payment_hash,
 					preimage: None,
 					secret: payment_secret,
+					counterparty_skimmed_fee_msat: None,
 				};
 				let payment = PaymentDetails::new(
 					payment_id,
@@ -324,6 +360,7 @@ impl Bolt11Payment {
 							hash: payment_hash,
 							preimage: None,
 							secret: payment_secret,
+							counterparty_skimmed_fee_msat: None,
 						};
 						let payment = PaymentDetails::new(
 							payment_id,
@@ -409,6 +446,7 @@ impl Bolt11Payment {
 					hash: payment_hash,
 					preimage: None,
 					secret: payment_secret,
+					counterparty_skimmed_fee_msat: None,
 				};
 
 				let payment = PaymentDetails::new(
@@ -439,6 +477,7 @@ impl Bolt11Payment {
 							hash: payment_hash,
 							preimage: None,
 							secret: payment_secret,
+							counterparty_skimmed_fee_msat: None,
 						};
 						let payment = PaymentDetails::new(
 							payment_id,
@@ -493,7 +532,7 @@ impl Bolt11Payment {
 			// For payments requested via `receive*_via_jit_channel_for_hash()`
 			// `skimmed_fee_msat` held by LSP must be taken into account.
 			let skimmed_fee_msat = match details.kind {
-				PaymentKind::Bolt11Jit {
+				PaymentKind::Bolt11 {
 					counterparty_skimmed_fee_msat: Some(skimmed_fee_msat),
 					..
 				} => skimmed_fee_msat,
@@ -686,7 +725,7 @@ impl Bolt11Payment {
 	/// [`PaymentClaimable`]: crate::Event::PaymentClaimable
 	/// [`claim_for_hash`]: Self::claim_for_hash
 	/// [`fail_for_hash`]: Self::fail_for_hash
-	/// [`counterparty_skimmed_fee_msat`]: crate::payment::PaymentKind::Bolt11Jit::counterparty_skimmed_fee_msat
+	/// [`counterparty_skimmed_fee_msat`]: crate::payment::PaymentKind::Bolt11::counterparty_skimmed_fee_msat
 	pub fn receive_via_jit_channel_for_hash(
 		&self, amount_msat: u64, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_total_lsp_fee_limit_msat: Option<u64>, payment_hash: PaymentHash,
@@ -753,7 +792,7 @@ impl Bolt11Payment {
 	/// [`PaymentClaimable`]: crate::Event::PaymentClaimable
 	/// [`claim_for_hash`]: Self::claim_for_hash
 	/// [`fail_for_hash`]: Self::fail_for_hash
-	/// [`counterparty_skimmed_fee_msat`]: crate::payment::PaymentKind::Bolt11Jit::counterparty_skimmed_fee_msat
+	/// [`counterparty_skimmed_fee_msat`]: crate::payment::PaymentKind::Bolt11::counterparty_skimmed_fee_msat
 	pub fn receive_variable_amount_via_jit_channel_for_hash(
 		&self, description: &Bolt11InvoiceDescription, expiry_secs: u32,
 		max_proportional_lsp_fee_limit_ppm_msat: Option<u64>, payment_hash: PaymentHash,

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -22,6 +22,7 @@ pub use onchain::OnchainPayment;
 pub use pending_payment_store::PendingPaymentDetails;
 pub use spontaneous::SpontaneousPayment;
 pub use store::{
-	ConfirmationStatus, LSPFeeLimits, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
+	ConfirmationStatus, LSPS2Parameters, PaymentDetails, PaymentDirection, PaymentKind,
+	PaymentStatus,
 };
 pub use unified::{UnifiedPayment, UnifiedPaymentResult};

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod store;
 mod unified;
 
 pub use bolt11::Bolt11Payment;
+pub(crate) use bolt11::PaymentMetadata;
 pub use bolt12::Bolt12Payment;
 pub use onchain::OnchainPayment;
 pub use pending_payment_store::PendingPaymentDetails;

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -129,18 +129,8 @@ impl Readable for PaymentDetails {
 			let hash = PaymentHash(id.0);
 
 			if secret.is_some() {
-				if let Some(lsp_fee_limits) = lsp_fee_limits {
-					let counterparty_skimmed_fee_msat = None;
-					PaymentKind::Bolt11Jit {
-						hash,
-						preimage,
-						secret,
-						counterparty_skimmed_fee_msat,
-						lsp_fee_limits,
-					}
-				} else {
-					PaymentKind::Bolt11 { hash, preimage, secret }
-				}
+				let _: Option<LSPS2Parameters> = lsp_fee_limits;
+				PaymentKind::Bolt11 { hash, preimage, secret, counterparty_skimmed_fee_msat: None }
 			} else {
 				PaymentKind::Spontaneous { hash, preimage }
 			}
@@ -225,9 +215,6 @@ impl StorableObject for PaymentDetails {
 				PaymentKind::Bolt11 { ref mut preimage, .. } => {
 					update_if_necessary!(*preimage, preimage_opt)
 				},
-				PaymentKind::Bolt11Jit { ref mut preimage, .. } => {
-					update_if_necessary!(*preimage, preimage_opt)
-				},
 				PaymentKind::Bolt12Offer { ref mut preimage, .. } => {
 					update_if_necessary!(*preimage, preimage_opt)
 				},
@@ -244,9 +231,6 @@ impl StorableObject for PaymentDetails {
 		if let Some(secret_opt) = update.secret {
 			match self.kind {
 				PaymentKind::Bolt11 { ref mut secret, .. } => {
-					update_if_necessary!(*secret, secret_opt)
-				},
-				PaymentKind::Bolt11Jit { ref mut secret, .. } => {
 					update_if_necessary!(*secret, secret_opt)
 				},
 				PaymentKind::Bolt12Offer { ref mut secret, .. } => {
@@ -269,12 +253,12 @@ impl StorableObject for PaymentDetails {
 
 		if let Some(skimmed_fee_msat) = update.counterparty_skimmed_fee_msat {
 			match self.kind {
-				PaymentKind::Bolt11Jit { ref mut counterparty_skimmed_fee_msat, .. } => {
+				PaymentKind::Bolt11 { ref mut counterparty_skimmed_fee_msat, .. } => {
 					update_if_necessary!(*counterparty_skimmed_fee_msat, skimmed_fee_msat);
 				},
 				_ => debug_assert!(
 					false,
-					"We should only ever override counterparty_skimmed_fee_msat for JIT payments"
+					"We should only ever override counterparty_skimmed_fee_msat for BOLT11 payments"
 				),
 			}
 		}
@@ -375,33 +359,14 @@ pub enum PaymentKind {
 		preimage: Option<PaymentPreimage>,
 		/// The secret used by the payment.
 		secret: Option<PaymentSecret>,
-	},
-	/// A [BOLT 11] payment intended to open an [bLIP-52 / LSPS 2] just-in-time channel.
-	///
-	/// [BOLT 11]: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
-	/// [bLIP-52 / LSPS2]: https://github.com/lightning/blips/blob/master/blip-0052.md
-	Bolt11Jit {
-		/// The payment hash, i.e., the hash of the `preimage`.
-		hash: PaymentHash,
-		/// The pre-image used by the payment.
-		preimage: Option<PaymentPreimage>,
-		/// The secret used by the payment.
-		secret: Option<PaymentSecret>,
 		/// The value, in thousands of a satoshi, that was deducted from this payment as an extra
 		/// fee taken by our channel counterparty.
 		///
-		/// Will only be `Some` once we received the payment. Will always be `None` for LDK Node
-		/// v0.4 and prior.
+		/// Will only ever be `Some` for inbound payments received via an [bLIP-52 / LSPS 2]
+		/// just-in-time channel, and only after the payment is observed; `None` otherwise.
+		///
+		/// [bLIP-52 / LSPS 2]: https://github.com/lightning/blips/blob/master/blip-0052.md
 		counterparty_skimmed_fee_msat: Option<u64>,
-		/// Limits applying to how much fee we allow an LSP to deduct from the payment amount.
-		///
-		/// Allowing them to deduct this fee from the first inbound payment will pay for the LSP's
-		/// channel opening fees.
-		///
-		/// See [`LdkChannelConfig::accept_underpaying_htlcs`] for more information.
-		///
-		/// [`LdkChannelConfig::accept_underpaying_htlcs`]: lightning::util::config::ChannelConfig::accept_underpaying_htlcs
-		lsp_fee_limits: LSPS2Parameters,
 	},
 	/// A [BOLT 12] 'offer' payment, i.e., a payment for an [`Offer`].
 	///
@@ -465,15 +430,19 @@ impl_writeable_tlv_based_enum!(PaymentKind,
 	},
 	(2, Bolt11) => {
 		(0, hash, required),
+		(1, counterparty_skimmed_fee_msat, option),
 		(2, preimage, option),
 		(4, secret, option),
 	},
-	(4, Bolt11Jit) => {
+	(4, Bolt11) => {
 		(0, hash, required),
 		(1, counterparty_skimmed_fee_msat, option),
 		(2, preimage, option),
 		(4, secret, option),
-		(6, lsp_fee_limits, required),
+		(6, _legacy_lsps2_parameters, (legacy, LSPS2Parameters,
+			|_| Ok(()),
+			|_: &PaymentKind| None::<Option<LSPS2Parameters>>
+		)),
 	},
 	(6, Bolt12Offer) => {
 		(0, hash, option),
@@ -580,7 +549,6 @@ impl From<&PaymentDetails> for PaymentDetailsUpdate {
 	fn from(value: &PaymentDetails) -> Self {
 		let (hash, preimage, secret) = match value.kind {
 			PaymentKind::Bolt11 { hash, preimage, secret, .. } => (Some(hash), preimage, secret),
-			PaymentKind::Bolt11Jit { hash, preimage, secret, .. } => (Some(hash), preimage, secret),
 			PaymentKind::Bolt12Offer { hash, preimage, secret, .. } => (hash, preimage, secret),
 			PaymentKind::Bolt12Refund { hash, preimage, secret, .. } => (hash, preimage, secret),
 			PaymentKind::Spontaneous { hash, preimage, .. } => (Some(hash), preimage, None),
@@ -593,7 +561,7 @@ impl From<&PaymentDetails> for PaymentDetailsUpdate {
 		};
 
 		let counterparty_skimmed_fee_msat = match value.kind {
-			PaymentKind::Bolt11Jit { counterparty_skimmed_fee_msat, .. } => {
+			PaymentKind::Bolt11 { counterparty_skimmed_fee_msat, .. } => {
 				Some(counterparty_skimmed_fee_msat)
 			},
 			_ => None,
@@ -623,7 +591,7 @@ impl StorableObjectUpdate<PaymentDetails> for PaymentDetailsUpdate {
 
 #[cfg(test)]
 mod tests {
-	use lightning::util::ser::Readable;
+	use lightning::util::ser::{Readable, Writeable};
 
 	use super::*;
 
@@ -682,10 +650,16 @@ mod tests {
 			assert_eq!(bolt11_decoded, PaymentDetails::read(&mut &*bolt11_reencoded).unwrap());
 
 			match bolt11_decoded.kind {
-				PaymentKind::Bolt11 { hash: h, preimage: p, secret: s } => {
+				PaymentKind::Bolt11 {
+					hash: h,
+					preimage: p,
+					secret: s,
+					counterparty_skimmed_fee_msat: c,
+				} => {
 					assert_eq!(hash, h);
 					assert_eq!(preimage, p);
 					assert_eq!(secret, s);
+					assert_eq!(None, c);
 				},
 				_ => {
 					panic!("Unexpected kind!");
@@ -724,18 +698,16 @@ mod tests {
 			);
 
 			match bolt11_jit_decoded.kind {
-				PaymentKind::Bolt11Jit {
+				PaymentKind::Bolt11 {
 					hash: h,
 					preimage: p,
 					secret: s,
 					counterparty_skimmed_fee_msat: c,
-					lsp_fee_limits: l,
 				} => {
 					assert_eq!(hash, h);
 					assert_eq!(preimage, p);
 					assert_eq!(secret, s);
 					assert_eq!(None, c);
-					assert_eq!(lsp_fee_limits, Some(l));
 				},
 				_ => {
 					panic!("Unexpected kind!");
@@ -778,5 +750,69 @@ mod tests {
 				},
 			}
 		}
+	}
+
+	#[derive(Clone, Debug, PartialEq, Eq)]
+	struct LegacyBolt11JitKind {
+		hash: PaymentHash,
+		counterparty_skimmed_fee_msat: Option<u64>,
+		preimage: Option<PaymentPreimage>,
+		secret: Option<PaymentSecret>,
+		lsp_fee_limits: LSPS2Parameters,
+	}
+
+	impl_writeable_tlv_based!(LegacyBolt11JitKind, {
+		(0, hash, required),
+		(1, counterparty_skimmed_fee_msat, option),
+		(2, preimage, option),
+		(4, secret, option),
+		(6, lsp_fee_limits, required),
+	});
+
+	#[test]
+	fn legacy_bolt11_jit_kind_decodes_as_bolt11() {
+		let hash = PaymentHash([42u8; 32]);
+		let preimage = Some(PaymentPreimage([43u8; 32]));
+		let secret = Some(PaymentSecret([44u8; 32]));
+		let counterparty_skimmed_fee_msat = Some(7_777u64);
+		let lsp_fee_limits = LSPS2Parameters {
+			max_total_opening_fee_msat: Some(46_000),
+			max_proportional_opening_fee_ppm_msat: Some(47_000),
+		};
+
+		let legacy = LegacyBolt11JitKind {
+			hash,
+			counterparty_skimmed_fee_msat,
+			preimage,
+			secret,
+			lsp_fee_limits,
+		};
+		let legacy_encoded = legacy.encode();
+		assert_eq!(legacy, LegacyBolt11JitKind::read(&mut &*legacy_encoded.clone()).unwrap());
+
+		let mut on_disk = Vec::with_capacity(legacy_encoded.len() + 1);
+		4u8.write(&mut on_disk).unwrap();
+		on_disk.extend_from_slice(&legacy_encoded);
+
+		let decoded = PaymentKind::read(&mut &*on_disk).unwrap();
+
+		match decoded {
+			PaymentKind::Bolt11 {
+				hash: h,
+				preimage: p,
+				secret: s,
+				counterparty_skimmed_fee_msat: c,
+			} => {
+				assert_eq!(hash, h);
+				assert_eq!(preimage, p);
+				assert_eq!(secret, s);
+				assert_eq!(counterparty_skimmed_fee_msat, c);
+			},
+			other => panic!("Expected Bolt11, got {:?}", other),
+		}
+
+		let reencoded = decoded.encode();
+		assert_eq!(reencoded[0], 2);
+		assert_eq!(decoded, PaymentKind::read(&mut &*reencoded).unwrap());
 	}
 }

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -68,7 +68,6 @@ impl Writeable for PaymentDetails {
 	) -> Result<(), lightning::io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.id, required), // Used to be `hash` for v0.2.1 and prior
-			// 1 briefly used to be lsp_fee_limits, could probably be reused at some point in the future.
 			// 2 used to be `preimage` before it was moved to `kind` in v0.3.0
 			(2, None::<Option<PaymentPreimage>>, required),
 			(3, self.kind, required),
@@ -92,7 +91,6 @@ impl Readable for PaymentDetails {
 			.as_secs();
 		_init_and_read_len_prefixed_tlv_fields!(reader, {
 			(0, id, required), // Used to be `hash`
-			(1, lsp_fee_limits, option),
 			(2, preimage, required),
 			(3, kind_opt, option),
 			(4, secret, required),
@@ -129,7 +127,6 @@ impl Readable for PaymentDetails {
 			let hash = PaymentHash(id.0);
 
 			if secret.is_some() {
-				let _: Option<LSPS2Parameters> = lsp_fee_limits;
 				PaymentKind::Bolt11 { hash, preimage, secret, counterparty_skimmed_fee_msat: None }
 			} else {
 				PaymentKind::Spontaneous { hash, preimage }
@@ -605,12 +602,10 @@ mod tests {
 		pub amount_msat: Option<u64>,
 		pub direction: PaymentDirection,
 		pub status: PaymentStatus,
-		pub lsp_fee_limits: Option<LSPS2Parameters>,
 	}
 
 	impl_writeable_tlv_based!(OldPaymentDetails, {
 		(0, hash, required),
-		(1, lsp_fee_limits, option),
 		(2, preimage, required),
 		(4, secret, required),
 		(6, amount_msat, required),
@@ -636,7 +631,6 @@ mod tests {
 				amount_msat,
 				direction: PaymentDirection::Inbound,
 				status: PaymentStatus::Pending,
-				lsp_fee_limits: None,
 			};
 
 			let old_bolt11_encoded = old_bolt11_payment.encode();
@@ -667,54 +661,6 @@ mod tests {
 			}
 		}
 
-		// Test `Bolt11Jit` de/ser
-		{
-			let lsp_fee_limits = Some(LSPS2Parameters {
-				max_total_opening_fee_msat: Some(46_000),
-				max_proportional_opening_fee_ppm_msat: Some(47_000),
-			});
-
-			let old_bolt11_jit_payment = OldPaymentDetails {
-				hash,
-				preimage,
-				secret,
-				amount_msat,
-				direction: PaymentDirection::Inbound,
-				status: PaymentStatus::Pending,
-				lsp_fee_limits,
-			};
-
-			let old_bolt11_jit_encoded = old_bolt11_jit_payment.encode();
-			assert_eq!(
-				old_bolt11_jit_payment,
-				OldPaymentDetails::read(&mut &*old_bolt11_jit_encoded.clone()).unwrap()
-			);
-
-			let bolt11_jit_decoded = PaymentDetails::read(&mut &*old_bolt11_jit_encoded).unwrap();
-			let bolt11_jit_reencoded = bolt11_jit_decoded.encode();
-			assert_eq!(
-				bolt11_jit_decoded,
-				PaymentDetails::read(&mut &*bolt11_jit_reencoded).unwrap()
-			);
-
-			match bolt11_jit_decoded.kind {
-				PaymentKind::Bolt11 {
-					hash: h,
-					preimage: p,
-					secret: s,
-					counterparty_skimmed_fee_msat: c,
-				} => {
-					assert_eq!(hash, h);
-					assert_eq!(preimage, p);
-					assert_eq!(secret, s);
-					assert_eq!(None, c);
-				},
-				_ => {
-					panic!("Unexpected kind!");
-				},
-			}
-		}
-
 		// Test `Spontaneous` de/ser
 		{
 			let old_spontaneous_payment = OldPaymentDetails {
@@ -724,7 +670,6 @@ mod tests {
 				amount_msat,
 				direction: PaymentDirection::Inbound,
 				status: PaymentStatus::Pending,
-				lsp_fee_limits: None,
 			};
 
 			let old_spontaneous_encoded = old_spontaneous_payment.encode();

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -401,7 +401,7 @@ pub enum PaymentKind {
 		/// See [`LdkChannelConfig::accept_underpaying_htlcs`] for more information.
 		///
 		/// [`LdkChannelConfig::accept_underpaying_htlcs`]: lightning::util::config::ChannelConfig::accept_underpaying_htlcs
-		lsp_fee_limits: LSPFeeLimits,
+		lsp_fee_limits: LSPS2Parameters,
 	},
 	/// A [BOLT 12] 'offer' payment, i.e., a payment for an [`Offer`].
 	///
@@ -529,7 +529,7 @@ impl_writeable_tlv_based_enum!(ConfirmationStatus,
 /// [`LdkChannelConfig::accept_underpaying_htlcs`]: lightning::util::config::ChannelConfig::accept_underpaying_htlcs
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct LSPFeeLimits {
+pub struct LSPS2Parameters {
 	/// The maximal total amount we allow any configured LSP withhold from us when forwarding the
 	/// payment.
 	pub max_total_opening_fee_msat: Option<u64>,
@@ -538,7 +538,7 @@ pub struct LSPFeeLimits {
 	pub max_proportional_opening_fee_ppm_msat: Option<u64>,
 }
 
-impl_writeable_tlv_based!(LSPFeeLimits, {
+impl_writeable_tlv_based!(LSPS2Parameters, {
 	(0, max_total_opening_fee_msat, option),
 	(2, max_proportional_opening_fee_ppm_msat, option),
 });
@@ -637,7 +637,7 @@ mod tests {
 		pub amount_msat: Option<u64>,
 		pub direction: PaymentDirection,
 		pub status: PaymentStatus,
-		pub lsp_fee_limits: Option<LSPFeeLimits>,
+		pub lsp_fee_limits: Option<LSPS2Parameters>,
 	}
 
 	impl_writeable_tlv_based!(OldPaymentDetails, {
@@ -695,7 +695,7 @@ mod tests {
 
 		// Test `Bolt11Jit` de/ser
 		{
-			let lsp_fee_limits = Some(LSPFeeLimits {
+			let lsp_fee_limits = Some(LSPS2Parameters {
 				max_total_opening_fee_msat: Some(46_000),
 				max_proportional_opening_fee_ppm_msat: Some(47_000),
 			});

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -1880,7 +1880,7 @@ async fn do_lsps2_client_service_integration(client_trusts_lsp: bool) {
 		expect_payment_received_event!(client_node, expected_received_amount_msat).unwrap();
 	let client_payment = client_node.payment(&client_payment_id).unwrap();
 	match client_payment.kind {
-		PaymentKind::Bolt11Jit { counterparty_skimmed_fee_msat, .. } => {
+		PaymentKind::Bolt11 { counterparty_skimmed_fee_msat, .. } => {
 			assert_eq!(counterparty_skimmed_fee_msat, Some(service_fee_msat));
 		},
 		_ => panic!("Unexpected payment kind"),
@@ -1955,7 +1955,7 @@ async fn do_lsps2_client_service_integration(client_trusts_lsp: bool) {
 		expect_payment_received_event!(client_node, expected_received_amount_msat).unwrap();
 	let client_payment = client_node.payment(&client_payment_id).unwrap();
 	match client_payment.kind {
-		PaymentKind::Bolt11Jit { counterparty_skimmed_fee_msat, .. } => {
+		PaymentKind::Bolt11 { counterparty_skimmed_fee_msat, .. } => {
 			assert_eq!(counterparty_skimmed_fee_msat, Some(service_fee_msat));
 		},
 		_ => panic!("Unexpected payment kind"),


### PR DESCRIPTION
## Context 

We recently found that for the intended BOLT12-JIT flow we'll have to encode the LSPS2 parameters in the payment metadata (based on https://github.com/lightningdevkit/rust-lightning/pull/4584). As a prefactor to that (and to simplify things for #811, rather than add yet another store type there, just to revert once we get to the BOLT12-JIT changes), we here switch to store the LSPS2 parameters in the BOLT11 `payment_metadata` rather than persisting them on-disk. To make this safe we'll also need https://github.com/lightningdevkit/rust-lightning/pull/4528, as otherwise the payer could collude with the LSP to rob the payee.

## Summary

  This moves LSPS2/JIT-channel receive parameters out of dedicated payment-store
  state and into the BOLT11 invoice `payment_metadata`, so the payment store no
  longer needs a `PaymentKind::Bolt11Jit` variant for new payments.

## Changes

  - Rename `LSPFeeLimits` to `LSPS2Parameters`.
  - Add `Bolt11PaymentMetadata` in `bolt11.rs` with TLV-based encoding.
  - Encode `LSPS2Parameters` into BOLT11 `payment_metadata` when creating JIT
    invoices.
  - Store new JIT receives as `PaymentKind::Bolt11`.
  - Decode legacy `PaymentKind::Bolt11Jit` records as `PaymentKind::Bolt11`.
  - Reject skimmed inbound payments unless valid BOLT11 `payment_metadata` proves
    the LSPS2 fee is within the negotiated limit.
  - Drop the stale top-level `PaymentDetails` field-1 JIT metadata reader, while
    keeping the released legacy `PaymentKind::Bolt11Jit` decoder.
  - Add a changelog note that pending JIT payments may fail after upgrade because
    prior JIT state is not migrated.


