### PR TITLE
Account for `vss-server` location change

### DIFF
--- a/.github/workflows/vss-integration.yml
+++ b/.github/workflows/vss-integration.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build and Deploy VSS Server
         run: |
-          cd vss-server/rust
+          cd vss-server
           cargo run server/vss-server-config.toml&
       - name: Run VSS Integration tests
         run: |

--- a/.github/workflows/vss-no-auth-integration.yml
+++ b/.github/workflows/vss-no-auth-integration.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build and Deploy VSS Server
         run: |
-          cd vss-server/rust
+          cd vss-server
           RUSTFLAGS=--cfg=noop_authorizer cargo run --no-default-features server/vss-server-config.toml&
       - name: Run VSS Integration tests
         run: |


### PR DESCRIPTION
In https://github.com/lightningdevkit/vss-server/pull/101 we dropped the Java version of `vss-server` and moved the Rust version to the repo root. Here we account for the updated location in our integration tests.