### PR TITLE
tests: Add interoperability tests for BOLT12 (Offers) with CLN

### DIFF
--- a/tests/common/cln.rs
+++ b/tests/common/cln.rs
@@ -181,12 +181,81 @@ impl ExternalNode for TestClnNode {
 		Ok(invoice.bolt11)
 	}
 
+	async fn create_offer(
+		&self, amount_msat: u64, description: &str,
+	) -> Result<String, TestFailure> {
+		let desc = description.to_string();
+		let label = format!(
+			"{}-{}",
+			desc,
+			std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.unwrap_or_default()
+				.as_nanos()
+		);
+
+		let params = serde_json::json!({
+			"amount": format!("{}msat", amount_msat),
+			"description": desc,
+			"label": label,
+			"single_use": true,
+		});
+
+		let response: serde_json::Value = self
+			.rpc(move |c| c.call("offer", &params))
+			.await
+			.map_err(|e| self.make_error(format!("offer RPC call failed: {}", e)))?;
+
+		let offer_str = response["bolt12"]
+			.as_str()
+			.ok_or_else(|| {
+				self.make_error("Failed to parse 'bolt12' from CLN response".to_string())
+			})?
+			.to_string();
+
+		Ok(offer_str)
+	}
+
 	async fn pay_invoice(&self, invoice: &str) -> Result<String, TestFailure> {
 		let inv = invoice.to_string();
 		let result = self
 			.rpc(move |c| c.pay(&inv, PayOptions::default()))
 			.await
 			.map_err(|e| self.make_error(format!("pay: {}", e)))?;
+		Ok(result.payment_preimage)
+	}
+
+	async fn pay_offer(
+		&self, offer_str: &str, amount_msat: Option<u64>,
+	) -> Result<String, TestFailure> {
+		let offer = offer_str.to_string();
+
+		let mut fetch_params = serde_json::json!({
+			"offer": offer,
+			"quantity": 1,
+		});
+
+		if let Some(msat) = amount_msat {
+			fetch_params["amount_msat"] = serde_json::json!(format!("{}msat", msat));
+		}
+
+		let fetch_response: serde_json::Value =
+			self.rpc(move |c| c.call("fetchinvoice", fetch_params)).await.map_err(|e| {
+				self.make_error(format!("fetchinvoice RPC call failed for BOLT12: {}", e))
+			})?;
+
+		let inv = fetch_response["invoice"]
+			.as_str()
+			.ok_or_else(|| {
+				self.make_error("Failed to parse 'invoice' from fetchinvoice response".to_string())
+			})?
+			.to_string();
+
+		let result = self
+			.rpc(move |c| c.pay(&inv, PayOptions::default()))
+			.await
+			.map_err(|e| self.make_error(format!("pay: {}", e)))?;
+
 		Ok(result.payment_preimage)
 	}
 

--- a/tests/common/eclair.rs
+++ b/tests/common/eclair.rs
@@ -211,6 +211,12 @@ impl ExternalNode for TestEclairNode {
 		Ok(invoice.to_string())
 	}
 
