### PR TITLE
Fix 0.6.2 compatibility test shutdown

### DIFF
--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -2580,7 +2580,11 @@ async fn build_0_6_2_node(
 	assert!(balance > 0);
 	let node_id = node_old.node_id();
 
-	node_old.stop().unwrap();
+	// Workaround necessary as v0.6.2's runtime wasn't dropsafe in a tokio context.
+	tokio::task::block_in_place(move || {
+		node_old.stop().unwrap();
+		drop(node_old);
+	});
 
 	(balance, node_id)
 }


### PR DESCRIPTION
Stop and drop the old compatibility node from a blocking region.

This avoids a Tokio runtime-drop panic in the async test.

Honestly not quite sure what changed that this only surfaces now that CI is back  (likely an unrelated refactoring while CI was gone is to blame). But we need to fix it so CI finally is green again.