### PR TITLE
Run `cargo +nightly fmt` on main

### DIFF
--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -421,7 +421,8 @@ impl VssStoreInner {
 
 	async fn list_keys(
 		&self, client: &VssClient<CustomRetryPolicy>, primary_namespace: &str,
-		secondary_namespace: &str, key_prefix: String, page_token: Option<String>, page_size: Option<i32>,
+		secondary_namespace: &str, key_prefix: String, page_token: Option<String>,
+		page_size: Option<i32>,
 	) -> io::Result<(Vec<String>, Option<String>)> {
 		let request = ListKeyVersionsRequest {
 			store_id: self.store_id.clone(),
@@ -574,7 +575,14 @@ impl VssStoreInner {
 		let mut keys = vec![];
 		loop {
 			let (page_keys, next_page_token) = self
-				.list_keys(client, &primary_namespace, &secondary_namespace, key_prefix.clone(), page_token, None)
+				.list_keys(
+					client,
+					&primary_namespace,
+					&secondary_namespace,
+					key_prefix.clone(),
+					page_token,
+					None,
+				)
 				.await?;
 			keys.extend(page_keys);
 			match next_page_token {

--- a/src/liquidity/mod.rs
+++ b/src/liquidity/mod.rs
@@ -10,10 +10,6 @@
 pub(crate) mod client;
 pub(crate) mod service;
 
-pub use client::lsps1::LSPS1Liquidity;
-pub use client::LSPS1OrderStatus;
-pub use service::lsps2::LSPS2ServiceConfig;
-
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -21,6 +17,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
+pub use client::lsps1::LSPS1Liquidity;
+pub use client::LSPS1OrderStatus;
 use lightning::ln::msgs::SocketAddress;
 use lightning_liquidity::events::LiquidityEvent;
 use lightning_liquidity::lsps0::event::LSPS0ClientEvent;
@@ -28,6 +26,7 @@ use lightning_liquidity::lsps1::client::LSPS1ClientConfig as LdkLSPS1ClientConfi
 use lightning_liquidity::lsps2::client::LSPS2ClientConfig as LdkLSPS2ClientConfig;
 use lightning_liquidity::lsps2::service::LSPS2ServiceConfig as LdkLSPS2ServiceConfig;
 use lightning_liquidity::{LiquidityClientConfig, LiquidityServiceConfig};
+pub use service::lsps2::LSPS2ServiceConfig;
 use tokio::sync::oneshot;
 
 use crate::builder::BuildError;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -381,9 +381,9 @@ impl FutureSpawner for RuntimeSpawner {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-
 	use tokio::sync::oneshot;
+
+	use super::*;
 
 	fn test_runtime() -> Runtime {
 		Runtime::new(Arc::new(Logger::new_log_facade())).unwrap()


### PR DESCRIPTION
Unfortunately PR #864 was merged without checking that `cargo fmt` passes, given that our CI is still broken. Turns out it doesn't. Here we fix this by running `cargo +nightly fmt` (given that our weekly job doing that is also on vacation right now).