### PR TITLE
Implement `MigratableKVStore` for all KV Stores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
 lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c", features = ["std", "_test_utils"] }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c", features = ["tokio"] }
 rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"

--- a/src/io/in_memory_store.rs
+++ b/src/io/in_memory_store.rs
@@ -11,7 +11,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use lightning::io;
-use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
+use lightning::util::persist::{
+	KVStore, MigratableKVStore, PageToken, PaginatedKVStore, PaginatedListResponse,
+};
 
 const IN_MEMORY_PAGE_SIZE: usize = 50;
 
@@ -95,6 +97,28 @@ impl InMemoryStore {
 			hash_map::Entry::Occupied(e) => Ok(e.get().keys().cloned().collect()),
 			hash_map::Entry::Vacant(_) => Ok(Vec::new()),
 		}
+	}
+
+	fn list_all_keys_internal(&self) -> io::Result<Vec<(String, String, String)>> {
+		let persisted_lock = self.persisted_bytes.lock().unwrap();
+		let capacity = persisted_lock.values().map(|entries| entries.len()).sum();
+		let mut keys = Vec::with_capacity(capacity);
+
+		for (prefixed_namespace, namespace_entries) in persisted_lock.iter() {
+			let (primary_namespace, secondary_namespace) =
+				prefixed_namespace.split_once('/').ok_or_else(|| {
+					io::Error::new(io::ErrorKind::InvalidData, "Invalid namespace format")
+				})?;
+			for key in namespace_entries.keys() {
+				keys.push((
+					primary_namespace.to_string(),
+					secondary_namespace.to_string(),
+					key.clone(),
+				));
+			}
+		}
+
+		Ok(keys)
 	}
 }
 
@@ -187,5 +211,40 @@ impl PaginatedKVStore for InMemoryStore {
 	}
 }
 
+impl MigratableKVStore for InMemoryStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + Send {
+		let res = self.list_all_keys_internal();
+		async move { res }
+	}
+}
+
 unsafe impl Sync for InMemoryStore {}
 unsafe impl Send for InMemoryStore {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn in_memory_store_list_all_keys() {
+		let store = InMemoryStore::new();
+
+		KVStore::write(&store, "ns_a", "sub_a", "key_a", vec![1u8]).await.unwrap();
+		KVStore::write(&store, "ns_a", "sub_b", "key_b", vec![2u8]).await.unwrap();
+		KVStore::write(&store, "ns_b", "", "key_c", vec![3u8]).await.unwrap();
+
+		let mut keys = MigratableKVStore::list_all_keys(&store).await.unwrap();
+		keys.sort();
+
+		assert_eq!(
+			keys,
+			vec![
+				("ns_a".to_string(), "sub_a".to_string(), "key_a".to_string()),
+				("ns_a".to_string(), "sub_b".to_string(), "key_b".to_string()),
+				("ns_b".to_string(), "".to_string(), "key_c".to_string()),
+			]
+		);
+	}
+}

--- a/src/io/postgres_store/mod.rs
+++ b/src/io/postgres_store/mod.rs
@@ -12,7 +12,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use lightning::io;
-use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
+use lightning::util::persist::{
+	KVStore, MigratableKVStore, PageToken, PaginatedKVStore, PaginatedListResponse,
+};
 use lightning_types::string::PrintableString;
 use native_tls::TlsConnector;
 use postgres_native_tls::MakeTlsConnector;
@@ -341,6 +343,24 @@ impl PaginatedKVStore for PostgresStore {
 					.list_paginated_internal(&primary_namespace, &secondary_namespace, page_token)
 					.await
 			});
