### PR TITLE
Wait for node announcements before asserting them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(cycle_tests)]
 use std::{any::Any, sync::Weak};
 
-use crate::ffi::maybe_wrap;
 pub use balance::{BalanceDetails, LightningBalance, PendingSweepBalance};
 pub use bip39;
 pub use bitcoin;
@@ -183,6 +182,7 @@ use types::{
 pub use types::{ChannelDetails, CustomTlvRecord, PeerDetails, SyncAndAsyncKVStore, UserChannelId};
 pub use vss_client;
 
+use crate::ffi::maybe_wrap;
 use crate::scoring::setup_background_pathfinding_scores_sync;
 use crate::wallet::FundingAmount;
 

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -1570,13 +1570,19 @@ async fn test_node_announcement_propagation() {
 	expect_channel_ready_event!(node_a, node_b.node_id());
 	expect_channel_ready_event!(node_b, node_a.node_id());
 
-	// Wait until node_b broadcasts a node announcement
-	while node_b.status().latest_node_announcement_broadcast_timestamp.is_none() {
+	let has_node_announcement = |node: &ldk_node::Node, node_id: bitcoin::secp256k1::PublicKey| {
+		node.network_graph()
+			.node(&NodeId::from_pubkey(&node_id))
+			.map_or(false, |info| info.announcement_info.is_some())
+	};
+
+	while node_a.status().latest_node_announcement_broadcast_timestamp.is_none()
+		|| node_b.status().latest_node_announcement_broadcast_timestamp.is_none()
+		|| !has_node_announcement(&node_b, node_a.node_id())
+		|| !has_node_announcement(&node_a, node_b.node_id())
+	{
 		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 	}
-
-	// Sleep to make sure the node announcement propagates
-	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
 	// Get node info from the other node's perspective
 	let node_a_info = node_b.network_graph().node(&NodeId::from_pubkey(&node_a.node_id())).unwrap();


### PR DESCRIPTION
Avoid assuming that a fixed sleep is enough for gossip propagation when integration tests are running concurrently. The test now waits for both peers' announcements to appear in the opposite graph before checking aliases and addresses.

Co-Authored-By: HAL 9000