### PR TITLE
Add 60 minute timeout to CI jobs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   audit:
+    timeout-minutes: 60
     permissions:
       issues: write
       checks: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,25 +9,26 @@ concurrency:
 jobs:
   benchmark:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       TOOLCHAIN: stable
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
-          rustup override set stable
+      - name: Set Rust override
+        run: rustup override set stable
       - name: Enable caching for bitcoind
         id: cache-bitcoind
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
           key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: bin/electrs-${{ runner.os }}-${{ runner.arch }}
           key: electrs-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   benchmark:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       TOOLCHAIN: stable

--- a/.github/workflows/cln-integration.yml
+++ b/.github/workflows/cln-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-cln:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/cron-weekly-rustfmt.yml
+++ b/.github/workflows/cron-weekly-rustfmt.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   format:
     name: Nightly rustfmt
+    timeout-minutes: 60
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cron-weekly-rustfmt.yml
+++ b/.github/workflows/cron-weekly-rustfmt.yml
@@ -12,7 +12,7 @@ jobs:
   format:
     name: Nightly rustfmt
     timeout-minutes: 60
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/eclair-integration.yml
+++ b/.github/workflows/eclair-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-eclair:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/hrn-integration.yml
+++ b/.github/workflows/hrn-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/hrn-integration.yml
+++ b/.github/workflows/hrn-integration.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build-and-test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     
     steps:
       - name: Checkout source code

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-kotlin:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/lnd-integration.yml
+++ b/.github/workflows/lnd-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-lnd:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-python:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [
-          ubuntu-latest,
+          self-hosted,
           macos-latest,
           windows-latest,
           ]
@@ -25,7 +25,7 @@ jobs:
           - toolchain: stable
             check-fmt: true
             build-uniffi: true
-            platform: ubuntu-latest
+            platform: self-hosted
           - toolchain: stable
             platform: macos-latest
           - toolchain: stable
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       - name: Install Rust ${{ matrix.toolchain }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ matrix.toolchain }}
@@ -51,13 +51,13 @@ jobs:
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
       - name: Enable caching for bitcoind
         id: cache-bitcoind
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
           key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: bin/electrs-${{ runner.os }}-${{ runner.arch }}
           key: electrs-${{ runner.os }}-${{ runner.arch }}
@@ -94,14 +94,15 @@ jobs:
   linting:
     name: Linting
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
-      - name: Install Rust and clippy
+        uses: actions/checkout@v4
+      - name: Install Rust stable toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
-          rustup component add clippy
+      - name: Add clippy component
+        run: rustup component add clippy
       - name: Ban `unwrap` in library code
         run: |
           cargo clippy --lib --verbose --color always -- -A warnings -D clippy::unwrap_used -A clippy::tabs_in_doc_comments
@@ -110,11 +111,11 @@ jobs:
   doc:
     name: Documentation
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
       - run: cargo docs-rs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 60
     strategy:
       matrix:
         platform: [
@@ -92,6 +93,7 @@ jobs:
 
   linting:
     name: Linting
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -107,6 +109,7 @@ jobs:
 
   doc:
     name: Documentation
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   semver-checks:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   check-swift:
+    timeout-minutes: 60
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/vss-integration.yml
+++ b/.github/workflows/vss-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/vss-no-auth-integration.yml
+++ b/.github/workflows/vss-no-auth-integration.yml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
We ran out of our CI limit largely from ldk-node. We had a few jobs this week run for multiple hours because of a hanging test. Add 60 minute timeout to all our jobs to prevent this in the future.