+	async fn create_offer(
+		&self, amount_msat: u64, description: &str,
+	) -> Result<String, TestFailure> {
+		Err(self.make_error("create_offer is not supported on Eclair".to_string()))
+	}
+
 	async fn pay_invoice(&self, invoice: &str) -> Result<String, TestFailure> {
 		let result = self.post("/payinvoice", &[("invoice", invoice)]).await?;
 		let payment_id = result
@@ -218,6 +224,12 @@ impl ExternalNode for TestEclairNode {
 			.ok_or_else(|| self.make_error("payinvoice did not return payment id"))?
 			.to_string();
 		self.poll_payment_settlement(&payment_id, "payment").await
+	}
+
+	async fn pay_offer(
+		&self, _offer_str: &str, _amount_msat: Option<u64>,
+	) -> Result<String, TestFailure> {
+		Err(self.make_error("pay_offer is not supported on Eclair".to_string()))
 	}
 
 	async fn send_keysend(

--- a/tests/common/external_node.rs
+++ b/tests/common/external_node.rs
@@ -87,8 +87,18 @@ pub(crate) trait ExternalNode: Send + Sync {
 		&self, amount_msat: u64, description: &str,
 	) -> Result<String, TestFailure>;
 
+	/// Create a BOLT12 offer for the given amount
+	async fn create_offer(
+		&self, amount_msat: u64, description: &str,
+	) -> Result<String, TestFailure>;
+
 	/// Pay a BOLT11 invoice; returns an implementation-specific payment identifier on success.
 	async fn pay_invoice(&self, invoice: &str) -> Result<String, TestFailure>;
+
+	/// Pay a BOLT12 offer; returns an implementation-specific payment identifier on success.
+	async fn pay_offer(
+		&self, offer_str: &str, amount_msat: Option<u64>,
+	) -> Result<String, TestFailure>;
 
 	/// Send a keysend payment to a peer.
 	async fn send_keysend(

--- a/tests/common/lnd.rs
+++ b/tests/common/lnd.rs
@@ -243,6 +243,14 @@ impl ExternalNode for TestLndNode {
 		Ok(response.payment_request)
 	}
 
+	async fn create_offer(
+		&self, amount_msat: u64, description: &str,
+	) -> Result<String, TestFailure> {
+		Err(self.make_error(
+			"create_offer is not supported on LND without LNDK integration".to_string(),
+		))
+	}
+
 	async fn pay_invoice(&self, invoice: &str) -> Result<String, TestFailure> {
 		let mut client = self.client.lock().await;
 		let request = SendPaymentRequest {
@@ -278,6 +286,13 @@ impl ExternalNode for TestLndNode {
 		}
 
 		Err(self.make_error("payment stream ended without terminal status"))
+	}
+
+	async fn pay_offer(
+		&self, _offer_str: &str, _amount_msat: Option<u64>,
+	) -> Result<String, TestFailure> {
+		Err(self
+			.make_error("pay_offer is not supported on LND without LNDK integration".to_string()))
 	}
 
 	async fn send_keysend(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -216,10 +216,30 @@ macro_rules! expect_payment_received_event {
 			panic!("{} timed out waiting for PaymentReceived event after 60s", $node.node_id())
 		});
 		match event {
-			ref e @ Event::PaymentReceived { payment_id, amount_msat, .. } => {
+			ref e @ Event::PaymentReceived { payment_id, amount_msat: rec_msat, .. } => {
 				println!("{} got event {:?}", $node.node_id(), e);
-				assert_eq!(amount_msat, $amount_msat);
+
 				let payment = $node.payment(&payment_id.unwrap()).unwrap();
+
+				match payment.kind {
+					ldk_node::payment::PaymentKind::Bolt12Offer { .. } => {
+						// BOLT12: Blinded paths can lead to minor overpayments (e.g., routing path fees)
+						assert!(
+							rec_msat >= $amount_msat,
+							"BOLT12: Received amount ({}) is less than expected ({})",
+							rec_msat,
+							$amount_msat
+						);
+					},
+					_ => {
+						assert_eq!(
+							rec_msat, $amount_msat,
+							"BOLT11/Keysend: Received amount ({}) does not match expected ({})",
+							rec_msat, $amount_msat
+						);
+					},
+				}
+
 				if !matches!(payment.kind, ldk_node::payment::PaymentKind::Onchain { .. }) {
 					assert_eq!(payment.fee_paid_msat, None);
 				}

--- a/tests/common/scenarios/mod.rs
+++ b/tests/common/scenarios/mod.rs
@@ -151,7 +151,7 @@ pub(crate) async fn run_interop_scenario<N, E, F>(
 }
 
 /// Open a channel, send a BOLT11 payment in each direction, then cooperatively close.
-pub(crate) async fn basic_channel_cycle_scenario<E: ElectrumApi>(
+pub(crate) async fn basic_channel_cycle_bolt11_scenario<E: ElectrumApi>(
 	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
 ) {
 	let (user_ch, ext_ch) = channel::open_channel_to_external(
@@ -164,8 +164,28 @@ pub(crate) async fn basic_channel_cycle_scenario<E: ElectrumApi>(
 	)
 	.await;
 
-	payment::send_bolt11_to_peer(node, peer, 10_000_000, "basic-send").await;
+	payment::send_bolt11_to_peer(node, peer, 10_000_000, "basic-send-bolt11").await;
 	payment::receive_bolt11_payment(node, peer, 10_000_000).await;
+
+	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
+}
+
+/// Open a channel, send a BOLT12 payment in each direction, then cooperatively close.
+pub(crate) async fn basic_channel_cycle_bolt12_scenario<E: ElectrumApi>(
+	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
+) {
+	let (user_ch, ext_ch) = channel::open_channel_to_external(
+		node,
+		peer,
+		bitcoind,
+		electrs,
+		1_000_000,
+		Some(500_000_000),
+	)
+	.await;
+
+	payment::send_bolt12_to_peer(node, peer, 10_000_000, "basic-send-bolt12").await;
+	payment::receive_bolt12_payment(node, peer, 10_000_000).await;
 
 	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
 }
@@ -188,8 +208,8 @@ pub(crate) async fn keysend_scenario<E: ElectrumApi>(
 	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
 }
 
-/// Open a channel, send a payment, then force-close from the LDK side.
-pub(crate) async fn force_close_after_payment_scenario<E: ElectrumApi>(
+/// Open a channel, send a BOLT11 payment, then force-close from the LDK side.
+pub(crate) async fn force_close_after_payment_bolt11_scenario<E: ElectrumApi>(
 	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
 ) {
 	let (user_ch, ext_ch) = channel::open_channel_to_external(
@@ -201,7 +221,25 @@ pub(crate) async fn force_close_after_payment_scenario<E: ElectrumApi>(
 		Some(500_000_000),
 	)
 	.await;
-	payment::send_bolt11_to_peer(node, peer, 5_000_000, "force-close").await;
+	payment::send_bolt11_to_peer(node, peer, 5_000_000, "force-close-bolt11").await;
+	wait_for_htlcs_settled(peer, &ext_ch).await;
+	channel::force_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
+}
+
+/// Open a channel, send a BOLT12 payment, then force-close from the LDK side.
+pub(crate) async fn force_close_after_payment_bolt12_scenario<E: ElectrumApi>(
+	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
+) {
+	let (user_ch, ext_ch) = channel::open_channel_to_external(
+		node,
+		peer,
+		bitcoind,
+		electrs,
+		1_000_000,
+		Some(500_000_000),
+	)
+	.await;
+	payment::send_bolt12_to_peer(node, peer, 5_000_000, "force-close-bolt12").await;
 	wait_for_htlcs_settled(peer, &ext_ch).await;
 	channel::force_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
 }
@@ -225,8 +263,8 @@ pub(crate) async fn disconnect_during_payment_scenario<E: ElectrumApi>(
 	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
 }
 
-/// Open a channel, splice-in additional funds, send a post-splice payment, then close.
-pub(crate) async fn splice_in_scenario<E: ElectrumApi>(
+/// Open a channel, splice-in additional funds, send a post-splice BOLT11 payment, then close.
+pub(crate) async fn splice_in_bolt11_scenario<E: ElectrumApi>(
 	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
 ) {
 	let (user_ch, ext_ch) = channel::open_channel_to_external(
@@ -245,7 +283,32 @@ pub(crate) async fn splice_in_scenario<E: ElectrumApi>(
 	sync_wallets_with_retry(node).await;
 	expect_channel_ready_event!(node, ext_node_id);
 
-	payment::send_bolt11_to_peer(node, peer, 5_000_000, "post-splice").await;
+	payment::send_bolt11_to_peer(node, peer, 5_000_000, "post-splice-bolt11").await;
+
+	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
+}
+
+/// Open a channel, splice-in additional funds, send a post-splice BOLT12 payment, then close.
+pub(crate) async fn splice_in_bolt12_scenario<E: ElectrumApi>(
+	node: &Node, peer: &(impl ExternalNode + ?Sized), bitcoind: &BitcoindClient, electrs: &E,
+) {
+	let (user_ch, ext_ch) = channel::open_channel_to_external(
+		node,
+		peer,
+		bitcoind,
+		electrs,
+		1_000_000,
+		Some(500_000_000),
+	)
+	.await;
+	let ext_node_id = peer.get_node_id().await.unwrap();
+	node.splice_in(&user_ch, ext_node_id, 500_000).unwrap();
+	expect_splice_pending_event!(node, ext_node_id);
+	generate_blocks_and_wait(bitcoind, electrs, 6).await;
+	sync_wallets_with_retry(node).await;
+	expect_channel_ready_event!(node, ext_node_id);
+
+	payment::send_bolt12_to_peer(node, peer, 5_000_000, "post-splice-bolt12").await;
 
 	channel::cooperative_close(node, peer, bitcoind, electrs, &user_ch, &ext_ch, Side::Ldk).await;
 }

--- a/tests/common/scenarios/payment.rs
+++ b/tests/common/scenarios/payment.rs
@@ -7,11 +7,11 @@
 
 use std::str::FromStr;
 
-use ldk_node::{Event, Node};
-use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
-
 use super::super::external_node::ExternalNode;
 use super::retry_until_ok;
+use ldk_node::{Event, Node};
+use lightning::offers::offer::Offer;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 
 /// LDK pays the peer via a fresh BOLT11 invoice; asserts `PaymentSuccessful`.
 pub(crate) async fn send_bolt11_to_peer(
@@ -20,6 +20,16 @@ pub(crate) async fn send_bolt11_to_peer(
 	let invoice_str = peer.create_invoice(amount_msat, label).await.unwrap();
 	let parsed = Bolt11Invoice::from_str(&invoice_str).unwrap();
 	node.bolt11_payment().send(&parsed, None).unwrap();
+	expect_event!(node, PaymentSuccessful);
+}
+
+/// LDK pays the peer via a fresh BOLT12 offer; asserts `PaymentSuccessful`.
+pub(crate) async fn send_bolt12_to_peer(
+	node: &Node, peer: &(impl ExternalNode + ?Sized), amount_msat: u64, label: &str,
+) {
+	let offer_str = peer.create_offer(amount_msat, label).await.unwrap();
+	let parsed_offer = Offer::from_str(&offer_str).unwrap();
+	node.bolt12_payment().send(&parsed_offer, None, None, None).unwrap();
 	expect_event!(node, PaymentSuccessful);
 }
 
@@ -33,13 +43,28 @@ pub(crate) async fn receive_bolt11_payment(
 		.receive(
 			amount_msat,
 			&Bolt11InvoiceDescription::Direct(
-				Description::new("interop-receive-test".to_string()).unwrap(),
+				Description::new("interop-receive-test-bolt11".to_string()).unwrap(),
 			),
 			3600,
 		)
 		.unwrap();
 	let invoice_str = invoice.to_string();
 	retry_until_ok(10, "receive_bolt11_payment", || peer.pay_invoice(&invoice_str)).await;
+	expect_payment_received_event!(node, amount_msat);
+}
+
+/// External node pays LDK via BOLT12 offer. Retries to absorb gossip-propagation
+/// delay (peer may not yet know a route to LDK right after channel confirmation).
+pub(crate) async fn receive_bolt12_payment(
+	node: &Node, peer: &(impl ExternalNode + ?Sized), amount_msat: u64,
+) {
+	let offer = node
+		.bolt12_payment()
+		.receive(amount_msat, "interop-receive-test-bolt12", Some(3600), Some(1))
+		.unwrap();
+	let offer_str = offer.to_string();
+	retry_until_ok(10, "receive_bolt12_payment", || peer.pay_offer(&offer_str, Some(amount_msat)))
+		.await;
 	expect_payment_received_event!(node, amount_msat);
 }
 

--- a/tests/integration_tests_cln.rs
+++ b/tests/integration_tests_cln.rs
@@ -11,8 +11,10 @@ mod common;
 
 use common::cln::TestClnNode;
 use common::scenarios::{
-	basic_channel_cycle_scenario, disconnect_during_payment_scenario,
-	force_close_after_payment_scenario, keysend_scenario, run_interop_scenario, splice_in_scenario,
+	basic_channel_cycle_bolt11_scenario, basic_channel_cycle_bolt12_scenario,
+	disconnect_during_payment_scenario, force_close_after_payment_bolt11_scenario,
+	force_close_after_payment_bolt12_scenario, keysend_scenario, run_interop_scenario,
+	splice_in_bolt11_scenario, splice_in_bolt12_scenario,
 };
 use electrsd::corepc_client::client_sync::Auth;
 use electrsd::corepc_node::Client as BitcoindClient;
@@ -30,8 +32,13 @@ async fn setup_clients() -> (BitcoindClient, ElectrumClient, TestClnNode) {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_basic_channel_cycle() {
-	run_interop_scenario(setup_clients(), basic_channel_cycle_scenario).await;
+async fn test_basic_channel_cycle_bolt11() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_basic_channel_cycle_bolt12() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -41,8 +48,13 @@ async fn test_keysend() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_force_close_after_payment() {
-	run_interop_scenario(setup_clients(), force_close_after_payment_scenario).await;
+async fn test_force_close_after_payment_bolt11() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_force_close_after_payment_bolt12() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -51,6 +63,11 @@ async fn test_disconnect_during_payment() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_splice_in() {
-	run_interop_scenario(setup_clients(), splice_in_scenario).await;
+async fn test_splice_in_bolt11() {
+	run_interop_scenario(setup_clients(), splice_in_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_splice_in_bolt12() {
+	run_interop_scenario(setup_clients(), splice_in_bolt12_scenario).await;
 }

--- a/tests/integration_tests_eclair.rs
+++ b/tests/integration_tests_eclair.rs
@@ -12,8 +12,10 @@ mod common;
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use common::eclair::TestEclairNode;
 use common::scenarios::{
-	basic_channel_cycle_scenario, disconnect_during_payment_scenario,
-	force_close_after_payment_scenario, keysend_scenario, run_interop_scenario, splice_in_scenario,
+	basic_channel_cycle_bolt11_scenario, basic_channel_cycle_bolt12_scenario,
+	disconnect_during_payment_scenario, force_close_after_payment_bolt11_scenario,
+	force_close_after_payment_bolt12_scenario, keysend_scenario, run_interop_scenario,
+	splice_in_bolt11_scenario, splice_in_bolt12_scenario,
 };
 use electrsd::corepc_client::client_sync::Auth;
 use electrsd::corepc_node::Client as BitcoindClient;
@@ -48,8 +50,14 @@ async fn setup_clients() -> (BitcoindClient, ElectrumClient, TestEclairNode) {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_basic_channel_cycle() {
-	run_interop_scenario(setup_clients(), basic_channel_cycle_scenario).await;
+async fn test_basic_channel_cycle_bolt11() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for Eclair is not implemented yet"]
+async fn test_basic_channel_cycle_bolt12() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -58,8 +66,14 @@ async fn test_keysend() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_force_close_after_payment() {
-	run_interop_scenario(setup_clients(), force_close_after_payment_scenario).await;
+async fn test_force_close_after_payment_bolt11() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for Eclair is not implemented yet"]
+async fn test_force_close_after_payment_bolt12() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -69,6 +83,12 @@ async fn test_disconnect_during_payment() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[ignore = "Eclair advertises splicing via custom bit 154 instead of BOLT bit 62/63; disjoint from LDK until Eclair migrates"]
-async fn test_splice_in() {
-	run_interop_scenario(setup_clients(), splice_in_scenario).await;
+async fn test_splice_in_bolt11() {
+	run_interop_scenario(setup_clients(), splice_in_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for Eclair is not implemented yet"]
+async fn test_splice_in_bolt12() {
+	run_interop_scenario(setup_clients(), splice_in_bolt12_scenario).await;
 }

--- a/tests/integration_tests_lnd.rs
+++ b/tests/integration_tests_lnd.rs
@@ -11,8 +11,10 @@ mod common;
 
 use common::lnd::TestLndNode;
 use common::scenarios::{
-	basic_channel_cycle_scenario, disconnect_during_payment_scenario,
-	force_close_after_payment_scenario, keysend_scenario, run_interop_scenario, splice_in_scenario,
+	basic_channel_cycle_bolt11_scenario, basic_channel_cycle_bolt12_scenario,
+	disconnect_during_payment_scenario, force_close_after_payment_bolt11_scenario,
+	force_close_after_payment_bolt12_scenario, keysend_scenario, run_interop_scenario,
+	splice_in_bolt11_scenario, splice_in_bolt12_scenario,
 };
 use electrsd::corepc_client::client_sync::Auth;
 use electrsd::corepc_node::Client as BitcoindClient;
@@ -30,8 +32,14 @@ async fn setup_clients() -> (BitcoindClient, ElectrumClient, TestLndNode) {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_basic_channel_cycle() {
-	run_interop_scenario(setup_clients(), basic_channel_cycle_scenario).await;
+async fn test_basic_channel_cycle_bolt11() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for LDN is not implemented yet"]
+async fn test_basic_channel_cycle_bolt12() {
+	run_interop_scenario(setup_clients(), basic_channel_cycle_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -40,8 +48,14 @@ async fn test_keysend() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_force_close_after_payment() {
-	run_interop_scenario(setup_clients(), force_close_after_payment_scenario).await;
+async fn test_force_close_after_payment_bolt11() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for LDN is not implemented yet"]
+async fn test_force_close_after_payment_bolt12() {
+	run_interop_scenario(setup_clients(), force_close_after_payment_bolt12_scenario).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -51,6 +65,12 @@ async fn test_disconnect_during_payment() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[ignore = "LND does not implement BOLT splicing"]
-async fn test_splice_in() {
-	run_interop_scenario(setup_clients(), splice_in_scenario).await;
+async fn test_splice_in_bolt11() {
+	run_interop_scenario(setup_clients(), splice_in_bolt11_scenario).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "BOLT12 support for LDN is not implemented yet"]
+async fn test_splice_in_bolt12() {
+	run_interop_scenario(setup_clients(), splice_in_bolt12_scenario).await;
 }


### PR DESCRIPTION
Activates scenarios for BOLT12 offer payments between ldk-node and Core Lightning (CLN) inside integration tests

Fix #856