### PR TITLE
Remove test-helper warnings

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -66,6 +66,7 @@ use in_memory_store::InMemoryStore;
 /// Shared timeout (in seconds) for waiting on LDK events and external node operations.
 pub(crate) const INTEROP_TIMEOUT_SECS: u64 = 60;
 
+#[macro_export]
 macro_rules! expect_event {
 	($node:expr, $event_type:ident) => {{
 		let event = tokio::time::timeout(
@@ -92,8 +93,7 @@ macro_rules! expect_event {
 	}};
 }
 
-pub(crate) use expect_event;
-
+#[macro_export]
 macro_rules! expect_channel_pending_event {
 	($node:expr, $counterparty_node_id:expr) => {{
 		let event = tokio::time::timeout(
@@ -118,8 +118,7 @@ macro_rules! expect_channel_pending_event {
 	}};
 }
 
-pub(crate) use expect_channel_pending_event;
-
+#[macro_export]
 macro_rules! expect_channel_ready_event {
 	($node:expr, $counterparty_node_id:expr) => {{
 		let event = tokio::time::timeout(
@@ -144,8 +143,7 @@ macro_rules! expect_channel_ready_event {
 	}};
 }
 
-pub(crate) use expect_channel_ready_event;
-
+#[macro_export]
 macro_rules! expect_channel_ready_events {
 	($node:expr, $counterparty_node_id_a:expr, $counterparty_node_id_b:expr) => {{
 		let mut ids = Vec::new();
@@ -180,8 +178,7 @@ macro_rules! expect_channel_ready_events {
 	}};
 }
 
-pub(crate) use expect_channel_ready_events;
-
+#[macro_export]
 macro_rules! expect_splice_negotiated_event {
 	($node:expr, $counterparty_node_id:expr) => {{
 		let event = tokio::time::timeout(
@@ -206,8 +203,7 @@ macro_rules! expect_splice_negotiated_event {
 	}};
 }
 
-pub(crate) use expect_splice_negotiated_event;
-
+#[macro_export]
 macro_rules! expect_payment_received_event {
 	($node:expr, $amount_msat:expr) => {{
 		let event = tokio::time::timeout(
@@ -236,8 +232,7 @@ macro_rules! expect_payment_received_event {
 	}};
 }
 
-pub(crate) use expect_payment_received_event;
-
+#[macro_export]
 macro_rules! expect_payment_claimable_event {
 	($node:expr, $payment_id:expr, $payment_hash:expr, $claimable_amount_msat:expr) => {{
 		let event = tokio::time::timeout(
@@ -272,8 +267,7 @@ macro_rules! expect_payment_claimable_event {
 	}};
 }
 
-pub(crate) use expect_payment_claimable_event;
-
+#[macro_export]
 macro_rules! expect_payment_successful_event {
 	($node:expr, $payment_id:expr, $fee_paid_msat:expr) => {{
 		let event = tokio::time::timeout(
@@ -301,8 +295,6 @@ macro_rules! expect_payment_successful_event {
 		}
 	}};
 }
-
-pub(crate) use expect_payment_successful_event;
 
 pub(crate) fn setup_bitcoind_and_electrsd() -> (BitcoinD, ElectrsD) {
 	let bitcoind_exe =
@@ -465,6 +457,7 @@ impl Default for TestConfig {
 	}
 }
 
+#[macro_export]
 macro_rules! setup_builder {
 	($builder:ident, $config:expr) => {
 		#[cfg(feature = "uniffi")]
@@ -473,8 +466,6 @@ macro_rules! setup_builder {
 		let mut $builder = Builder::from_config($config.clone());
 	};
 }
-
-pub(crate) use setup_builder;
 
 #[cfg(any(cln_test, lnd_test, eclair_test))]
 pub(crate) mod scenarios;

--- a/tests/integration_tests_hrn.rs
+++ b/tests/integration_tests_hrn.rs
@@ -11,9 +11,8 @@ mod common;
 
 use bitcoin::Amount;
 use common::{
-	expect_channel_ready_event, expect_payment_successful_event, generate_blocks_and_wait,
-	open_channel, premine_and_distribute_funds, random_chain_source, setup_bitcoind_and_electrsd,
-	setup_two_nodes, TestChainSource,
+	generate_blocks_and_wait, open_channel, premine_and_distribute_funds, random_chain_source,
+	setup_bitcoind_and_electrsd, setup_two_nodes, TestChainSource,
 };
 use ldk_node::payment::UnifiedPaymentResult;
 use ldk_node::Event;

--- a/tests/integration_tests_migration.rs
+++ b/tests/integration_tests_migration.rs
@@ -13,10 +13,7 @@ mod common;
 
 use std::path::PathBuf;
 
-use common::{
-	drop_table, expect_channel_ready_event, expect_payment_received_event,
-	expect_payment_successful_event, test_connection_string,
-};
+use common::{drop_table, test_connection_string};
 use ldk_node::entropy::NodeEntropy;
 use ldk_node::io::postgres_store::PostgresStore;
 use ldk_node::io::sqlite_store::{SqliteStore, KV_TABLE_NAME, SQLITE_DB_FILE_NAME};

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -18,12 +18,9 @@ use bitcoin::{Address, Amount, ScriptBuf, Txid};
 use common::logging::{init_log_logger, validate_log_entry, MultiNodeLogger, TestLogWriter};
 use common::{
 	bump_fee_and_broadcast, distribute_funds_unconfirmed, do_channel_full_cycle,
-	expect_channel_pending_event, expect_channel_ready_event, expect_channel_ready_events,
-	expect_event, expect_payment_claimable_event, expect_payment_received_event,
-	expect_payment_successful_event, expect_splice_negotiated_event, generate_blocks_and_wait,
-	generate_listening_addresses, invalidate_blocks, open_channel, open_channel_push_amt,
-	open_channel_with_all, premine_and_distribute_funds, premine_blocks, prepare_rbf,
-	random_chain_source, random_config, setup_bitcoind_and_electrsd, setup_builder, setup_node,
+	generate_blocks_and_wait, generate_listening_addresses, invalidate_blocks, open_channel,
+	open_channel_push_amt, open_channel_with_all, premine_and_distribute_funds, premine_blocks,
+	prepare_rbf, random_chain_source, random_config, setup_bitcoind_and_electrsd, setup_node,
 	setup_two_nodes, splice_in_with_all, wait_for_block, wait_for_tx, TestChainSource, TestConfig,
 	TestStoreType, TestSyncStore,
 };

--- a/tests/reorg_test.rs
+++ b/tests/reorg_test.rs
@@ -8,9 +8,9 @@ use proptest::prelude::prop;
 use proptest::proptest;
 
 use crate::common::{
-	expect_event, generate_blocks_and_wait, invalidate_blocks, open_channel,
-	premine_and_distribute_funds, random_chain_source, random_config, setup_bitcoind_and_electrsd,
-	setup_node, wait_for_outpoint_spend,
+	generate_blocks_and_wait, invalidate_blocks, open_channel, premine_and_distribute_funds,
+	random_chain_source, random_config, setup_bitcoind_and_electrsd, setup_node,
+	wait_for_outpoint_spend,
 };
 
 proptest! {


### PR DESCRIPTION
fixes the annoying unused warnings in tests

The shared integration-test helpers are macros used by different test binaries in different combinations. Export them as macros instead of reexporting private macro definitions from common, so targets that use only a subset no longer emit unused helper warnings.