### PR TITLE
Reject malformed (odd-length) hex strings

### DIFF
--- a/src/hex_utils.rs
+++ b/src/hex_utils.rs
@@ -9,6 +9,11 @@ use std::fmt::Write;
 
 #[cfg(feature = "uniffi")]
 pub fn to_vec(hex: &str) -> Option<Vec<u8>> {
+	// Reject malformed hex strings.
+	if hex.len() % 2 != 0 {
+		return None;
+	}
+
 	let mut out = Vec::with_capacity(hex.len() / 2);
 
 	let mut b = 0;


### PR DESCRIPTION
Previously, we'd attempt to decode any hex string even if it had an odd number of input characters. Here, we check the length and return `None` in case it's odd.