### PR TITLE
Derive `PartialEq` and `Eq` for `AsyncPaymentsRole`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -681,7 +681,7 @@ impl From<MaxDustHTLCExposure> for LdkMaxDustHTLCExposure {
 	}
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 /// The role of the node in an asynchronous payments context.
 ///


### PR DESCRIPTION
In https://github.com/lightningdevkit/ldk-server/pull/208 I needed to use `matches!` instead of an `assert_eq!`