### PR TITLE
Add paginated payment listing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   succeeds, allowing restored wallets to rediscover funds sent to previously-unknown addresses.
 - `Config::anchor_channels_config` is no longer optional, hence anchor channels can no longer be
   disabled. We still negotiate legacy channels if the peer does not support anchor channels.
+- `Node::list_payments` now retrieves payments page-by-page, ordered from most recently created to
+  least recently created, instead of returning all payments at once. This is a breaking API change,
+  and `Node::list_payments_with_filter` is now deprecated. Invalid pagination tokens return the new
+  `Error::InvalidPageToken` variant. Generic KV store migrations do not preserve creation-order
+  metadata and may change the order of existing payments (#959).
 
 ## Bug Fixes and Improvements
 - Building a fresh node against a Bitcoin Core RPC or REST chain source that fails to return the

--- a/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
+++ b/bindings/kotlin/ldk-node-jvm/lib/src/test/kotlin/org/lightningdevkit/ldknode/LibraryTest.kt
@@ -301,8 +301,9 @@ class LibraryTest {
         assert(paymentReceivedEvent is Event.PaymentReceived)
         node2.eventHandled()
 
-        assert(node1.listPayments().size == 3)
-        assert(node2.listPayments().size == 2)
+        assert(node1.listPayments(null).payments.size == 3)
+        assert(node2.listPayments(null).payments.size == 2)
+        assert(PageToken("1").toString() == "1")
 
         node2.closeChannel(userChannelId, nodeId1)
 

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -151,7 +151,8 @@ interface Node {
 	[Throws=NodeError]
 	void remove_payment([ByRef]PaymentId payment_id);
 	BalanceDetails list_balances();
-	sequence<PaymentDetails> list_payments();
+	[Throws=NodeError]
+	PaymentDetailsPage list_payments(PageToken? page_token);
 	sequence<PeerDetails> list_peers();
 	sequence<ChannelDetails> list_channels();
 	NetworkGraph network_graph();
@@ -235,6 +236,7 @@ enum NodeError {
 	"InvalidDateTime",
 	"InvalidFeeRate",
 	"InvalidScriptPubKey",
+	"InvalidPageToken",
 	"DuplicatePayment",
 	"UnsupportedCurrency",
 	"InsufficientFunds",
@@ -276,6 +278,10 @@ enum PaymentFailureReason {
 };
 
 typedef dictionary PaymentDetails;
+
+typedef dictionary PaymentDetailsPage;
+
+typedef interface PageToken;
 
 [Remote]
 dictionary RouteParametersConfig {

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. You may not use this file except in
 // accordance with one or both of these licenses.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
-use lightning::util::persist::KVStore;
+use lightning::util::persist::{KVStore, PageToken};
 use lightning::util::ser::{Readable, Writeable};
 
 use crate::logger::{log_error, LdkLogger};
@@ -25,7 +25,7 @@ pub(crate) trait StorableObject: Clone + Readable + Writeable {
 	fn to_update(&self) -> Self::Update;
 }
 
-pub(crate) trait StorableObjectId: std::hash::Hash + PartialEq + Eq {
+pub(crate) trait StorableObjectId: Clone + std::hash::Hash + Eq {
 	fn encode_to_hex_str(&self) -> String;
 }
 
@@ -40,11 +40,18 @@ pub(crate) enum DataStoreUpdateResult {
 	NotFound,
 }
 
+struct InMemoryObjects<SO: StorableObject> {
+	objects: HashMap<SO::Id, SO>,
+	creation_order: BTreeMap<u64, SO::Id>,
+	creation_order_by_key: HashMap<String, u64>,
+	next_creation_order: u64,
+}
+
 pub(crate) struct DataStore<SO: StorableObject, L: Deref>
 where
 	L::Target: LdkLogger,
 {
-	objects: Mutex<HashMap<SO::Id, SO>>,
+	objects: Mutex<InMemoryObjects<SO>>,
 	mutation_lock: tokio::sync::Mutex<()>,
 	primary_namespace: String,
 	secondary_namespace: String,
@@ -60,8 +67,23 @@ where
 		objects: Vec<SO>, primary_namespace: String, secondary_namespace: String,
 		kv_store: Arc<DynStore>, logger: L,
 	) -> Self {
-		let objects =
-			Mutex::new(HashMap::from_iter(objects.into_iter().map(|obj| (obj.id(), obj))));
+		let object_count = objects.len();
+		let mut creation_order = BTreeMap::new();
+		let mut creation_order_by_key = HashMap::with_capacity(object_count);
+		let mut objects_by_id = HashMap::with_capacity(objects.len());
+		for (creation_index, object) in objects.into_iter().rev().enumerate() {
+			let id = object.id();
+			let order = creation_index as u64;
+			creation_order.insert(order, id.clone());
+			creation_order_by_key.insert(id.encode_to_hex_str(), order);
+			objects_by_id.insert(id, object);
+		}
+		let objects = Mutex::new(InMemoryObjects {
+			objects: objects_by_id,
+			creation_order,
+			creation_order_by_key,
+			next_creation_order: object_count as u64,
+		});
 		Self {
 			objects,
 			mutation_lock: tokio::sync::Mutex::new(()),
@@ -77,7 +99,15 @@ where
 
 		self.persist(&object).await?;
 		let mut locked_objects = self.objects.lock().expect("lock");
-		let updated = locked_objects.insert(object.id(), object).is_some();
+		let id = object.id();
+		let updated = locked_objects.objects.insert(id.clone(), object).is_some();
+		if !updated {
+			let creation_order = locked_objects.next_creation_order;
+			locked_objects.next_creation_order =
+				creation_order.checked_add(1).expect("creation order overflow");
+			locked_objects.creation_order.insert(creation_order, id.clone());
+			locked_objects.creation_order_by_key.insert(id.encode_to_hex_str(), creation_order);
+		}
 		Ok(updated)
 	}
 
@@ -87,7 +117,7 @@ where
 		let id = object.id();
 		let data_to_persist = {
 			let locked_objects = self.objects.lock().expect("lock");
-			if let Some(existing_object) = locked_objects.get(&id) {
+			if let Some(existing_object) = locked_objects.objects.get(&id) {
 				let mut updated_object = existing_object.clone();
 				let updated = updated_object.update(object.to_update());
 				if updated {
@@ -104,7 +134,16 @@ where
 			Some(updated_object) => {
 				self.persist(&updated_object).await?;
 				let mut locked_objects = self.objects.lock().expect("lock");
-				locked_objects.insert(id, updated_object);
+				let is_new = locked_objects.objects.insert(id.clone(), updated_object).is_none();
+				if is_new {
+					let creation_order = locked_objects.next_creation_order;
+					locked_objects.next_creation_order =
+						creation_order.checked_add(1).expect("creation order overflow");
+					locked_objects.creation_order.insert(creation_order, id.clone());
+					locked_objects
+						.creation_order_by_key
+						.insert(id.encode_to_hex_str(), creation_order);
+				}
 				Ok(true)
 			},
 			None => Ok(false),
@@ -113,7 +152,7 @@ where
 
 	pub(crate) async fn remove(&self, id: &SO::Id) -> Result<(), Error> {
 		let _guard = self.mutation_lock.lock().await;
-		let should_remove = { self.objects.lock().expect("lock").contains_key(id) };
+		let should_remove = { self.objects.lock().expect("lock").objects.contains_key(id) };
 		if should_remove {
 			let store_key = id.encode_to_hex_str();
 			KVStore::remove(
@@ -135,7 +174,11 @@ where
 				);
 				Error::PersistenceFailed
 			})?;
-			self.objects.lock().expect("lock").remove(id);
+			let mut locked_objects = self.objects.lock().expect("lock");
+			locked_objects.objects.remove(id);
+			if let Some(creation_order) = locked_objects.creation_order_by_key.remove(&store_key) {
+				locked_objects.creation_order.remove(&creation_order);
+			}
 		}
 		Ok(())
 	}
@@ -146,7 +189,7 @@ where
 	/// Until store reads are async, callers may temporarily see in-memory state that has not yet
 	/// caught up to a write in progress.
 	pub(crate) fn get(&self, id: &SO::Id) -> Option<SO> {
-		self.objects.lock().expect("lock").get(id).cloned()
+		self.objects.lock().expect("lock").objects.get(id).cloned()
 	}
 
 	pub(crate) async fn update(&self, update: SO::Update) -> Result<DataStoreUpdateResult, Error> {
@@ -154,7 +197,7 @@ where
 		let id = update.id();
 		let updated_object = {
 			let locked_objects = self.objects.lock().expect("lock");
-			let Some(object) = locked_objects.get(&id) else {
+			let Some(object) = locked_objects.objects.get(&id) else {
 				return Ok(DataStoreUpdateResult::NotFound);
 			};
 			let mut updated_object = object.clone();
@@ -166,7 +209,7 @@ where
 
 		self.persist(&updated_object).await?;
 		let mut locked_objects = self.objects.lock().expect("lock");
-		locked_objects.insert(id, updated_object);
+		locked_objects.objects.insert(id, updated_object);
 		Ok(DataStoreUpdateResult::Updated)
 	}
 
@@ -176,7 +219,63 @@ where
 	/// Until store reads are async, callers may temporarily see in-memory state that has not yet
 	/// caught up to a write in progress.
 	pub(crate) fn list_filter<F: FnMut(&&SO) -> bool>(&self, f: F) -> Vec<SO> {
-		self.objects.lock().expect("lock").values().filter(f).cloned().collect::<Vec<SO>>()
+		self.objects.lock().expect("lock").objects.values().filter(f).cloned().collect()
+	}
+
+	/// Returns a page of objects, ordered from most recently created to least recently created,
+	/// together with a token that can be passed to a subsequent call to retrieve the next page.
+	pub(crate) fn list_page(
+		&self, page_token: Option<PageToken>,
+	) -> Result<(Vec<SO>, Option<PageToken>), Error> {
+		const PAGE_SIZE: usize = 50;
+
+		let locked_objects = self.objects.lock().expect("lock");
+		let start_order = if let Some(token) = page_token {
+			// The key resolves the current order across reloads, while the encoded order lets us
+			// continue if the key was removed after the token was issued.
+			let (encoded_order, key) = token
+				.as_str()
+				.split_once(':')
+				.and_then(|(order, key)| order.parse::<u64>().ok().map(|order| (order, key)))
+				.ok_or_else(|| {
+					log_error!(self.logger, "Object page token not found: {}", token);
+					Error::InvalidPageToken
+				})?;
+			if let Some(current_order) = locked_objects.creation_order_by_key.get(key) {
+				// Reloading after an older removal shifts the current order down, while removing and
+				// reinserting the cursor shifts it up. In either case, resume from the older position.
+				encoded_order.min(*current_order)
+			} else if encoded_order < locked_objects.next_creation_order {
+				encoded_order
+			} else {
+				log_error!(self.logger, "Object page token not found: {}", token);
+				return Err(Error::InvalidPageToken);
+			}
+		} else {
+			locked_objects.next_creation_order
+		};
+
+		let mut entries = locked_objects
+			.creation_order
+			.range(..start_order)
+			.rev()
+			.filter_map(|(order, id)| {
+				locked_objects.objects.get(id).cloned().map(|object| (*order, id, object))
+			})
+			.take(PAGE_SIZE + 1)
+			.collect::<Vec<_>>();
+		let has_more = entries.len() > PAGE_SIZE;
+		entries.truncate(PAGE_SIZE);
+
+		let next_page_token = if has_more {
+			entries.last().map(|(order, id, _)| {
+				PageToken::new(format!("{}:{}", order, id.encode_to_hex_str()))
+			})
+		} else {
+			None
+		};
+		let objects = entries.into_iter().map(|(_, _, object)| object).collect();
+		Ok((objects, next_page_token))
 	}
 
 	async fn persist(&self, object: &SO) -> Result<(), Error> {
@@ -217,12 +316,14 @@ where
 	/// Until store reads are async, callers may temporarily see in-memory state that has not yet
 	/// caught up to a write in progress.
 	pub(crate) fn contains_key(&self, id: &SO::Id) -> bool {
-		self.objects.lock().expect("lock").contains_key(id)
+		self.objects.lock().expect("lock").objects.contains_key(id)
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::cell::Cell;
+
 	use lightning::util::persist::{PageToken, PaginatedKVStore, PaginatedListResponse};
 	use lightning::util::test_utils::TestLogger;
 	use lightning::{impl_writeable_tlv_based, io};
@@ -230,6 +331,7 @@ mod tests {
 	use super::*;
 	use crate::hex_utils;
 	use crate::io::test_utils::InMemoryStore;
+	use crate::io::utils::read_all_objects;
 	use crate::types::DynStoreWrapper;
 
 	#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -237,8 +339,13 @@ mod tests {
 		id: [u8; 4],
 	}
 
+	thread_local! {
+		static ID_ENCODING_COUNT: Cell<usize> = const { Cell::new(0) };
+	}
+
 	impl StorableObjectId for TestObjectId {
 		fn encode_to_hex_str(&self) -> String {
+			ID_ENCODING_COUNT.set(ID_ENCODING_COUNT.get() + 1);
 			hex_utils::to_string(&self.id)
 		}
 	}
@@ -335,6 +442,174 @@ mod tests {
 			store,
 			logger,
 		)
+	}
+
+	#[tokio::test]
+	async fn list_page_paginates_in_reverse_creation_order() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let data_store: DataStore<TestObject, Arc<TestLogger>> = DataStore::new(
+			Vec::new(),
+			"datastore_test_primary".to_string(),
+			"datastore_test_secondary".to_string(),
+			Arc::clone(&store),
+			logger,
+		);
+
+		// Insert more objects than fit in a single page to exercise the pagination loop.
+		let num_objects = 120u32;
+		for i in 0..num_objects {
+			let id = TestObjectId { id: i.to_be_bytes() };
+			data_store.insert(TestObject { id, data: [7u8; 3] }).await.unwrap();
+		}
+
+		let mut listed = Vec::with_capacity(num_objects as usize);
+		let mut page_token = None;
+		loop {
+			let (page, next_page_token) = data_store.list_page(page_token).unwrap();
+			assert!(!page.is_empty());
+			listed.extend(page);
+			page_token = next_page_token.map(|token| PageToken::new(token.to_string()));
+			if page_token.is_none() {
+				break;
+			}
+		}
+
+		let expected: Vec<TestObject> = (0..num_objects)
+			.rev()
+			.map(|i| TestObject { id: TestObjectId { id: i.to_be_bytes() }, data: [7u8; 3] })
+			.collect();
+		assert_eq!(listed, expected);
+	}
+
+	#[test]
+	fn list_page_cursor_lookup_does_not_scan_preceding_entries() {
+		let objects = (0..120u32)
+			.rev()
+			.map(|i| TestObject { id: TestObjectId { id: i.to_be_bytes() }, data: [7u8; 3] })
+			.collect();
+		let data_store = new_failing_data_store(objects);
+		ID_ENCODING_COUNT.set(0);
+
+		let mut page_token = None;
+		loop {
+			let (_, next_page_token) = data_store.list_page(page_token).unwrap();
+			page_token = next_page_token;
+			if page_token.is_none() {
+				break;
+			}
+		}
+
+		assert_eq!(ID_ENCODING_COUNT.get(), 2);
+	}
+
+	#[tokio::test]
+	async fn list_page_resumes_after_cursor_payment_is_removed() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let data_store: DataStore<TestObject, Arc<TestLogger>> = DataStore::new(
+			Vec::new(),
+			"datastore_test_primary".to_string(),
+			"datastore_test_secondary".to_string(),
+			store,
+			logger,
+		);
+
+		for i in 0..60u32 {
+			let id = TestObjectId { id: i.to_be_bytes() };
+			data_store.insert(TestObject { id, data: [7u8; 3] }).await.unwrap();
+		}
+
+		let (first_page, page_token) = data_store.list_page(None).unwrap();
+		assert_eq!(first_page.len(), 50);
+		let cursor_id = first_page.last().unwrap().id;
+		assert_eq!(cursor_id.id, 10u32.to_be_bytes());
+		let page_token = page_token.unwrap();
+		data_store.remove(&cursor_id).await.unwrap();
+
+		let (second_page, next_page_token) =
+			data_store.list_page(Some(page_token.clone())).unwrap();
+		assert_eq!(second_page.len(), 10);
+		assert_eq!(second_page.first().unwrap().id.id, 9u32.to_be_bytes());
+		assert_eq!(second_page.last().unwrap().id.id, 0u32.to_be_bytes());
+		assert!(next_page_token.is_none());
+
+		data_store.insert(TestObject { id: cursor_id, data: [7u8; 3] }).await.unwrap();
+		let (page_after_reinsert, next_page_token) =
+			data_store.list_page(Some(page_token)).unwrap();
+		assert_eq!(page_after_reinsert, second_page);
+		assert!(next_page_token.is_none());
+	}
+
+	#[tokio::test]
+	async fn list_page_token_survives_reload_after_unseen_object_is_removed() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let primary_namespace = "datastore_test_primary".to_string();
+		let secondary_namespace = "datastore_test_secondary".to_string();
+		let data_store: DataStore<TestObject, Arc<TestLogger>> = DataStore::new(
+			Vec::new(),
+			primary_namespace.clone(),
+			secondary_namespace.clone(),
+			Arc::clone(&store),
+			Arc::clone(&logger),
+		);
+
+		for i in 0..101u32 {
+			let id = TestObjectId { id: i.to_be_bytes() };
+			data_store.insert(TestObject { id, data: [7u8; 3] }).await.unwrap();
+		}
+
+		let (first_page, page_token) = data_store.list_page(None).unwrap();
+		assert_eq!(first_page.first().unwrap().id.id, 100u32.to_be_bytes());
+		assert_eq!(first_page.last().unwrap().id.id, 51u32.to_be_bytes());
+		let page_token = page_token.unwrap();
+
+		let oldest_id = TestObjectId { id: 0u32.to_be_bytes() };
+		data_store.remove(&oldest_id).await.unwrap();
+		let reloaded_objects = read_all_objects(
+			&*store,
+			&primary_namespace,
+			&secondary_namespace,
+			Arc::clone(&logger),
+		)
+		.await
+		.unwrap();
+		let reloaded_data_store: DataStore<TestObject, Arc<TestLogger>> =
+			DataStore::new(reloaded_objects, primary_namespace, secondary_namespace, store, logger);
+
+		let (second_page, next_page_token) =
+			reloaded_data_store.list_page(Some(page_token)).unwrap();
+		assert_eq!(second_page.first().unwrap().id.id, 50u32.to_be_bytes());
+		assert_eq!(second_page.last().unwrap().id.id, 1u32.to_be_bytes());
+		assert_eq!(second_page.len(), 50);
+		assert!(next_page_token.is_none());
+	}
+
+	#[test]
+	fn list_page_rejects_invalid_tokens() {
+		let newest = TestObject { id: TestObjectId { id: 2u32.to_be_bytes() }, data: [2u8; 3] };
+		let oldest = TestObject { id: TestObjectId { id: 1u32.to_be_bytes() }, data: [1u8; 3] };
+		let data_store = new_failing_data_store(vec![newest, oldest]);
+
+		let malformed_error =
+			data_store.list_page(Some(PageToken::new("3".to_string()))).unwrap_err();
+		assert_eq!(malformed_error, Error::InvalidPageToken);
+
+		let unknown_error =
+			data_store.list_page(Some(PageToken::new("ffffffff".to_string()))).unwrap_err();
+		assert_eq!(unknown_error, Error::InvalidPageToken);
+	}
+
+	#[test]
+	fn list_page_only_reads_in_memory() {
+		let newest = TestObject { id: TestObjectId { id: 2u32.to_be_bytes() }, data: [2u8; 3] };
+		let oldest = TestObject { id: TestObjectId { id: 1u32.to_be_bytes() }, data: [1u8; 3] };
+		let data_store = new_failing_data_store(vec![newest, oldest]);
+
+		let (page, next_page_token) = data_store.list_page(None).unwrap();
+		assert_eq!(page, vec![newest, oldest]);
+		assert!(next_page_token.is_none());
 	}
 
 	#[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,8 @@ pub enum Error {
 	InvalidFeeRate,
 	/// The given script public key is invalid.
 	InvalidScriptPubKey,
+	/// The given page token is invalid.
+	InvalidPageToken,
 	/// A payment with the given hash has already been initiated.
 	DuplicatePayment,
 	/// The provided offer was denonminated in an unsupported currency.
@@ -199,6 +201,7 @@ impl fmt::Display for Error {
 			Self::InvalidDateTime => write!(f, "The given date time is invalid."),
 			Self::InvalidFeeRate => write!(f, "The given fee rate is invalid."),
 			Self::InvalidScriptPubKey => write!(f, "The given script pubkey is invalid."),
+			Self::InvalidPageToken => write!(f, "The given page token is invalid."),
 			Self::DuplicatePayment => {
 				write!(f, "A payment with the given hash has already been initiated.")
 			},

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -37,6 +37,7 @@ use lightning::offers::static_invoice::StaticInvoice as LdkStaticInvoice;
 use lightning::onion_message::dns_resolution::HumanReadableName as LdkHumanReadableName;
 pub use lightning::routing::gossip::{NodeAlias, NodeId, RoutingFees};
 pub use lightning::routing::router::RouteParametersConfig;
+use lightning::util::persist::PageToken as LdkPageToken;
 use lightning::util::ser::{Readable, Writeable, Writer};
 use lightning_invoice::{Bolt11Invoice as LdkBolt11Invoice, Bolt11InvoiceDescriptionRef};
 pub use lightning_invoice::{Description, SignedRawBolt11Invoice};
@@ -75,6 +76,34 @@ pub enum VssHeaderProviderError {
 		/// The error message.
 		error: String,
 	},
+}
+
+/// An opaque token used to continue paginated listing operations.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct PageToken {
+	pub(crate) inner: LdkPageToken,
+}
+
+#[uniffi::export]
+impl PageToken {
+	/// Creates a page token from its opaque string representation.
+	#[uniffi::constructor]
+	pub fn new(token: String) -> Self {
+		Self { inner: LdkPageToken::new(token) }
+	}
+}
+
+impl From<LdkPageToken> for PageToken {
+	fn from(token: LdkPageToken) -> Self {
+		Self { inner: token }
+	}
+}
+
+impl std::fmt::Display for PageToken {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.inner)
+	}
 }
 
 impl std::fmt::Display for VssHeaderProviderError {

--- a/src/io/utils.rs
+++ b/src/io/utils.rs
@@ -26,7 +26,7 @@ use lightning::routing::scoring::{
 	ChannelLiquidities, ProbabilisticScorer, ProbabilisticScoringDecayParameters,
 };
 use lightning::util::persist::{
-	migrate_kv_store_data_async, KVStore, KVSTORE_NAMESPACE_KEY_ALPHABET,
+	migrate_kv_store_data_async, KVStore, PaginatedKVStore, KVSTORE_NAMESPACE_KEY_ALPHABET,
 	KVSTORE_NAMESPACE_KEY_MAX_LEN, NETWORK_GRAPH_PERSISTENCE_KEY,
 	NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
 	OUTPUT_SWEEPER_PERSISTENCE_KEY, OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
@@ -222,7 +222,8 @@ where
 	})
 }
 
-/// Read all objects of type `T` from the given namespace, spawning reads in parallel.
+/// Read all objects of type `T` from the given namespace in reverse creation order, spawning reads
+/// within each page in parallel.
 pub(crate) async fn read_all_objects<T, L>(
 	kv_store: &DynStore, primary_namespace: &str, secondary_namespace: &str, logger: L,
 ) -> Result<Vec<T>, std::io::Error>
@@ -233,56 +234,67 @@ where
 {
 	let type_name = std::any::type_name::<T>();
 	let mut res = Vec::new();
-
-	let mut stored_keys = KVStore::list(&*kv_store, primary_namespace, secondary_namespace).await?;
-
 	const BATCH_SIZE: usize = 50;
+	let mut page_token = None;
 
-	let mut set = tokio::task::JoinSet::new();
+	loop {
+		let page = PaginatedKVStore::list_paginated(
+			&*kv_store,
+			primary_namespace,
+			secondary_namespace,
+			page_token,
+		)
+		.await?;
+		let page_len = page.keys.len();
+		let mut stored_keys = page.keys.into_iter().enumerate();
+		let mut page_objects = Vec::with_capacity(page_len);
+		page_objects.resize_with(page_len, || None);
+		let mut set = tokio::task::JoinSet::new();
 
-	// Fill JoinSet with tasks if possible
-	while set.len() < BATCH_SIZE && !stored_keys.is_empty() {
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(kv_store, primary_namespace, secondary_namespace, &next_key);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
+		while set.len() < BATCH_SIZE {
+			let Some((index, key)) = stored_keys.next() else {
+				break;
+			};
+			let fut = KVStore::read(kv_store, primary_namespace, secondary_namespace, &key);
+			set.spawn(async move { (index, fut.await) });
 		}
-	}
 
-	while let Some(read_res) = set.join_next().await {
-		// Exit early if we get an IO error.
-		let reader = read_res
-			.map_err(|e| {
-				log_error!(logger, "Failed to read {}: {}", type_name, e);
-				set.abort_all();
-				e
-			})?
-			.map_err(|e| {
+		while let Some(read_res) = set.join_next().await {
+			let (index, reader) = read_res.map_err(|e| {
 				log_error!(logger, "Failed to read {}: {}", type_name, e);
 				set.abort_all();
 				e
 			})?;
+			let reader = reader.map_err(|e| {
+				log_error!(logger, "Failed to read {}: {}", type_name, e);
+				set.abort_all();
+				e
+			})?;
+			let object = T::read(&mut &*reader).map_err(|e| {
+				log_error!(logger, "Failed to deserialize {}: {}", type_name, e);
+				set.abort_all();
+				std::io::Error::new(
+					std::io::ErrorKind::InvalidData,
+					format!("Failed to deserialize {}", type_name),
+				)
+			})?;
+			page_objects[index] = Some(object);
 
-		// Refill set for every finished future, if we still have something to do.
-		if let Some(next_key) = stored_keys.pop() {
-			let fut = KVStore::read(kv_store, primary_namespace, secondary_namespace, &next_key);
-			set.spawn(fut);
-			debug_assert!(set.len() <= BATCH_SIZE);
+			if let Some((next_index, next_key)) = stored_keys.next() {
+				let fut =
+					KVStore::read(kv_store, primary_namespace, secondary_namespace, &next_key);
+				set.spawn(async move { (next_index, fut.await) });
+			}
 		}
 
-		// Handle result.
-		let object = T::read(&mut &*reader).map_err(|e| {
-			log_error!(logger, "Failed to deserialize {}: {}", type_name, e);
-			std::io::Error::new(
-				std::io::ErrorKind::InvalidData,
-				format!("Failed to deserialize {}", type_name),
-			)
-		})?;
-		res.push(object);
-	}
+		debug_assert!(stored_keys.next().is_none());
+		res.extend(page_objects.into_iter().map(|object| object.expect("all reads completed")));
 
-	debug_assert!(set.is_empty());
-	debug_assert!(stored_keys.is_empty());
+		page_token = page.next_page_token;
+		if page_token.is_none() {
+			break;
+		}
+	}
 
 	Ok(res)
 }
@@ -718,13 +730,18 @@ fn recover_incomplete_fs_store_migration(storage_dir_path: &Path) -> Result<(), 
 mod tests {
 	use std::fs;
 	use std::path::{Path, PathBuf};
+	use std::sync::Arc;
 
 	use lightning::util::persist::{migrate_kv_store_data_async, KVStore};
+	use lightning::util::ser::Writeable;
+	use lightning::util::test_utils::TestLogger;
 	use lightning_persister::fs_store::v1::FilesystemStore;
 	use lightning_persister::fs_store::v2::FilesystemStoreV2;
 
 	use super::test_utils::random_storage_path;
-	use super::{open_or_migrate_fs_store, read_or_generate_seed_file};
+	use super::{open_or_migrate_fs_store, read_all_objects, read_or_generate_seed_file};
+	use crate::io::test_utils::InMemoryStore;
+	use crate::types::{DynStore, DynStoreWrapper};
 
 	const TEST_PRIMARY_NAMESPACE: &str = "test_primary_namespace";
 	const TEST_SECONDARY_NAMESPACE: &str = "test_secondary_namespace";
@@ -738,6 +755,31 @@ mod tests {
 		let expected_seed_bytes = read_or_generate_seed_file(&rand_path.to_str().unwrap()).unwrap();
 		let read_seed_bytes = read_or_generate_seed_file(&rand_path.to_str().unwrap()).unwrap();
 		assert_eq!(expected_seed_bytes, read_seed_bytes);
+	}
+
+	#[tokio::test]
+	async fn read_all_objects_preserves_paginated_creation_order() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let object_count = 120u64;
+
+		for object in 0..object_count {
+			KVStore::write(
+				&*store,
+				TEST_PRIMARY_NAMESPACE,
+				TEST_SECONDARY_NAMESPACE,
+				&object.to_string(),
+				object.encode(),
+			)
+			.await
+			.unwrap();
+		}
+
+		let objects: Vec<u64> =
+			read_all_objects(&*store, TEST_PRIMARY_NAMESPACE, TEST_SECONDARY_NAMESPACE, logger)
+				.await
+				.unwrap();
+		assert_eq!(objects, (0..object_count).rev().collect::<Vec<_>>());
 	}
 
 	#[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,8 @@ use lightning::ln::peer_handler::CustomMessageHandler;
 use lightning::routing::gossip::NodeAlias;
 use lightning::sign::EntropySource;
 use lightning::util::persist::KVStore;
+#[cfg(not(feature = "uniffi"))]
+pub use lightning::util::persist::PageToken;
 use lightning::util::wallet_utils::{Input, Wallet as LdkWallet};
 use lightning_background_processor::process_events_async;
 pub use lightning_invoice;
@@ -2207,15 +2209,43 @@ impl Node {
 	/// # let node = builder.build(node_entropy.into()).unwrap();
 	/// node.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound);
 	/// ```
+	#[deprecated(
+		note = "Use the paginated list_payments API and filter the returned pages instead."
+	)]
 	pub fn list_payments_with_filter<F: FnMut(&&PaymentDetails) -> bool>(
 		&self, f: F,
 	) -> Vec<PaymentDetails> {
 		self.payment_store.list_filter(f)
 	}
 
-	/// Retrieves all payments.
-	pub fn list_payments(&self) -> Vec<PaymentDetails> {
-		self.payment_store.list_filter(|_| true)
+	/// Retrieves a page of payments, ordered from most recently created to least recently created.
+	///
+	/// Pass `None` to start listing from the most recently created payment. If the returned
+	/// [`PaymentDetailsPage::next_page_token`] is `Some`, pass it to a subsequent call to
+	/// retrieve the next page.
+	#[cfg(not(feature = "uniffi"))]
+	pub fn list_payments(
+		&self, page_token: Option<PageToken>,
+	) -> Result<PaymentDetailsPage, Error> {
+		let (payments, next_page_token) = self.payment_store.list_page(page_token)?;
+		Ok(PaymentDetailsPage { payments, next_page_token })
+	}
+
+	/// Retrieves a page of payments, ordered from most recently created to least recently created.
+	///
+	/// Pass `None` to start listing from the most recently created payment. If the returned
+	/// [`PaymentDetailsPage::next_page_token`] is `Some`, pass it to a subsequent call to
+	/// retrieve the next page.
+	#[cfg(feature = "uniffi")]
+	pub fn list_payments(
+		&self, page_token: Option<Arc<PageToken>>,
+	) -> Result<PaymentDetailsPage, Error> {
+		let page_token = page_token.map(|t| t.inner.clone());
+		let (payments, next_page_token) = self.payment_store.list_page(page_token)?;
+		Ok(PaymentDetailsPage {
+			payments,
+			next_page_token: next_page_token.map(|token| Arc::new(token.into())),
+		})
 	}
 
 	/// Retrieves a list of known peers.
@@ -2331,6 +2361,20 @@ impl Drop for Node {
 	fn drop(&mut self) {
 		let _ = self.stop();
 	}
+}
+
+/// A page of payments returned from a paginated listing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct PaymentDetailsPage {
+	/// Payments in this page, ordered from most recently created to least recently created.
+	pub payments: Vec<PaymentDetails>,
+	/// Token to pass to the next call to continue listing, if another page exists.
+	#[cfg(not(feature = "uniffi"))]
+	pub next_page_token: Option<PageToken>,
+	/// Token to pass to the next call to continue listing, if another page exists.
+	#[cfg(feature = "uniffi")]
+	pub next_page_token: Option<Arc<PageToken>>,
 }
 
 /// The best known block as identified by its hash and height.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -43,7 +43,9 @@ use ldk_node::config::{
 };
 use ldk_node::entropy::{generate_entropy_mnemonic, NodeEntropy};
 use ldk_node::io::sqlite_store::SqliteStore;
-use ldk_node::payment::{PaymentDirection, PaymentKind, PaymentStatus, TransactionType};
+use ldk_node::payment::{
+	PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus, TransactionType,
+};
 use ldk_node::probing::ProbingConfig;
 use ldk_node::{
 	Builder, ChannelShutdownState, CustomTlvRecord, Event, LightningBalance, Node, NodeError,
@@ -67,6 +69,48 @@ pub(crate) use in_memory_store::InMemoryStore;
 
 /// Shared timeout (in seconds) for waiting on LDK events and external node operations.
 pub(crate) const INTEROP_TIMEOUT_SECS: u64 = 60;
+
+pub(crate) trait NodePaymentExt {
+	fn list_first_page_payments(&self) -> Vec<PaymentDetails>;
+	fn list_first_page_payments_with_filter<F: FnMut(&PaymentDetails) -> bool>(
+		&self, f: F,
+	) -> Vec<PaymentDetails>;
+	fn list_all_payments(&self) -> Vec<PaymentDetails>;
+	fn list_all_payments_with_filter<F: FnMut(&PaymentDetails) -> bool>(
+		&self, f: F,
+	) -> Vec<PaymentDetails>;
+}
+
+impl NodePaymentExt for Node {
+	fn list_first_page_payments(&self) -> Vec<PaymentDetails> {
+		self.list_payments(None).unwrap().payments
+	}
+
+	fn list_first_page_payments_with_filter<F: FnMut(&PaymentDetails) -> bool>(
+		&self, mut f: F,
+	) -> Vec<PaymentDetails> {
+		self.list_first_page_payments().into_iter().filter(|p| f(p)).collect()
+	}
+
+	fn list_all_payments(&self) -> Vec<PaymentDetails> {
+		let mut payments = Vec::new();
+		let mut page_token = None;
+		loop {
+			let page = self.list_payments(page_token).unwrap();
+			payments.extend(page.payments);
+			page_token = page.next_page_token;
+			if page_token.is_none() {
+				return payments;
+			}
+		}
+	}
+
+	fn list_all_payments_with_filter<F: FnMut(&PaymentDetails) -> bool>(
+		&self, mut f: F,
+	) -> Vec<PaymentDetails> {
+		self.list_all_payments().into_iter().filter(|p| f(p)).collect()
+	}
+}
 
 macro_rules! expect_event {
 	($node:expr, $event_type:ident) => {{
@@ -411,7 +455,7 @@ pub(crate) type TestNode = Arc<Node>;
 pub(crate) type TestNode = Node;
 
 fn has_onchain_tx_type<F: Fn(&TransactionType) -> bool>(node: &TestNode, predicate: F) -> bool {
-	node.list_payments().into_iter().any(|payment| {
+	node.list_all_payments().into_iter().any(|payment| {
 		matches!(
 			payment.kind,
 			PaymentKind::Onchain { tx_type: Some(ref tx_type), .. } if predicate(tx_type)
@@ -429,7 +473,7 @@ fn assert_any_node_has_onchain_tx_type<F: Fn(&TransactionType) -> bool + Copy>(
 	let observed: Vec<String> = nodes
 		.iter()
 		.flat_map(|(name, node)| {
-			node.list_payments().into_iter().filter_map(move |payment| match payment.kind {
+			node.list_all_payments().into_iter().filter_map(move |payment| match payment.kind {
 				PaymentKind::Onchain { tx_type, .. } => Some(format!("{}:{:?}", name, tx_type)),
 				_ => None,
 			})
@@ -448,7 +492,7 @@ fn assert_all_nodes_have_onchain_tx_type<F: Fn(&TransactionType) -> bool + Copy>
 	let observed: Vec<String> = nodes
 		.iter()
 		.flat_map(|(name, node)| {
-			node.list_payments().into_iter().filter_map(move |payment| match payment.kind {
+			node.list_all_payments().into_iter().filter_map(move |payment| match payment.kind {
 				PaymentKind::Onchain { tx_type, .. } => Some(format!("{}:{:?}", name, tx_type)),
 				_ => None,
 			})
@@ -1091,28 +1135,28 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	// Check we saw the node funding transactions.
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		1
 	);
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		0
 	);
 	assert_eq!(
 		node_b
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		1
 	);
 	assert_eq!(
 		node_b
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		0
@@ -1165,7 +1209,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	// Check we now see the channel funding transaction as outbound.
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		1
@@ -1243,24 +1287,24 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	let payment_id = node_a.bolt11_payment().send(&invoice, None).unwrap();
 	assert_eq!(node_a.bolt11_payment().send(&invoice, None), Err(NodeError::DuplicatePayment));
 
-	assert!(!node_a.list_payments_with_filter(|p| p.id == payment_id).is_empty());
+	assert!(!node_a.list_first_page_payments_with_filter(|p| p.id == payment_id).is_empty());
 
-	let outbound_payments_a = node_a.list_payments_with_filter(|p| {
+	let outbound_payments_a = node_a.list_first_page_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Outbound && matches!(p.kind, PaymentKind::Bolt11 { .. })
 	});
 	assert_eq!(outbound_payments_a.len(), 1);
 
-	let inbound_payments_a = node_a.list_payments_with_filter(|p| {
+	let inbound_payments_a = node_a.list_first_page_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Inbound && matches!(p.kind, PaymentKind::Bolt11 { .. })
 	});
 	assert_eq!(inbound_payments_a.len(), 0);
 
-	let outbound_payments_b = node_b.list_payments_with_filter(|p| {
+	let outbound_payments_b = node_b.list_first_page_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Outbound && matches!(p.kind, PaymentKind::Bolt11 { .. })
 	});
 	assert_eq!(outbound_payments_b.len(), 0);
 
-	let inbound_payments_b = node_b.list_payments_with_filter(|p| {
+	let inbound_payments_b = node_b.list_first_page_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Inbound && matches!(p.kind, PaymentKind::Bolt11 { .. })
 	});
 	assert_eq!(inbound_payments_b.len(), 1);
@@ -1507,22 +1551,30 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 		PaymentKind::Spontaneous { .. }
 	));
 	assert_eq!(
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt11 { .. })).len(),
+		node_a
+			.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt11 { .. }))
+			.len(),
 		5
 	);
 	assert_eq!(
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt11 { .. })).len(),
+		node_b
+			.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt11 { .. }))
+			.len(),
 		6
 	);
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Spontaneous { .. }))
+			.list_first_page_payments_with_filter(|p| {
+				matches!(p.kind, PaymentKind::Spontaneous { .. })
+			})
 			.len(),
 		1
 	);
 	assert_eq!(
 		node_b
-			.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Spontaneous { .. }))
+			.list_first_page_payments_with_filter(|p| {
+				matches!(p.kind, PaymentKind::Spontaneous { .. })
+			})
 			.len(),
 		1
 	);
@@ -1549,7 +1601,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Inbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		2
@@ -1571,7 +1623,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 
 	assert_eq!(
 		node_a
-			.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
+			.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. }))
 			.len(),
 		2
@@ -1745,13 +1797,13 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 
 	// Now we should have seen the channel closing transaction on-chain.
 	let node_a_inbound_onchain_count = node_a
-		.list_payments_with_filter(|p| {
+		.list_all_payments_with_filter(|p| {
 			p.direction == PaymentDirection::Inbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. })
 		})
 		.len();
 	let node_b_inbound_onchain_count = node_b
-		.list_payments_with_filter(|p| {
+		.list_all_payments_with_filter(|p| {
 			p.direction == PaymentDirection::Inbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. })
 		})

--- a/tests/integration_tests_migration.rs
+++ b/tests/integration_tests_migration.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use common::{
 	drop_table, expect_channel_ready_event, expect_payment_received_event,
-	expect_payment_successful_event, test_connection_string,
+	expect_payment_successful_event, test_connection_string, NodePaymentExt,
 };
 use ldk_node::entropy::NodeEntropy;
 use ldk_node::io::postgres_store::PostgresStore;
@@ -224,7 +224,7 @@ async fn migrate_node_across_all_backends() {
 	// Capture the state we expect to survive every migration.
 	let expected_balance_sats = node.list_balances().total_onchain_balance_sats;
 	let expected_ln_balance_sats = node.list_balances().total_lightning_balance_sats;
-	let mut expected_payments = node.list_payments();
+	let mut expected_payments = node.list_all_payments();
 	expected_payments.sort_by_key(|p| p.id.0);
 	assert!(expected_payments.len() >= 4);
 
@@ -249,7 +249,7 @@ async fn migrate_node_across_all_backends() {
 		assert_eq!(node.list_balances().total_onchain_balance_sats, expected_balance_sats);
 		assert_eq!(node.list_balances().total_lightning_balance_sats, expected_ln_balance_sats);
 		assert_eq!(node.list_channels().len(), 1);
-		let mut migrated_payments = node.list_payments();
+		let mut migrated_payments = node.list_all_payments();
 		migrated_payments.sort_by_key(|p| p.id.0);
 		assert_eq!(migrated_payments, expected_payments);
 

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -28,7 +28,7 @@ use common::{
 	open_channel_with_all, premine_and_distribute_funds, premine_blocks, prepare_rbf,
 	random_chain_source, random_config, setup_bitcoind_and_electrsd, setup_builder, setup_node,
 	setup_two_nodes, splice_in_with_all, wait_for_block, wait_for_tx, InMemoryStore,
-	TestChainSource, TestConfig, TestStoreType, TestSyncStore,
+	NodePaymentExt, TestChainSource, TestConfig, TestStoreType, TestSyncStore,
 };
 use electrsd::corepc_node::{self, Node as BitcoinD};
 use electrsd::ElectrsD;
@@ -58,7 +58,7 @@ use serde_json::json;
 async fn wait_for_classified_funding_payment(node: &Node, funding_txid: Txid) {
 	let poll = async {
 		loop {
-			let classified = node.list_payments().into_iter().any(|p| {
+			let classified = node.list_first_page_payments().into_iter().any(|p| {
 				matches!(
 					p.kind,
 					PaymentKind::Onchain { txid, tx_type: Some(_), .. } if txid == funding_txid
@@ -591,15 +591,15 @@ async fn split_underpaid_bolt11_payment() {
 
 	// The receiver records the full invoice amount; each payer records only its own half.
 	let receiver_payments =
-		node_c.list_payments_with_filter(|p| p.id == receiver_payment_id.unwrap());
+		node_c.list_first_page_payments_with_filter(|p| p.id == receiver_payment_id.unwrap());
 	assert_eq!(receiver_payments.len(), 1);
 	assert_eq!(receiver_payments.first().unwrap().amount_msat, Some(amount_msat));
 
-	let node_a_payments = node_a.list_payments_with_filter(|p| p.id == payment_id_a);
+	let node_a_payments = node_a.list_first_page_payments_with_filter(|p| p.id == payment_id_a);
 	assert_eq!(node_a_payments.len(), 1);
 	assert_eq!(node_a_payments.first().unwrap().amount_msat, Some(half_amount_msat));
 
-	let node_b_payments = node_b.list_payments_with_filter(|p| p.id == payment_id_b);
+	let node_b_payments = node_b.list_first_page_payments_with_filter(|p| p.id == payment_id_b);
 	assert_eq!(node_b_payments.len(), 1);
 	assert_eq!(node_b_payments.first().unwrap().amount_msat, Some(half_amount_msat));
 }
@@ -723,8 +723,8 @@ async fn onchain_send_receive() {
 	assert_eq!(node_a.list_balances().spendable_onchain_balance_sats, premine_amount_sat);
 	assert_eq!(node_b.list_balances().spendable_onchain_balance_sats, premine_amount_sat);
 
-	let node_a_payments = node_a.list_payments();
-	let node_b_payments = node_b.list_payments();
+	let node_a_payments = node_a.list_first_page_payments();
+	let node_b_payments = node_b.list_first_page_payments();
 	for payments in [&node_a_payments, &node_b_payments] {
 		assert_eq!(payments.len(), 1)
 	}
@@ -751,11 +751,11 @@ async fn onchain_send_receive() {
 	expect_channel_ready_event!(node_a, node_b.node_id());
 	expect_channel_ready_event!(node_b, node_a.node_id());
 
-	let node_a_payments =
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_a_payments = node_a
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_a_payments.len(), 1);
-	let node_b_payments =
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_b_payments = node_b
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_b_payments.len(), 2);
 
 	let onchain_fee_buffer_sat = 1000;
@@ -826,11 +826,11 @@ async fn onchain_send_receive() {
 	assert!(node_b.list_balances().spendable_onchain_balance_sats > expected_node_b_balance_lower);
 	assert!(node_b.list_balances().spendable_onchain_balance_sats < expected_node_b_balance_upper);
 
-	let node_a_payments =
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_a_payments = node_a
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_a_payments.len(), 2);
-	let node_b_payments =
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_b_payments = node_b
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_b_payments.len(), 3);
 
 	let payment_a = node_a.payment(&payment_id).unwrap();
@@ -869,11 +869,11 @@ async fn onchain_send_receive() {
 	assert!(node_b.list_balances().spendable_onchain_balance_sats > expected_node_b_balance_lower);
 	assert!(node_b.list_balances().spendable_onchain_balance_sats < expected_node_b_balance_upper);
 
-	let node_a_payments =
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_a_payments = node_a
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_a_payments.len(), 3);
-	let node_b_payments =
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_b_payments = node_b
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_b_payments.len(), 4);
 
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
@@ -893,11 +893,11 @@ async fn onchain_send_receive() {
 	assert!(node_b.list_balances().spendable_onchain_balance_sats > expected_node_b_balance_lower);
 	assert!(node_b.list_balances().spendable_onchain_balance_sats < expected_node_b_balance_upper);
 
-	let node_a_payments =
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_a_payments = node_a
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_a_payments.len(), 4);
-	let node_b_payments =
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
+	let node_b_payments = node_b
+		.list_first_page_payments_with_filter(|p| matches!(p.kind, PaymentKind::Onchain { .. }));
 	assert_eq!(node_b_payments.len(), 5);
 }
 
@@ -1776,7 +1776,7 @@ async fn splice_channel() {
 	// them to the channel balance since there may not be a change output.
 	let expected_splice_in_lightning_balance_sat = 4_000_002;
 
-	let payments = node_b.list_payments();
+	let payments = node_b.list_first_page_payments();
 	let payment =
 		payments.into_iter().find(|p| p.id == PaymentId(txo.txid.to_byte_array())).unwrap();
 	assert_eq!(payment.fee_paid_msat, Some(expected_splice_in_fee_sat * 1_000));
@@ -1829,7 +1829,7 @@ async fn splice_channel() {
 
 	let expected_splice_out_fee_sat = 183;
 
-	let payments = node_a.list_payments();
+	let payments = node_a.list_first_page_payments();
 	let payment =
 		payments.into_iter().find(|p| p.id == PaymentId(txo.txid.to_byte_array())).unwrap();
 	assert_eq!(payment.fee_paid_msat, Some(expected_splice_out_fee_sat * 1_000));
@@ -1998,7 +1998,7 @@ async fn run_rbf_splice_channel_test(confirm_original: bool) {
 		}
 		assert_eq!(payment.status, PaymentStatus::Pending);
 		// Only one Onchain Pending payment for this splice attempt (not one per candidate).
-		let splice_payments = node_b.list_payments_with_filter(|p| {
+		let splice_payments = node_b.list_first_page_payments_with_filter(|p| {
 			p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Onchain { .. })
 				&& p.status == PaymentStatus::Pending
@@ -2324,8 +2324,9 @@ async fn simple_bolt12_send_receive() {
 		},
 		ref e => panic!("{} got unexpected event!: {:?}", "node_a", e),
 	}
-	let node_a_payments =
-		node_a.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt12Offer { .. }));
+	let node_a_payments = node_a.list_first_page_payments_with_filter(|p| {
+		matches!(p.kind, PaymentKind::Bolt12Offer { .. })
+	});
 	assert_eq!(node_a_payments.len(), 1);
 	match node_a_payments.first().unwrap().kind {
 		PaymentKind::Bolt12Offer {
@@ -2351,8 +2352,9 @@ async fn simple_bolt12_send_receive() {
 	assert_eq!(node_a_payments.first().unwrap().amount_msat, Some(expected_amount_msat));
 
 	expect_payment_received_event!(node_b, expected_amount_msat);
-	let node_b_payments =
-		node_b.list_payments_with_filter(|p| matches!(p.kind, PaymentKind::Bolt12Offer { .. }));
+	let node_b_payments = node_b.list_first_page_payments_with_filter(|p| {
+		matches!(p.kind, PaymentKind::Bolt12Offer { .. })
+	});
 	assert_eq!(node_b_payments.len(), 1);
 	match node_b_payments.first().unwrap().kind {
 		PaymentKind::Bolt12Offer { hash, preimage, secret, offer_id, .. } => {
@@ -2390,7 +2392,7 @@ async fn simple_bolt12_send_receive() {
 		.unwrap();
 
 	expect_payment_successful_event!(node_a, Some(payment_id), None);
-	let node_a_payments = node_a.list_payments_with_filter(|p| {
+	let node_a_payments = node_a.list_first_page_payments_with_filter(|p| {
 		matches!(p.kind, PaymentKind::Bolt12Offer { .. }) && p.id == payment_id
 	});
 	assert_eq!(node_a_payments.len(), 1);
@@ -2420,7 +2422,7 @@ async fn simple_bolt12_send_receive() {
 
 	expect_payment_received_event!(node_b, expected_amount_msat);
 	let node_b_payment_id = PaymentId(payment_hash.0);
-	let node_b_payments = node_b.list_payments_with_filter(|p| {
+	let node_b_payments = node_b.list_first_page_payments_with_filter(|p| {
 		matches!(p.kind, PaymentKind::Bolt12Offer { .. }) && p.id == node_b_payment_id
 	});
 	assert_eq!(node_b_payments.len(), 1);
@@ -2455,7 +2457,7 @@ async fn simple_bolt12_send_receive() {
 	expect_payment_received_event!(node_a, overpaid_amount);
 
 	let node_b_payment_id = node_b
-		.list_payments_with_filter(|p| {
+		.list_first_page_payments_with_filter(|p| {
 			matches!(p.kind, PaymentKind::Bolt12Refund { .. })
 				&& p.amount_msat == Some(overpaid_amount)
 		})
@@ -2464,7 +2466,7 @@ async fn simple_bolt12_send_receive() {
 		.id;
 	expect_payment_successful_event!(node_b, Some(node_b_payment_id), None);
 
-	let node_b_payments = node_b.list_payments_with_filter(|p| {
+	let node_b_payments = node_b.list_first_page_payments_with_filter(|p| {
 		matches!(p.kind, PaymentKind::Bolt12Refund { .. }) && p.id == node_b_payment_id
 	});
 	assert_eq!(node_b_payments.len(), 1);
@@ -2490,7 +2492,7 @@ async fn simple_bolt12_send_receive() {
 	assert_eq!(node_b_payments.first().unwrap().amount_msat, Some(overpaid_amount));
 
 	let node_a_payment_id = PaymentId(invoice.payment_hash().0);
-	let node_a_payments = node_a.list_payments_with_filter(|p| {
+	let node_a_payments = node_a.list_first_page_payments_with_filter(|p| {
 		matches!(p.kind, PaymentKind::Bolt12Refund { .. }) && p.id == node_a_payment_id
 	});
 	assert_eq!(node_a_payments.len(), 1);
@@ -3200,8 +3202,11 @@ async fn spontaneous_send_with_custom_preimage() {
 
 	// check payment status and verify stored preimage
 	expect_payment_successful_event!(node_a, Some(payment_id), None);
-	let details: PaymentDetails =
-		node_a.list_payments_with_filter(|p| p.id == payment_id).first().unwrap().clone();
+	let details: PaymentDetails = node_a
+		.list_first_page_payments_with_filter(|p| p.id == payment_id)
+		.first()
+		.unwrap()
+		.clone();
 	assert_eq!(details.status, PaymentStatus::Succeeded);
 	if let PaymentKind::Spontaneous { preimage: Some(pi), .. } = details.kind {
 		assert_eq!(pi.0, custom_bytes);
@@ -3211,7 +3216,7 @@ async fn spontaneous_send_with_custom_preimage() {
 
 	// Verify receiver side (node_b)
 	expect_payment_received_event!(node_b, amount_msat);
-	let receiver_payments: Vec<PaymentDetails> = node_b.list_payments_with_filter(|p| {
+	let receiver_payments: Vec<PaymentDetails> = node_b.list_first_page_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Inbound
 			&& matches!(p.kind, PaymentKind::Spontaneous { .. })
 	});
@@ -3613,7 +3618,7 @@ async fn payment_persistence_after_restart() {
 		println!("All {} payments completed successfully", num_payments);
 
 		// Verify node_a has 200 outbound Bolt11 payments before shutdown
-		let outbound_payments_before = node_a.list_payments_with_filter(|p| {
+		let outbound_payments_before = node_a.list_all_payments_with_filter(|p| {
 			p.direction == PaymentDirection::Outbound
 				&& matches!(p.kind, PaymentKind::Bolt11 { .. })
 		});
@@ -3630,7 +3635,7 @@ async fn payment_persistence_after_restart() {
 	let restarted_node_a = setup_node(&chain_source, config_a);
 
 	// Assert all 200 payments are still in the store
-	let outbound_payments_after = restarted_node_a.list_payments_with_filter(|p| {
+	let outbound_payments_after = restarted_node_a.list_all_payments_with_filter(|p| {
 		p.direction == PaymentDirection::Outbound && matches!(p.kind, PaymentKind::Bolt11 { .. })
 	});
 	assert_eq!(
@@ -3962,7 +3967,7 @@ async fn onchain_fee_bump_rbf() {
 	}
 
 	// Verify node A received the funds correctly
-	let node_a_received_payment = node_a.list_payments_with_filter(|p| {
+	let node_a_received_payment = node_a.list_first_page_payments_with_filter(|p| {
 		p.id == payment_id && matches!(p.kind, PaymentKind::Onchain { .. })
 	});
 

--- a/tests/reorg_test.rs
+++ b/tests/reorg_test.rs
@@ -10,7 +10,7 @@ use proptest::proptest;
 use crate::common::{
 	expect_event, exponential_backoff_poll, generate_blocks_and_wait, invalidate_blocks,
 	open_channel, premine_and_distribute_funds, random_chain_source, random_config,
-	setup_bitcoind_and_electrsd, setup_node, wait_for_outpoint_spend, wait_for_tx,
+	setup_bitcoind_and_electrsd, setup_node, wait_for_outpoint_spend, wait_for_tx, NodePaymentExt,
 };
 
 async fn wait_for_pending_sweep_balance<F>(
@@ -118,10 +118,9 @@ proptest! {
 			let mut node_channels_id = HashMap::new();
 			for (i, node) in nodes.iter().enumerate() {
 				assert_eq!(
-					node
-						.list_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
-							&& matches!(p.kind, PaymentKind::Onchain { .. }))
-						.len(),
+					node.list_first_page_payments_with_filter(|p| p.direction == PaymentDirection::Outbound
+						&& matches!(p.kind, PaymentKind::Onchain { .. }))
+					.len(),
 					1
 				);
 


### PR DESCRIPTION
Add paginated payment listing API

Return payment history in reverse creation order one page at a time.
Keep ordering metadata in memory, support opaque tokens in language
bindings, and deprecate the unpaginated filtering API.

This commit was created with assistance from OpenAI Codex.