+			task.await.map_err(|e| {
+				io::Error::new(
+					io::ErrorKind::Other,
+					format!("PostgreSQL runtime task failed: {}", e),
+				)
+			})?
+		}
+	}
+}
+
+impl MigratableKVStore for PostgresStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + Send {
+		let inner = Arc::clone(&self.inner);
+		let runtime = self.internal_runtime();
+		async move {
+			let task = runtime.spawn(async move { inner.list_all_keys_internal().await });
 			task.await.map_err(|e| {
 				io::Error::new(
 					io::ErrorKind::Other,
@@ -725,6 +745,25 @@ impl PostgresStoreInner {
 		Ok(keys)
 	}
 
+	async fn list_all_keys_internal(&self) -> io::Result<Vec<(String, String, String)>> {
+		let sql = format!(
+			"SELECT primary_namespace, secondary_namespace, key FROM {}",
+			self.kv_table_name_sql
+		);
+
+		let err_map = |e: PgError| {
+			let msg = format!("Failed to retrieve queried rows: {e}");
+			io::Error::new(io::ErrorKind::Other, msg)
+		};
+
+		let mut locked = self.locked_client().await?;
+		let rows = query_with_retry!(self, locked, err_map, locked.query(sql.as_str(), &[]))?;
+
+		let keys: Vec<(String, String, String)> =
+			rows.iter().map(|row| (row.get(0), row.get(1), row.get(2))).collect();
+		Ok(keys)
+	}
+
 	async fn list_paginated_internal(
 		&self, primary_namespace: &str, secondary_namespace: &str, page_token: Option<PageToken>,
 	) -> io::Result<PaginatedListResponse> {
@@ -902,6 +941,29 @@ mod tests {
 		do_test_store(&store_0, &store_1);
 		cleanup_store(&store_0).await;
 		cleanup_store(&store_1).await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn test_postgres_store_list_all_keys() {
+		let store = create_test_store("test_pg_list_all_keys").await;
+
+		KVStore::write(&store, "ns_a", "sub_a", "key_a", vec![1u8]).await.unwrap();
+		KVStore::write(&store, "ns_a", "sub_b", "key_b", vec![2u8]).await.unwrap();
+		KVStore::write(&store, "ns_b", "", "key_c", vec![3u8]).await.unwrap();
+
+		let mut keys = MigratableKVStore::list_all_keys(&store).await.unwrap();
+		keys.sort();
+
+		assert_eq!(
+			keys,
+			vec![
+				("ns_a".to_string(), "sub_a".to_string(), "key_a".to_string()),
+				("ns_a".to_string(), "sub_b".to_string(), "key_b".to_string()),
+				("ns_b".to_string(), "".to_string(), "key_c".to_string()),
+			]
+		);
+
+		cleanup_store(&store).await;
 	}
 
 	async fn kill_connection(store: &PostgresStore) {

--- a/src/io/sqlite_store/mod.rs
+++ b/src/io/sqlite_store/mod.rs
@@ -14,7 +14,9 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use lightning::io;
-use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
+use lightning::util::persist::{
+	KVStore, MigratableKVStore, PageToken, PaginatedKVStore, PaginatedListResponse,
+};
 use lightning_types::string::PrintableString;
 use rusqlite::{named_params, Connection};
 
@@ -193,6 +195,21 @@ impl PaginatedKVStore for SqliteStore {
 		let fut = tokio::task::spawn_blocking(move || {
 			inner.list_paginated_internal(&primary_namespace, &secondary_namespace, page_token)
 		});
+		async move {
+			fut.await.unwrap_or_else(|e| {
+				let msg = format!("Failed to IO operation due join error: {}", e);
+				Err(io::Error::new(io::ErrorKind::Other, msg))
+			})
+		}
+	}
+}
+
+impl MigratableKVStore for SqliteStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + Send {
+		let inner = Arc::clone(&self.inner);
+		let fut = tokio::task::spawn_blocking(move || inner.list_all_keys_internal());
 		async move {
 			fut.await.unwrap_or_else(|e| {
 				let msg = format!("Failed to IO operation due join error: {}", e);
@@ -486,6 +503,42 @@ impl SqliteStoreInner {
 		Ok(keys)
 	}
 
+	fn list_all_keys_internal(&self) -> io::Result<Vec<(String, String, String)>> {
+		let locked_conn = self.connection.lock().expect("lock");
+
+		let sql = format!(
+			"SELECT primary_namespace, secondary_namespace, key FROM {}",
+			self.kv_table_name
+		);
+		let count_sql = format!("SELECT COUNT(*) FROM {}", self.kv_table_name);
+		let count: usize =
+			locked_conn.query_row(&count_sql, [], |row| row.get(0)).map_err(|e| {
+				let msg = format!("Failed to count rows: {}", e);
+				io::Error::new(io::ErrorKind::Other, msg)
+			})?;
+
+		let mut stmt = locked_conn.prepare_cached(&sql).map_err(|e| {
+			let msg = format!("Failed to prepare statement: {}", e);
+			io::Error::new(io::ErrorKind::Other, msg)
+		})?;
+
+		let mut keys = Vec::with_capacity(count);
+		let rows_iter =
+			stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?))).map_err(|e| {
+				let msg = format!("Failed to retrieve queried rows: {}", e);
+				io::Error::new(io::ErrorKind::Other, msg)
+			})?;
+
+		for key in rows_iter {
+			keys.push(key.map_err(|e| {
+				let msg = format!("Failed to retrieve queried rows: {}", e);
+				io::Error::new(io::ErrorKind::Other, msg)
+			})?);
+		}
+
+		Ok(keys)
+	}
+
 	fn list_paginated_internal(
 		&self, primary_namespace: &str, secondary_namespace: &str, page_token: Option<PageToken>,
 	) -> io::Result<PaginatedListResponse> {
@@ -677,6 +730,34 @@ mod tests {
 		)
 		.unwrap();
 		do_test_store(&store_0, &store_1)
+	}
+
+	#[tokio::test]
+	async fn test_sqlite_store_list_all_keys() {
+		let mut temp_path = random_storage_path();
+		temp_path.push("test_sqlite_store_list_all_keys");
+		let store = SqliteStore::new(
+			temp_path,
+			Some("test_db".to_string()),
+			Some("test_table".to_string()),
+		)
+		.unwrap();
+
+		KVStore::write(&store, "ns_a", "sub_a", "key_a", vec![1u8]).await.unwrap();
+		KVStore::write(&store, "ns_a", "sub_b", "key_b", vec![2u8]).await.unwrap();
+		KVStore::write(&store, "ns_b", "", "key_c", vec![3u8]).await.unwrap();
+
+		let mut keys = MigratableKVStore::list_all_keys(&store).await.unwrap();
+		keys.sort();
+
+		assert_eq!(
+			keys,
+			vec![
+				("ns_a".to_string(), "sub_a".to_string(), "key_a".to_string()),
+				("ns_a".to_string(), "sub_b".to_string(), "key_b".to_string()),
+				("ns_b".to_string(), "".to_string(), "key_c".to_string()),
+			]
+		);
 	}
 
 	#[tokio::test]

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -399,7 +399,7 @@ impl VssStoreInner {
 		}
 	}
 
-	fn extract_key(&self, unified_key: &str) -> io::Result<String> {
+	fn extract_obfuscated_key<'a>(&self, unified_key: &'a str) -> io::Result<&'a str> {
 		let mut parts = if self.schema_version == VssSchemaVersion::V1 {
 			let mut parts = unified_key.splitn(2, '#');
 			let _obfuscated_namespace = parts.next();
@@ -411,12 +411,15 @@ impl VssStoreInner {
 			parts
 		};
 		match parts.next() {
-			Some(obfuscated_key) => {
-				let actual_key = self.key_obfuscator.deobfuscate(obfuscated_key)?;
-				Ok(actual_key)
-			},
+			Some(obfuscated_key) => Ok(obfuscated_key),
 			None => Err(Error::new(ErrorKind::InvalidData, "Invalid key format")),
 		}
+	}
+
+	fn extract_key(&self, unified_key: &str) -> io::Result<String> {
+		let obfuscated_key = self.extract_obfuscated_key(unified_key)?;
+		let actual_key = self.key_obfuscator.deobfuscate(obfuscated_key)?;
+		Ok(actual_key)
 	}
 
 	async fn list_keys(

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -24,7 +24,9 @@ use bitcoin::Network;
 use lightning::impl_writeable_tlv_based_enum;
 use lightning::io::{self, Error, ErrorKind};
 use lightning::sign::{EntropySource as LdkEntropySource, RandomBytes};
-use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
+use lightning::util::persist::{
+	KVStore, MigratableKVStore, PageToken, PaginatedKVStore, PaginatedListResponse,
+};
 use lightning::util::ser::{Readable, Writeable};
 use prost::Message;
 use vss_client::client::VssClient;
@@ -321,6 +323,22 @@ impl PaginatedKVStore for VssStore {
 	}
 }
 
+impl MigratableKVStore for VssStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + Send {
+		let inner = Arc::clone(&self.inner);
+		let runtime = self.internal_runtime();
+		async move {
+			let task = runtime
+				.spawn(async move { inner.list_all_keys_internal(&inner.async_client).await });
+			task.await.map_err(|e| {
+				io::Error::new(io::ErrorKind::Other, format!("VSS runtime task failed: {}", e))
+			})?
+		}
+	}
+}
+
 impl Drop for VssStore {
 	fn drop(&mut self) {
 		if let Some(runtime) = self.internal_runtime.take() {
@@ -420,6 +438,41 @@ impl VssStoreInner {
 		let obfuscated_key = self.extract_obfuscated_key(unified_key)?;
 		let actual_key = self.key_obfuscator.deobfuscate(obfuscated_key)?;
 		Ok(actual_key)
+	}
+
+	fn extract_namespaces(&self, unified_key: &str) -> io::Result<(String, String)> {
+		if self.schema_version == VssSchemaVersion::V1 {
+			let mut parts = unified_key.splitn(2, '#');
+			let obfuscated_namespace = parts.next();
+			let _obfuscated_key = parts.next();
+			match (obfuscated_namespace, _obfuscated_key) {
+				(Some(obfuscated_namespace), Some(_obfuscated_key)) => {
+					let namespace = self.key_obfuscator.deobfuscate(obfuscated_namespace)?;
+					let mut namespace_parts = namespace.splitn(2, '#');
+					let primary_namespace = namespace_parts.next();
+					let secondary_namespace = namespace_parts.next();
+					match (primary_namespace, secondary_namespace) {
+						(Some(primary_namespace), Some(secondary_namespace)) => {
+							Ok((primary_namespace.to_string(), secondary_namespace.to_string()))
+						},
+						_ => Err(Error::new(ErrorKind::InvalidData, "Invalid namespace format")),
+					}
+				},
+				_ => Err(Error::new(ErrorKind::InvalidData, "Invalid key format")),
+			}
+		} else {
+			// Default to V0 schema.
+			let mut parts = unified_key.splitn(3, '#');
+			let primary_namespace = parts.next();
+			let secondary_namespace = parts.next();
+			match (primary_namespace, secondary_namespace) {
+				(Some(_obfuscated_key), None) => Ok(("".to_string(), "".to_string())),
+				(Some(primary_namespace), Some(secondary_namespace)) => {
+					Ok((primary_namespace.to_string(), secondary_namespace.to_string()))
+				},
+				_ => Err(Error::new(ErrorKind::InvalidData, "Invalid key format")),
+			}
+		}
 	}
 
 	async fn list_keys(
@@ -623,6 +676,52 @@ impl VssStoreInner {
 		let next_page_token = next_page_token.map(PageToken::new);
 
 		Ok(PaginatedListResponse { keys, next_page_token })
+	}
+
+	async fn list_all_keys_internal(
+		&self, client: &VssClient<CustomRetryPolicy>,
+	) -> io::Result<Vec<(String, String, String)>> {
+		let mut page_token: Option<String> = None;
+		let mut keys = vec![];
+		loop {
+			let request = ListKeyVersionsRequest {
+				store_id: self.store_id.clone(),
+				key_prefix: None,
+				page_token,
+				page_size: Some(PAGE_SIZE),
+			};
+
+			let response = client.list_key_versions(&request).await.map_err(|e| {
+				let msg = format!("Failed to list all keys: {}", e);
+				Error::new(ErrorKind::Other, msg)
+			})?;
+
+			for kv in response.key_versions {
+				let (primary_namespace, secondary_namespace) = self.extract_namespaces(&kv.key)?;
+				let key = match self.extract_key(&kv.key) {
+					Ok(key) => key,
+					Err(_)
+						if self.schema_version == VssSchemaVersion::V0 && !kv.key.contains('#') =>
+					{
+						self.key_obfuscator.deobfuscate(&kv.key)?
+					},
+					Err(e) => return Err(e),
+				};
+				if primary_namespace.is_empty()
+					&& secondary_namespace.is_empty()
+					&& key == VSS_SCHEMA_VERSION_KEY
+				{
+					continue;
+				}
+				keys.push((primary_namespace, secondary_namespace, key));
+			}
+
+			match response.next_page_token.filter(|t| !t.is_empty()) {
+				Some(t) => page_token = Some(t),
+				None => break,
+			}
+		}
+		Ok(keys)
 	}
 
 	async fn execute_locked_write<
@@ -1039,6 +1138,27 @@ mod tests {
 		let vss_store = build_vss_store();
 		do_read_write_remove_list_persist(&vss_store).await;
 		drop(vss_store)
+	}
+
+	#[tokio::test]
+	async fn vss_list_all_keys() {
+		let store = build_vss_store();
+
+		KVStore::write(&store, "ns_a", "sub_a", "key_a", vec![1u8]).await.unwrap();
+		KVStore::write(&store, "ns_a", "sub_b", "key_b", vec![2u8]).await.unwrap();
+		KVStore::write(&store, "ns_b", "", "key_c", vec![3u8]).await.unwrap();
+
+		let mut keys = MigratableKVStore::list_all_keys(&store).await.unwrap();
+		keys.sort();
+
+		assert_eq!(
+			keys,
+			vec![
+				("ns_a".to_string(), "sub_a".to_string(), "key_a".to_string()),
+				("ns_a".to_string(), "sub_b".to_string(), "key_b".to_string()),
+				("ns_b".to_string(), "".to_string(), "key_c".to_string()),
+			]
+		);
 	}
 
 	#[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1922,3 +1922,26 @@ impl TestSyncStoreInner {
 		}
 	}
 }
+
+/// The PostgreSQL connection string used by the Postgres-backed tests, overridable via the
+/// `TEST_POSTGRES_URL` environment variable.
+#[cfg(feature = "postgres")]
+pub(crate) fn test_connection_string() -> String {
+	std::env::var("TEST_POSTGRES_URL")
+		.unwrap_or_else(|_| "host=localhost user=postgres password=postgres".to_string())
+}
+
+/// Drops the given table from the `ldk_db` database, ignoring the case where the database doesn't
+/// exist yet. Used to ensure a clean slate before and after Postgres-backed tests.
+#[cfg(feature = "postgres")]
+pub(crate) async fn drop_table(table_name: &str) {
+	let connection_string = format!("{} dbname=ldk_db", test_connection_string());
+	let Ok((client, connection)) =
+		tokio_postgres::connect(&connection_string, tokio_postgres::NoTls).await
+	else {
+		// Database doesn't exist yet — nothing to drop.
+		return;
+	};
+	tokio::spawn(connection);
+	let _ = client.execute(&format!("DROP TABLE IF EXISTS {table_name}"), &[]).await;
+}

--- a/tests/integration_tests_migration.rs
+++ b/tests/integration_tests_migration.rs
@@ -1,0 +1,263 @@
+// This file is Copyright its original authors, visible in version control history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
+// accordance with one or both of these licenses.
+
+// The migration test exercises the filesystem, SQLite, and Postgres stores. It is gated on the
+// `postgres` feature because Postgres is the only one of the three that needs an external service.
+#![cfg(feature = "postgres")]
+
+mod common;
+
+use std::path::PathBuf;
+
+use common::{
+	drop_table, expect_channel_ready_event, expect_payment_received_event,
+	expect_payment_successful_event, test_connection_string,
+};
+use ldk_node::entropy::NodeEntropy;
+use ldk_node::io::postgres_store::PostgresStore;
+use ldk_node::io::sqlite_store::{SqliteStore, KV_TABLE_NAME, SQLITE_DB_FILE_NAME};
+use ldk_node::{Builder, Event};
+use lightning::util::persist::migrate_kv_store_data_async;
+use lightning_invoice::{Bolt11InvoiceDescription, Description};
+use lightning_persister::fs_store::v2::FilesystemStoreV2;
+use rand::seq::SliceRandom;
+
+async fn drop_tables<'a>(table_names: impl IntoIterator<Item = &'a String>) {
+	for table_name in table_names {
+		drop_table(table_name).await;
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum MigrationBackend {
+	FilesystemStore,
+	Sqlite,
+	Postgres,
+}
+
+struct BackendInstance {
+	backend: MigrationBackend,
+	path: String,
+	connection_string: String,
+	table: String,
+}
+
+impl BackendInstance {
+	fn new(
+		backend: MigrationBackend, base_dir: &str, connection_string: &str, table: &str,
+	) -> Self {
+		let path = match backend {
+			MigrationBackend::FilesystemStore => format!("{base_dir}/fs_store"),
+			MigrationBackend::Sqlite => format!("{base_dir}/sqlite_store"),
+			MigrationBackend::Postgres => base_dir.to_string(),
+		};
+		BackendInstance {
+			backend,
+			path,
+			connection_string: connection_string.to_string(),
+			table: table.to_string(),
+		}
+	}
+}
+
+macro_rules! with_opened_store {
+	($instance:expr, |$store:ident| $body:expr) => {{
+		let instance = $instance;
+		match instance.backend {
+			MigrationBackend::FilesystemStore => {
+				let $store = open_fs_store(&instance.path);
+				$body
+			},
+			MigrationBackend::Sqlite => {
+				let $store = open_sqlite_store(&instance.path);
+				$body
+			},
+			MigrationBackend::Postgres => {
+				let $store =
+					open_postgres_store(&instance.connection_string, &instance.table).await;
+				$body
+			},
+		}
+	}};
+}
+
+async fn build_migration_node(
+	instance: &BackendInstance, node_config: ldk_node::config::Config, node_entropy: NodeEntropy,
+	esplora_url: &str,
+) -> ldk_node::Node {
+	let mut builder = Builder::from_config(node_config);
+	builder.set_chain_source_esplora(esplora_url.to_string(), None);
+	with_opened_store!(instance, |store| builder.build_with_store(node_entropy, store).unwrap())
+}
+
+fn open_fs_store(data_dir: &str) -> FilesystemStoreV2 {
+	std::fs::create_dir_all(data_dir).unwrap();
+	FilesystemStoreV2::new(PathBuf::from(data_dir)).unwrap()
+}
+
+fn open_sqlite_store(data_dir: &str) -> SqliteStore {
+	std::fs::create_dir_all(data_dir).unwrap();
+	SqliteStore::new(
+		PathBuf::from(data_dir),
+		Some(SQLITE_DB_FILE_NAME.to_string()),
+		Some(KV_TABLE_NAME.to_string()),
+	)
+	.unwrap()
+}
+
+async fn open_postgres_store(connection_string: &str, table: &str) -> PostgresStore {
+	PostgresStore::new(connection_string.to_string(), None, Some(table.to_string()), None)
+		.await
+		.unwrap()
+}
+
+/// Migrates all data from a freshly-opened handle on the `source` backend to a freshly-opened
+/// handle on the `dest` backend. The node owning the source store must be stopped beforehand.
+async fn migrate_between_backends(source: &BackendInstance, dest: &BackendInstance) {
+	with_opened_store!(source, |source_store| {
+		with_opened_store!(dest, |dest_store| {
+			migrate_kv_store_data_async(&source_store, &dest_store).await.unwrap();
+		})
+	})
+}
+
+/// Spins up a node on a KV store backend, creates some on-chain and Lightning transaction history,
+/// then migrates its data through every other backend in turn. After each migration it restarts
+/// the node on the new backend and verifies that the node identity, on-chain balance, channel, and
+/// payment history are all preserved.
+///
+/// The order in which the backends are visited is randomized.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn migrate_node_across_all_backends() {
+	let mut order =
+		[MigrationBackend::FilesystemStore, MigrationBackend::Sqlite, MigrationBackend::Postgres];
+	order.shuffle(&mut rand::rng());
+	println!("Migrating node across backends in order: {:?}", order);
+
+	// Tables we might use: one per hop plus node B's. (Only the Postgres hops actually use them.)
+	let tables: Vec<String> = (0..order.len()).map(|i| format!("migrate_chain_{i}")).collect();
+	let node_b_table = "migrate_chain_node_b".to_string();
+	drop_tables(tables.iter().chain(std::iter::once(&node_b_table))).await;
+
+	let (bitcoind, electrsd) = common::setup_bitcoind_and_electrsd();
+	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
+	let connection_string = test_connection_string();
+
+	// Set up node B, the Lightning counterparty.
+	let config_b = common::random_config(false);
+	let node_b_instance = BackendInstance::new(
+		MigrationBackend::Postgres,
+		&config_b.node_config.storage_dir_path,
+		&connection_string,
+		&node_b_table,
+	);
+	let node_b = build_migration_node(
+		&node_b_instance,
+		config_b.node_config,
+		config_b.node_entropy,
+		&esplora_url,
+	)
+	.await;
+	node_b.start().unwrap();
+
+	// Spin up the node we'll migrate on the first backend. The same node config (storage dir,
+	// listening addresses, identity) is reused across every hop — only the backend changes — so
+	// each backend's store lives in its own subdirectory of the one storage dir.
+	let config = common::random_config(false);
+	let node_entropy = config.node_entropy;
+	let node_config = config.node_config;
+	let base_dir = node_config.storage_dir_path.clone();
+
+	let mut current = BackendInstance::new(order[0], &base_dir, &connection_string, &tables[0]);
+	let mut node =
+		build_migration_node(&current, node_config.clone(), node_entropy, &esplora_url).await;
+	node.start().unwrap();
+	let expected_node_id = node.node_id();
+
+	// On-chain receive: fund the node.
+	let addr = node.onchain_payment().new_address().unwrap();
+	common::premine_and_distribute_funds(
+		&bitcoind.client,
+		&electrsd.client,
+		vec![addr],
+		bitcoin::Amount::from_sat(1_000_000),
+	)
+	.await;
+	node.sync_wallets().unwrap();
+
+	// Open a channel to node B (pushing half so both sides can route) and let it confirm.
+	common::open_channel_push_amt(&node, &node_b, 200_000, Some(100_000_000), false, &electrsd)
+		.await;
+	common::generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6).await;
+	node.sync_wallets().unwrap();
+	node_b.sync_wallets().unwrap();
+	expect_channel_ready_event!(node, node_b.node_id());
+	expect_channel_ready_event!(node_b, node.node_id());
+
+	// Lightning send: node -> node B.
+	let description =
+		Bolt11InvoiceDescription::Direct(Description::new("ln send".to_string()).unwrap());
+	let invoice = node_b.bolt11_payment().receive(10_000, &description.into(), 3600).unwrap();
+	let ln_send_id = node.bolt11_payment().send(&invoice, None).unwrap();
+	expect_payment_successful_event!(node, Some(ln_send_id), None);
+	expect_payment_received_event!(node_b, 10_000);
+
+	// Lightning receive: node B -> node.
+	let description =
+		Bolt11InvoiceDescription::Direct(Description::new("ln receive".to_string()).unwrap());
+	let invoice = node.bolt11_payment().receive(5_000, &description.into(), 3600).unwrap();
+	let ln_receive_id = node_b.bolt11_payment().send(&invoice, None).unwrap();
+	expect_payment_successful_event!(node_b, Some(ln_receive_id), None);
+	expect_payment_received_event!(node, 5_000);
+
+	// On-chain send: node -> a foreign address.
+	let bitcoind_addr = bitcoind.client.new_address().unwrap();
+	let txid = node.onchain_payment().send_to_address(&bitcoind_addr, 50_000, None).unwrap();
+	common::wait_for_tx(&electrsd.client, txid).await;
+	common::generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6).await;
+	node.sync_wallets().unwrap();
+
+	// Capture the state we expect to survive every migration.
+	let expected_balance_sats = node.list_balances().total_onchain_balance_sats;
+	let expected_ln_balance_sats = node.list_balances().total_lightning_balance_sats;
+	let mut expected_payments = node.list_payments();
+	expected_payments.sort_by_key(|p| p.id.0);
+	assert!(expected_payments.len() >= 4);
+
+	for (i, &next_backend) in order.iter().enumerate().skip(1) {
+		println!("Migrating from {:?} to {:?}", current.backend, next_backend);
+
+		let next = BackendInstance::new(next_backend, &base_dir, &connection_string, &tables[i]);
+
+		// Spin the node down so the source store is no longer being written to.
+		node.stop().unwrap();
+		drop(node);
+
+		migrate_between_backends(&current, &next).await;
+
+		// Spin the node back up on the new backend.
+		node = build_migration_node(&next, node_config.clone(), node_entropy, &esplora_url).await;
+		node.start().unwrap();
+		node.sync_wallets().unwrap();
+
+		// The balance, channel, and transaction history are preserved across the migration.
+		assert_eq!(node.node_id(), expected_node_id);
+		assert_eq!(node.list_balances().total_onchain_balance_sats, expected_balance_sats);
+		assert_eq!(node.list_balances().total_lightning_balance_sats, expected_ln_balance_sats);
+		assert_eq!(node.list_channels().len(), 1);
+		let mut migrated_payments = node.list_payments();
+		migrated_payments.sort_by_key(|p| p.id.0);
+		assert_eq!(migrated_payments, expected_payments);
+
+		current = next;
+	}
+
+	node.stop().unwrap();
+	node_b.stop().unwrap();
+
+	drop_tables(tables.iter().chain(std::iter::once(&node_b_table))).await;
+}

--- a/tests/integration_tests_postgres.rs
+++ b/tests/integration_tests_postgres.rs
@@ -9,26 +9,10 @@
 
 mod common;
 
+use common::{drop_table, test_connection_string};
 use ldk_node::entropy::NodeEntropy;
 use ldk_node::Builder;
 use rand::RngCore;
-
-fn test_connection_string() -> String {
-	std::env::var("TEST_POSTGRES_URL")
-		.unwrap_or_else(|_| "host=localhost user=postgres password=postgres".to_string())
-}
-
-async fn drop_table(table_name: &str) {
-	let connection_string = format!("{} dbname=ldk_db", test_connection_string());
-	let Ok((client, connection)) =
-		tokio_postgres::connect(&connection_string, tokio_postgres::NoTls).await
-	else {
-		// Database doesn't exist yet — nothing to drop.
-		return;
-	};
-	tokio::spawn(connection);
-	let _ = client.execute(&format!("DROP TABLE IF EXISTS {table_name}"), &[]).await;
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn channel_full_cycle_with_postgres_store() {


### PR DESCRIPTION
Pulled out of #915

These were unimplemented for our kv stores. Useful if the user wants to migrate to a different database and also in tests so we don't have to re-init and setup a node.