### PR TITLE
Avoid wallet persistence deadlocks

### DIFF
--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -461,11 +461,12 @@ impl BitcoindChainSource {
 					evicted_txids.len(),
 					elapsed_ms,
 				);
-				onchain_wallet.apply_mempool_txs(unconfirmed_txs, evicted_txids).unwrap_or_else(
-					|e| {
+				onchain_wallet
+					.apply_mempool_txs(unconfirmed_txs, evicted_txids)
+					.await
+					.unwrap_or_else(|e| {
 						log_error!(self.logger, "Failed to apply mempool transactions: {:?}", e);
-					},
-				);
+					});
 			},
 			Err(e) => {
 				log_error!(self.logger, "Failed to poll for mempool transactions: {:?}", e);

--- a/src/chain/electrum.rs
+++ b/src/chain/electrum.rs
@@ -182,7 +182,7 @@ impl ElectrumChainSource {
 		update_res: Result<BdkUpdate, Error>, now: Instant,
 	) -> Result<(), Error> {
 		match update_res {
-			Ok(update) => match onchain_wallet.apply_update(update) {
+			Ok(update) => match onchain_wallet.apply_update(update).await {
 				Ok(()) => {
 					log_debug!(
 						self.logger,

--- a/src/chain/esplora.rs
+++ b/src/chain/esplora.rs
@@ -146,7 +146,7 @@ impl EsploraChainSource {
 				let now = Instant::now();
 				match $sync_future.await {
 					Ok(res) => match res {
-						Ok(update) => match onchain_wallet.apply_update(update) {
+						Ok(update) => match onchain_wallet.apply_update(update).await {
 							Ok(()) => {
 								log_debug!(
 									self.logger,

--- a/src/event.rs
+++ b/src/event.rs
@@ -694,12 +694,16 @@ where
 
 				// Sign the final funding transaction and broadcast it.
 				let channel_amount = Amount::from_sat(channel_value_satoshis);
-				match self.wallet.create_funding_transaction(
-					output_script,
-					channel_amount,
-					confirmation_target,
-					locktime,
-				) {
+				let funding_transaction = self
+					.wallet
+					.create_funding_transaction(
+						output_script,
+						channel_amount,
+						confirmation_target,
+						locktime,
+					)
+					.await;
+				match funding_transaction {
 					Ok(final_tx) => {
 						let needs_manual_broadcast = self
 							.liquidity_source
@@ -1743,7 +1747,7 @@ where
 							})
 							.collect(),
 					};
-					if let Err(e) = self.wallet.cancel_tx(tx) {
+					if let Err(e) = self.wallet.cancel_tx(tx).await {
 						log_error!(self.logger, "Failed reclaiming unused addresses: {}", e);
 						return Err(ReplayEvent());
 					}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1106,6 +1106,7 @@ impl Node {
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
+			Arc::clone(&self.runtime),
 			Arc::clone(&self.logger),
 		)
 	}
@@ -1118,6 +1119,7 @@ impl Node {
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.config),
 			Arc::clone(&self.is_running),
+			Arc::clone(&self.runtime),
 			Arc::clone(&self.logger),
 		))
 	}

--- a/src/liquidity/client/lsps1.rs
+++ b/src/liquidity/client/lsps1.rs
@@ -488,7 +488,7 @@ impl LSPS1Liquidity {
 
 		log_info!(self.logger, "Connected to LSP {}@{}. ", lsps1_node.node_id, lsps1_node.address);
 
-		let refund_address = self.wallet.get_new_address()?;
+		let refund_address = self.runtime.block_on(self.wallet.get_new_address())?;
 
 		let liquidity_source = Arc::clone(&self.liquidity_source);
 		let response = self.runtime.block_on(async move {

--- a/src/payment/onchain.rs
+++ b/src/payment/onchain.rs
@@ -15,6 +15,7 @@ use lightning::ln::channelmanager::PaymentId;
 use crate::config::Config;
 use crate::error::Error;
 use crate::logger::{log_info, LdkLogger, Logger};
+use crate::runtime::Runtime;
 use crate::types::{ChannelManager, Wallet};
 use crate::wallet::OnchainSendAmount;
 
@@ -47,15 +48,30 @@ pub struct OnchainPayment {
 	channel_manager: Arc<ChannelManager>,
 	config: Arc<Config>,
 	is_running: Arc<RwLock<bool>>,
+	runtime: Arc<Runtime>,
 	logger: Arc<Logger>,
 }
 
 impl OnchainPayment {
 	pub(crate) fn new(
 		wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>, config: Arc<Config>,
-		is_running: Arc<RwLock<bool>>, logger: Arc<Logger>,
+		is_running: Arc<RwLock<bool>>, runtime: Arc<Runtime>, logger: Arc<Logger>,
 	) -> Self {
-		Self { wallet, channel_manager, config, is_running, logger }
+		Self { wallet, channel_manager, config, is_running, runtime, logger }
+	}
+
+	pub(crate) async fn send_to_address_inner(
+		&self, address: &bitcoin::Address, amount_sats: u64, fee_rate: Option<bitcoin::FeeRate>,
+	) -> Result<Txid, Error> {
+		if !*self.is_running.read().expect("lock") {
+			return Err(Error::NotRunning);
+		}
+
+		let cur_anchor_reserve_sats =
+			crate::total_anchor_channels_reserve_sats(&self.channel_manager, &self.config);
+		let send_amount =
+			OnchainSendAmount::ExactRetainingReserve { amount_sats, cur_anchor_reserve_sats };
+		self.wallet.send_to_address(address, send_amount, fee_rate).await
 	}
 }
 
@@ -63,7 +79,7 @@ impl OnchainPayment {
 impl OnchainPayment {
 	/// Retrieve a new on-chain/funding address.
 	pub fn new_address(&self) -> Result<Address, Error> {
-		let funding_address = self.wallet.get_new_address()?;
+		let funding_address = self.runtime.block_on(self.wallet.get_new_address())?;
 		log_info!(self.logger, "Generated new funding address: {}", funding_address);
 		Ok(funding_address)
 	}
@@ -80,16 +96,8 @@ impl OnchainPayment {
 	pub fn send_to_address(
 		&self, address: &bitcoin::Address, amount_sats: u64, fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
-		if !*self.is_running.read().expect("lock") {
-			return Err(Error::NotRunning);
-		}
-
-		let cur_anchor_reserve_sats =
-			crate::total_anchor_channels_reserve_sats(&self.channel_manager, &self.config);
-		let send_amount =
-			OnchainSendAmount::ExactRetainingReserve { amount_sats, cur_anchor_reserve_sats };
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+		self.runtime.block_on(self.send_to_address_inner(address, amount_sats, fee_rate_opt))
 	}
 
 	/// Send an on-chain payment to the given address, draining the available funds.
@@ -123,7 +131,7 @@ impl OnchainPayment {
 		};
 
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.send_to_address(address, send_amount, fee_rate_opt)
+		self.runtime.block_on(self.wallet.send_to_address(address, send_amount, fee_rate_opt))
 	}
 
 	/// Attempt to bump the fee of an unconfirmed transaction using Replace-by-Fee (RBF).
@@ -146,6 +154,10 @@ impl OnchainPayment {
 		let cur_anchor_reserve_sats =
 			crate::total_anchor_channels_reserve_sats(&self.channel_manager, &self.config);
 		let fee_rate_opt = maybe_map_fee_rate_opt!(fee_rate);
-		self.wallet.bump_fee_rbf(payment_id, fee_rate_opt, cur_anchor_reserve_sats)
+		self.runtime.block_on(self.wallet.bump_fee_rbf(
+			payment_id,
+			fee_rate_opt,
+			cur_anchor_reserve_sats,
+		))
 	}
 }

--- a/src/payment/unified.rs
+++ b/src/payment/unified.rs
@@ -328,7 +328,10 @@ impl UnifiedPayment {
 						Error::InvalidAmount
 					})?;
 
-					let txid = self.onchain_payment.send_to_address(&address, amt_sats, None)?;
+					let txid = self
+						.onchain_payment
+						.send_to_address_inner(&address, amt_sats, None)
+						.await?;
 					return Ok(UnifiedPaymentResult::Onchain { txid });
 				},
 			}

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -331,7 +331,9 @@ impl Wallet {
 							unconfirmed_outbound_txids
 								.iter()
 								.filter_map(|txid| {
-									locked_wallet.tx_details(*txid).map(|d| (*d.tx).clone())
+									locked_wallet
+										.get_tx(*txid)
+										.map(|tx| tx.tx_node.tx.as_ref().clone())
 								})
 								.collect()
 						};

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -84,7 +84,7 @@ const DUST_LIMIT_SATS: u64 = 546;
 pub(crate) struct Wallet {
 	// A BDK on-chain wallet.
 	inner: Mutex<PersistedWallet<KVStoreWalletPersister>>,
-	persister: Mutex<KVStoreWalletPersister>,
+	persister: tokio::sync::Mutex<KVStoreWalletPersister>,
 	broadcaster: Arc<Broadcaster>,
 	fee_estimator: Arc<OnchainFeeEstimator>,
 	chain_source: Arc<ChainSource>,
@@ -104,7 +104,7 @@ impl Wallet {
 		logger: Arc<Logger>, pending_payment_store: Arc<PendingPaymentStore>,
 	) -> Self {
 		let inner = Mutex::new(wallet);
-		let persister = Mutex::new(wallet_persister);
+		let persister = tokio::sync::Mutex::new(wallet_persister);
 		Self {
 			inner,
 			persister,
@@ -154,56 +154,57 @@ impl Wallet {
 		BlockLocator { block_hash: checkpoint.hash(), height: checkpoint.height(), previous_blocks }
 	}
 
-	pub(crate) fn apply_update(&self, update: impl Into<Update>) -> Result<(), Error> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		match locked_wallet.apply_update_events(update) {
-			Ok(events) => {
-				self.update_payment_store(&mut *locked_wallet, events).map_err(|e| {
-					log_error!(self.logger, "Failed to update payment store: {}", e);
-					Error::PersistenceFailed
-				})?;
+	pub(crate) async fn apply_update(&self, update: impl Into<Update>) -> Result<(), Error> {
+		let mut locked_persister = self.persister.lock().await;
+		let events = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			match locked_wallet.apply_update_events(update) {
+				Ok(events) => events,
+				Err(e) => {
+					log_error!(self.logger, "Sync failed due to chain connection error: {}", e);
+					return Err(Error::WalletOperationFailed);
+				},
+			}
+		};
+		self.update_payment_store(events).await.map_err(|e| {
+			log_error!(self.logger, "Failed to update payment store: {}", e);
+			Error::PersistenceFailed
+		})?;
 
-				let mut locked_persister = self.persister.lock().expect("lock");
-				self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(
-					|e| {
-						log_error!(self.logger, "Failed to persist wallet: {}", e);
-						Error::PersistenceFailed
-					},
-				)?;
-
-				Ok(())
-			},
-			Err(e) => {
-				log_error!(self.logger, "Sync failed due to chain connection error: {}", e);
-				Err(Error::WalletOperationFailed)
-			},
-		}
+		let change_set = self.inner.lock().expect("lock").take_staged().unwrap_or_default();
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
+			log_error!(self.logger, "Failed to persist wallet: {}", e);
+			Error::PersistenceFailed
+		})?;
+		Ok(())
 	}
 
-	pub(crate) fn apply_mempool_txs(
+	pub(crate) async fn apply_mempool_txs(
 		&self, unconfirmed_txs: Vec<(Transaction, u64)>, evicted_txids: Vec<(Txid, u64)>,
 	) -> Result<(), Error> {
 		if unconfirmed_txs.is_empty() && evicted_txids.is_empty() {
 			return Ok(());
 		}
 
-		let mut locked_wallet = self.inner.lock().expect("lock");
+		let mut locked_persister = self.persister.lock().await;
+		let events = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			locked_wallet
+				.events_helper(|wallet| -> Result<(), std::convert::Infallible> {
+					wallet.apply_unconfirmed_txs(unconfirmed_txs);
+					wallet.apply_evicted_txs(evicted_txids);
+					Ok(())
+				})
+				.expect("applying mempool updates cannot fail")
+		};
 
-		let events = locked_wallet
-			.events_helper(|wallet| -> Result<(), std::convert::Infallible> {
-				wallet.apply_unconfirmed_txs(unconfirmed_txs);
-				wallet.apply_evicted_txs(evicted_txids);
-				Ok(())
-			})
-			.expect("applying mempool updates cannot fail");
-
-		self.update_payment_store(&mut *locked_wallet, events).map_err(|e| {
+		self.update_payment_store(events).await.map_err(|e| {
 			log_error!(self.logger, "Failed to update payment store: {}", e);
 			Error::PersistenceFailed
 		})?;
 
-		let mut locked_persister = self.persister.lock().expect("lock");
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+		let change_set = self.inner.lock().expect("lock").take_staged().unwrap_or_default();
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
 			Error::PersistenceFailed
 		})?;
@@ -211,10 +212,7 @@ impl Wallet {
 		Ok(())
 	}
 
-	fn update_payment_store<'a>(
-		&self, locked_wallet: &'a mut PersistedWallet<KVStoreWalletPersister>,
-		mut events: Vec<WalletEvent>,
-	) -> Result<(), Error> {
+	async fn update_payment_store(&self, mut events: Vec<WalletEvent>) -> Result<(), Error> {
 		if events.is_empty() {
 			return Ok(());
 		}
@@ -242,7 +240,7 @@ impl Wallet {
 		for event in events {
 			match event {
 				WalletEvent::TxConfirmed { txid, tx, block_time, .. } => {
-					let cur_height = locked_wallet.latest_checkpoint().height();
+					let cur_height = self.inner.lock().expect("lock").latest_checkpoint().height();
 					let confirmation_height = block_time.block_id.height;
 					let payment_status = if cur_height >= confirmation_height + ANTI_REORG_DELAY - 1
 					{
@@ -261,28 +259,32 @@ impl Wallet {
 						.find_payment_by_txid(txid)
 						.unwrap_or_else(|| PaymentId(txid.to_byte_array()));
 
-					if self.apply_funding_status_update(payment_id, txid, confirmation_status)? {
+					if self
+						.apply_funding_status_update(payment_id, txid, confirmation_status)
+						.await?
+					{
 						continue;
 					}
 
-					let payment = self.create_payment_from_tx(
-						locked_wallet,
-						txid,
-						payment_id,
-						&tx,
-						payment_status,
-						confirmation_status,
-					);
+					let payment = {
+						let locked_wallet = self.inner.lock().expect("lock");
+						self.create_payment_from_tx(
+							&locked_wallet,
+							txid,
+							payment_id,
+							&tx,
+							payment_status,
+							confirmation_status,
+						)
+					};
 
-					self.runtime.block_on(self.payment_store.insert_or_update(payment.clone()))?;
+					self.payment_store.insert_or_update(payment.clone()).await?;
 
 					if payment_status == PaymentStatus::Pending {
 						let pending_payment =
 							self.create_pending_payment_from_tx(payment, Vec::new());
 
-						self.runtime.block_on(
-							self.pending_payment_store.insert_or_update(pending_payment),
-						)?;
+						self.pending_payment_store.insert_or_update(pending_payment).await?;
 					}
 				},
 				WalletEvent::ChainTipChanged { new_tip, .. } => {
@@ -308,11 +310,8 @@ impl Wallet {
 								let payment_id = payment.details.id;
 								if new_tip.height >= height + ANTI_REORG_DELAY - 1 {
 									payment.details.status = PaymentStatus::Succeeded;
-									self.runtime.block_on(
-										self.payment_store.insert_or_update(payment.details),
-									)?;
-									self.runtime
-										.block_on(self.pending_payment_store.remove(&payment_id))?;
+									self.payment_store.insert_or_update(payment.details).await?;
+									self.pending_payment_store.remove(&payment_id).await?;
 								}
 							},
 							PaymentKind::Onchain {
@@ -326,20 +325,28 @@ impl Wallet {
 						}
 					}
 
-					let count: usize = unconfirmed_outbound_txids
-						.into_iter()
-						.filter_map(|txid| {
-							let tx = locked_wallet.tx_details(txid).map(|d| (*d.tx).clone())?;
-							self.broadcaster.broadcast_unclassified_transaction(tx);
-							Some(())
-						})
-						.count();
-					if count != 0 {
-						log_info!(
-							self.logger,
-							"Rebroadcast {} unconfirmed transactions on chain tip change",
-							count,
-						);
+					if !unconfirmed_outbound_txids.is_empty() {
+						let txs_to_broadcast: Vec<Transaction> = {
+							let locked_wallet = self.inner.lock().expect("lock");
+							unconfirmed_outbound_txids
+								.iter()
+								.filter_map(|txid| {
+									locked_wallet.tx_details(*txid).map(|d| (*d.tx).clone())
+								})
+								.collect()
+						};
+
+						if !txs_to_broadcast.is_empty() {
+							let tx_count = txs_to_broadcast.len();
+							for tx in txs_to_broadcast {
+								self.broadcaster.broadcast_unclassified_transaction(tx);
+							}
+							log_info!(
+								self.logger,
+								"Rebroadcast {} unconfirmed transactions on chain tip change",
+								tx_count
+							);
+						}
 					}
 				},
 				WalletEvent::TxUnconfirmed { txid, tx, .. } => {
@@ -347,27 +354,32 @@ impl Wallet {
 						.find_payment_by_txid(txid)
 						.unwrap_or_else(|| PaymentId(txid.to_byte_array()));
 
-					if self.apply_funding_status_update(
-						payment_id,
-						txid,
-						ConfirmationStatus::Unconfirmed,
-					)? {
+					if self
+						.apply_funding_status_update(
+							payment_id,
+							txid,
+							ConfirmationStatus::Unconfirmed,
+						)
+						.await?
+					{
 						continue;
 					}
 
-					let payment = self.create_payment_from_tx(
-						locked_wallet,
-						txid,
-						payment_id,
-						&tx,
-						PaymentStatus::Pending,
-						ConfirmationStatus::Unconfirmed,
-					);
+					let payment = {
+						let locked_wallet = self.inner.lock().expect("lock");
+						self.create_payment_from_tx(
+							&locked_wallet,
+							txid,
+							payment_id,
+							&tx,
+							PaymentStatus::Pending,
+							ConfirmationStatus::Unconfirmed,
+						)
+					};
 					let pending_payment =
 						self.create_pending_payment_from_tx(payment.clone(), Vec::new());
-					self.runtime.block_on(self.payment_store.insert_or_update(payment))?;
-					self.runtime
-						.block_on(self.pending_payment_store.insert_or_update(pending_payment))?;
+					self.payment_store.insert_or_update(payment).await?;
+					self.pending_payment_store.insert_or_update(pending_payment).await?;
 				},
 				WalletEvent::TxReplaced { txid, conflicts, .. } => {
 					let Some(payment_id) = self.find_payment_by_txid(txid) else {
@@ -397,36 +409,39 @@ impl Wallet {
 					let pending_payment_details =
 						self.create_pending_payment_from_tx(payment, conflict_txids.clone());
 
-					self.runtime.block_on(
-						self.pending_payment_store.insert_or_update(pending_payment_details),
-					)?;
+					self.pending_payment_store.insert_or_update(pending_payment_details).await?;
 				},
 				WalletEvent::TxDropped { txid, tx } => {
 					let payment_id = self
 						.find_payment_by_txid(txid)
 						.unwrap_or_else(|| PaymentId(txid.to_byte_array()));
 
-					if self.apply_funding_status_update(
-						payment_id,
-						txid,
-						ConfirmationStatus::Unconfirmed,
-					)? {
+					if self
+						.apply_funding_status_update(
+							payment_id,
+							txid,
+							ConfirmationStatus::Unconfirmed,
+						)
+						.await?
+					{
 						continue;
 					}
 
-					let payment = self.create_payment_from_tx(
-						locked_wallet,
-						txid,
-						payment_id,
-						&tx,
-						PaymentStatus::Pending,
-						ConfirmationStatus::Unconfirmed,
-					);
+					let payment = {
+						let locked_wallet = self.inner.lock().expect("lock");
+						self.create_payment_from_tx(
+							&locked_wallet,
+							txid,
+							payment_id,
+							&tx,
+							PaymentStatus::Pending,
+							ConfirmationStatus::Unconfirmed,
+						)
+					};
 					let pending_payment =
 						self.create_pending_payment_from_tx(payment.clone(), Vec::new());
-					self.runtime.block_on(self.payment_store.insert_or_update(payment))?;
-					self.runtime
-						.block_on(self.pending_payment_store.insert_or_update(pending_payment))?;
+					self.payment_store.insert_or_update(payment).await?;
+					self.pending_payment_store.insert_or_update(pending_payment).await?;
 				},
 				_ => {
 					continue;
@@ -438,42 +453,43 @@ impl Wallet {
 	}
 
 	#[allow(deprecated)]
-	pub(crate) fn create_funding_transaction(
+	pub(crate) async fn create_funding_transaction(
 		&self, output_script: ScriptBuf, amount: Amount, confirmation_target: ConfirmationTarget,
 		locktime: LockTime,
 	) -> Result<Transaction, Error> {
 		let fee_rate = self.fee_estimator.estimate_fee_rate(confirmation_target);
+		let mut locked_persister = self.persister.lock().await;
+		let (psbt, change_set) = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			let mut tx_builder = locked_wallet.build_tx();
+			tx_builder.add_recipient(output_script, amount).fee_rate(fee_rate).nlocktime(locktime);
 
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut tx_builder = locked_wallet.build_tx();
+			let mut psbt = match tx_builder.finish() {
+				Ok(psbt) => {
+					log_trace!(self.logger, "Created funding PSBT: {:?}", psbt);
+					psbt
+				},
+				Err(err) => {
+					log_error!(self.logger, "Failed to create funding transaction: {}", err);
+					return Err(err.into());
+				},
+			};
 
-		tx_builder.add_recipient(output_script, amount).fee_rate(fee_rate).nlocktime(locktime);
+			match locked_wallet.sign(&mut psbt, SignOptions::default()) {
+				Ok(finalized) => {
+					if !finalized {
+						return Err(Error::OnchainTxCreationFailed);
+					}
+				},
+				Err(err) => {
+					log_error!(self.logger, "Failed to create funding transaction: {}", err);
+					return Err(err.into());
+				},
+			}
 
-		let mut psbt = match tx_builder.finish() {
-			Ok(psbt) => {
-				log_trace!(self.logger, "Created funding PSBT: {:?}", psbt);
-				psbt
-			},
-			Err(err) => {
-				log_error!(self.logger, "Failed to create funding transaction: {}", err);
-				return Err(err.into());
-			},
+			(psbt, locked_wallet.take_staged().unwrap_or_default())
 		};
-
-		match locked_wallet.sign(&mut psbt, SignOptions::default()) {
-			Ok(finalized) => {
-				if !finalized {
-					return Err(Error::OnchainTxCreationFailed);
-				}
-			},
-			Err(err) => {
-				log_error!(self.logger, "Failed to create funding transaction: {}", err);
-				return Err(err.into());
-			},
-		}
-
-		let mut locked_persister = self.persister.lock().expect("lock");
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
 			Error::PersistenceFailed
 		})?;
@@ -486,36 +502,42 @@ impl Wallet {
 		Ok(tx)
 	}
 
-	pub(crate) fn get_new_address(&self) -> Result<bitcoin::Address, Error> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut locked_persister = self.persister.lock().expect("lock");
-
-		let address_info = locked_wallet.reveal_next_address(KeychainKind::External);
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+	pub(crate) async fn get_new_address(&self) -> Result<bitcoin::Address, Error> {
+		let mut locked_persister = self.persister.lock().await;
+		let (address_info, change_set) = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			let address_info = locked_wallet.reveal_next_address(KeychainKind::External);
+			(address_info, locked_wallet.take_staged().unwrap_or_default())
+		};
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
 			Error::PersistenceFailed
 		})?;
 		Ok(address_info.address)
 	}
 
-	pub(crate) fn get_new_internal_address(&self) -> Result<bitcoin::Address, Error> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut locked_persister = self.persister.lock().expect("lock");
-
-		let address_info = locked_wallet.next_unused_address(KeychainKind::Internal);
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+	pub(crate) async fn get_new_internal_address(&self) -> Result<bitcoin::Address, Error> {
+		let mut locked_persister = self.persister.lock().await;
+		let (address_info, change_set) = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			let address_info = locked_wallet.next_unused_address(KeychainKind::Internal);
+			(address_info, locked_wallet.take_staged().unwrap_or_default())
+		};
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
 			Error::PersistenceFailed
 		})?;
 		Ok(address_info.address)
 	}
 
-	pub(crate) fn cancel_tx(&self, tx: Transaction) -> Result<(), Error> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut locked_persister = self.persister.lock().expect("lock");
-
-		Self::cancel_tx_inner(&mut locked_wallet, tx);
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+	pub(crate) async fn cancel_tx(&self, tx: Transaction) -> Result<(), Error> {
+		let mut locked_persister = self.persister.lock().await;
+		let change_set = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			Self::cancel_tx_inner(&mut locked_wallet, tx);
+			locked_wallet.take_staged().unwrap_or_default()
+		};
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
 			Error::PersistenceFailed
 		})?;
@@ -729,7 +751,7 @@ impl Wallet {
 	}
 
 	#[allow(deprecated)]
-	pub(crate) fn send_to_address(
+	pub(crate) async fn send_to_address(
 		&self, address: &bitcoin::Address, send_amount: OnchainSendAmount,
 		fee_rate: Option<FeeRate>,
 	) -> Result<Txid, Error> {
@@ -740,7 +762,8 @@ impl Wallet {
 		let fee_rate =
 			fee_rate.unwrap_or_else(|| self.fee_estimator.estimate_fee_rate(confirmation_target));
 
-		let tx = {
+		let mut locked_persister = self.persister.lock().await;
+		let (psbt, change_set) = {
 			let mut locked_wallet = self.inner.lock().expect("lock");
 
 			// Prepare the tx_builder. We properly check the reserve requirements (again) further down.
@@ -863,19 +886,17 @@ impl Wallet {
 				},
 			}
 
-			let mut locked_persister = self.persister.lock().expect("lock");
-			self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(
-				|e| {
-					log_error!(self.logger, "Failed to persist wallet: {}", e);
-					Error::PersistenceFailed
-				},
-			)?;
-
-			psbt.extract_tx().map_err(|e| {
-				log_error!(self.logger, "Failed to extract transaction: {}", e);
-				e
-			})?
+			(psbt, locked_wallet.take_staged().unwrap_or_default())
 		};
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
+			log_error!(self.logger, "Failed to persist wallet: {}", e);
+			Error::PersistenceFailed
+		})?;
+
+		let tx = psbt.extract_tx().map_err(|e| {
+			log_error!(self.logger, "Failed to extract transaction: {}", e);
+			e
+		})?;
 
 		let txid = tx.compute_txid();
 		self.broadcaster.broadcast_unclassified_transaction(tx);
@@ -912,83 +933,91 @@ impl Wallet {
 		Ok(txid)
 	}
 
-	pub(crate) fn select_confirmed_utxos(
+	pub(crate) async fn select_confirmed_utxos(
 		&self, must_spend: Vec<Input>, must_pay_to: &[TxOut], fee_rate: FeeRate,
 	) -> Result<CoinSelection, ()> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut locked_persister = self.persister.lock().expect("lock");
+		let mut locked_persister = self.persister.lock().await;
+		let (coin_selection, change_set) = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
 
-		debug_assert!(matches!(
-			locked_wallet.public_descriptor(KeychainKind::External),
-			ExtendedDescriptor::Wpkh(_)
-		));
-		debug_assert!(matches!(
-			locked_wallet.public_descriptor(KeychainKind::Internal),
-			ExtendedDescriptor::Wpkh(_)
-		));
+			debug_assert!(matches!(
+				locked_wallet.public_descriptor(KeychainKind::External),
+				ExtendedDescriptor::Wpkh(_)
+			));
+			debug_assert!(matches!(
+				locked_wallet.public_descriptor(KeychainKind::Internal),
+				ExtendedDescriptor::Wpkh(_)
+			));
 
-		let mut tx_builder = locked_wallet.build_tx();
-		tx_builder.only_witness_utxo();
+			let mut tx_builder = locked_wallet.build_tx();
+			tx_builder.only_witness_utxo();
 
-		for input in &must_spend {
-			let psbt_input = psbt::Input {
-				witness_utxo: Some(input.previous_utxo.clone()),
-				..Default::default()
+			for input in &must_spend {
+				let psbt_input = psbt::Input {
+					witness_utxo: Some(input.previous_utxo.clone()),
+					..Default::default()
+				};
+				let weight = ldk_to_bdk_satisfaction_weight(input.satisfaction_weight);
+				tx_builder.add_foreign_utxo(input.outpoint, psbt_input, weight).map_err(|_| ())?;
+			}
+
+			for output in must_pay_to {
+				tx_builder.add_recipient(output.script_pubkey.clone(), output.value);
+			}
+
+			tx_builder.fee_rate(fee_rate);
+			tx_builder.exclude_unconfirmed();
+
+			let unsigned_tx = tx_builder
+				.finish()
+				.map_err(|e| {
+					log_error!(self.logger, "Failed to select confirmed UTXOs: {}", e);
+				})?
+				.unsigned_tx;
+
+			let confirmed_utxos = unsigned_tx
+				.input
+				.iter()
+				.filter(|txin| {
+					must_spend.iter().all(|input| input.outpoint != txin.previous_output)
+				})
+				.filter_map(|txin| {
+					locked_wallet
+						.tx_details(txin.previous_output.txid)
+						.map(|tx_details| tx_details.tx.deref().clone())
+						.map(|prevtx| ConfirmedUtxo::new_p2wpkh(prevtx, txin.previous_output.vout))
+				})
+				.collect::<Result<Vec<_>, ()>>()?;
+
+			if unsigned_tx.output.len() > must_pay_to.len() + 1 {
+				log_error!(
+					self.logger,
+					"Unexpected number of change outputs during coin selection: {}",
+					unsigned_tx.output.len() - must_pay_to.len(),
+				);
+				return Err(());
+			}
+
+			let change_output = unsigned_tx
+				.output
+				.into_iter()
+				.find(|txout| must_pay_to.iter().all(|output| output != txout));
+			let change_set = if change_output.is_some() {
+				Some(locked_wallet.take_staged().unwrap_or_default())
+			} else {
+				None
 			};
-			let weight = ldk_to_bdk_satisfaction_weight(input.satisfaction_weight);
-			tx_builder.add_foreign_utxo(input.outpoint, psbt_input, weight).map_err(|_| ())?;
+
+			(CoinSelection { confirmed_utxos, change_output }, change_set)
+		};
+
+		if let Some(change_set) = change_set {
+			locked_persister.persist_changeset(change_set).await.map_err(|e| {
+				log_error!(self.logger, "Failed to persist wallet: {}", e);
+			})?;
 		}
 
-		for output in must_pay_to {
-			tx_builder.add_recipient(output.script_pubkey.clone(), output.value);
-		}
-
-		tx_builder.fee_rate(fee_rate);
-		tx_builder.exclude_unconfirmed();
-
-		let unsigned_tx = tx_builder
-			.finish()
-			.map_err(|e| {
-				log_error!(self.logger, "Failed to select confirmed UTXOs: {}", e);
-			})?
-			.unsigned_tx;
-
-		let confirmed_utxos = unsigned_tx
-			.input
-			.iter()
-			.filter(|txin| must_spend.iter().all(|input| input.outpoint != txin.previous_output))
-			.filter_map(|txin| {
-				locked_wallet
-					.tx_details(txin.previous_output.txid)
-					.map(|tx_details| tx_details.tx.deref().clone())
-					.map(|prevtx| ConfirmedUtxo::new_p2wpkh(prevtx, txin.previous_output.vout))
-			})
-			.collect::<Result<Vec<_>, ()>>()?;
-
-		if unsigned_tx.output.len() > must_pay_to.len() + 1 {
-			log_error!(
-				self.logger,
-				"Unexpected number of change outputs during coin selection: {}",
-				unsigned_tx.output.len() - must_pay_to.len(),
-			);
-			return Err(());
-		}
-
-		let change_output = unsigned_tx
-			.output
-			.into_iter()
-			.find(|txout| must_pay_to.iter().all(|output| output != txout));
-
-		if change_output.is_some() {
-			self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(
-				|e| {
-					log_error!(self.logger, "Failed to persist wallet: {}", e);
-					()
-				},
-			)?;
-		}
-
-		Ok(CoinSelection { confirmed_utxos, change_output })
+		Ok(coin_selection)
 	}
 
 	fn list_confirmed_utxos_inner(&self) -> Result<Vec<Utxo>, ()> {
@@ -1085,14 +1114,15 @@ impl Wallet {
 	}
 
 	#[allow(deprecated)]
-	fn get_change_script_inner(&self) -> Result<ScriptBuf, ()> {
-		let mut locked_wallet = self.inner.lock().expect("lock");
-		let mut locked_persister = self.persister.lock().expect("lock");
-
-		let address_info = locked_wallet.next_unused_address(KeychainKind::Internal);
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
+	async fn get_change_script_inner(&self) -> Result<ScriptBuf, ()> {
+		let mut locked_persister = self.persister.lock().await;
+		let (address_info, change_set) = {
+			let mut locked_wallet = self.inner.lock().expect("lock");
+			let address_info = locked_wallet.next_unused_address(KeychainKind::Internal);
+			(address_info, locked_wallet.take_staged().unwrap_or_default())
+		};
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
 			log_error!(self.logger, "Failed to persist wallet: {}", e);
-			()
 		})?;
 		Ok(address_info.address.script_pubkey())
 	}
@@ -1466,7 +1496,7 @@ impl Wallet {
 	/// `sent`/`received` don't capture our contribution to a shared funding output. Returns `true`
 	/// when it handled the payment, so the caller skips the default on-chain path. Graduation to
 	/// `Succeeded` is left to `ChainTipChanged` after `ANTI_REORG_DELAY`.
-	fn apply_funding_status_update(
+	async fn apply_funding_status_update(
 		&self, payment_id: PaymentId, event_txid: Txid, confirmation_status: ConfirmationStatus,
 	) -> Result<bool, Error> {
 		let Some(mut payment) = self.payment_store.get(&payment_id) else {
@@ -1496,20 +1526,20 @@ impl Wallet {
 
 		payment.kind =
 			PaymentKind::Onchain { txid: event_txid, status: confirmation_status, tx_type };
-		self.runtime.block_on(self.payment_store.insert_or_update(payment.clone()))?;
+		self.payment_store.insert_or_update(payment.clone()).await?;
 		// Mirror the refreshed confirmation status onto the pending entry: `ChainTipChanged`
 		// graduates by reading the pending entry's details, so it must see the new status. This is
 		// the same dual-write the default `TxConfirmed` path performs; an empty conflicting-txids
 		// list leaves any stored conflicts intact (the update treats absent as "unchanged").
 		if payment.status == PaymentStatus::Pending {
 			let pending = self.create_pending_payment_from_tx(payment, Vec::new());
-			self.runtime.block_on(self.pending_payment_store.insert_or_update(pending))?;
+			self.pending_payment_store.insert_or_update(pending).await?;
 		}
 		Ok(true)
 	}
 
 	#[allow(deprecated)]
-	pub(crate) fn bump_fee_rbf(
+	pub(crate) async fn bump_fee_rbf(
 		&self, payment_id: PaymentId, fee_rate: Option<FeeRate>, cur_anchor_reserve_sats: u64,
 	) -> Result<Txid, Error> {
 		let payment = self.payment_store.get(&payment_id).ok_or_else(|| {
@@ -1570,6 +1600,7 @@ impl Wallet {
 			},
 		};
 
+		let mut locked_persister = self.persister.lock().await;
 		let mut locked_wallet = self.inner.lock().expect("lock");
 
 		debug_assert!(
@@ -1729,12 +1760,6 @@ impl Wallet {
 			},
 		}
 
-		let mut locked_persister = self.persister.lock().expect("lock");
-		self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)).map_err(|e| {
-			log_error!(self.logger, "Failed to persist wallet after fee bump of {}: {}", txid, e);
-			Error::PersistenceFailed
-		})?;
-
 		let fee_bumped_tx = psbt.extract_tx().map_err(|e| {
 			log_error!(self.logger, "Failed to extract fee bump transaction for {}: {}", txid, e);
 			e
@@ -1753,10 +1778,15 @@ impl Wallet {
 
 		let pending_payment_store =
 			self.create_pending_payment_from_tx(new_payment.clone(), Vec::new());
+		let change_set = locked_wallet.take_staged().unwrap_or_default();
+		drop(locked_wallet);
+		locked_persister.persist_changeset(change_set).await.map_err(|e| {
+			log_error!(self.logger, "Failed to persist wallet after fee bump of {}: {}", txid, e);
+			Error::PersistenceFailed
+		})?;
 
-		self.runtime.block_on(self.payment_store.insert_or_update(new_payment))?;
-		self.runtime
-			.block_on(self.pending_payment_store.insert_or_update(pending_payment_store))?;
+		self.payment_store.insert_or_update(new_payment).await?;
+		self.pending_payment_store.insert_or_update(pending_payment_store).await?;
 
 		self.broadcaster.broadcast_unclassified_transaction(fee_bumped_tx);
 
@@ -1820,64 +1850,66 @@ impl Listen for Wallet {
 	}
 
 	fn block_connected(&self, block: &bitcoin::Block, height: u32) {
-		let mut locked_wallet = self.inner.lock().expect("lock");
+		self.runtime.block_on(async {
+			let mut locked_persister = self.persister.lock().await;
+			let events = {
+				let mut locked_wallet = self.inner.lock().expect("lock");
 
-		let pre_checkpoint = locked_wallet.latest_checkpoint();
-		if pre_checkpoint.height() != height - 1
-			|| pre_checkpoint.hash() != block.header.prev_blockhash
-		{
-			log_debug!(
-				self.logger,
-				"Detected reorg while applying a connected block to on-chain wallet: new block with hash {} at height {}",
-				block.header.block_hash(),
-				height
-			);
-		}
-
-		// In order to be able to reliably calculate fees the `Wallet` needs access to the previous
-		// ouput data. To this end, we here insert any ouputs of transactions that LDK is intersted
-		// in (e.g., funding transaction ouputs) into the wallet's transaction graph when we see
-		// them, so it is reliably able to calculate fees for subsequent spends.
-		//
-		// FIXME: technically, we should also do this for mempool transactions. However, at the
-		// current time fixing the edge case doesn't seem worth the additional conplexity /
-		// additional overhead..
-		let registered_txids = self.chain_source.registered_txids();
-		for tx in &block.txdata {
-			let txid = tx.compute_txid();
-			if registered_txids.contains(&txid) {
-				for (vout, txout) in tx.output.iter().enumerate() {
-					let outpoint = OutPoint { txid, vout: vout as u32 };
-					locked_wallet.insert_txout(outpoint, txout.clone());
+				let pre_checkpoint = locked_wallet.latest_checkpoint();
+				if pre_checkpoint.height() != height - 1
+					|| pre_checkpoint.hash() != block.header.prev_blockhash
+				{
+					log_debug!(
+						self.logger,
+						"Detected reorg while applying a connected block to on-chain wallet: new block with hash {} at height {}",
+						block.header.block_hash(),
+						height
+					);
 				}
-			}
-		}
 
-		match locked_wallet.apply_block_events(block, height) {
-			Ok(events) => {
-				if let Err(e) = self.update_payment_store(&mut *locked_wallet, events) {
-					log_error!(self.logger, "Failed to update payment store: {}", e);
-					return;
+				// In order to be able to reliably calculate fees the `Wallet` needs access to the previous
+				// ouput data. To this end, we here insert any ouputs of transactions that LDK is intersted
+				// in (e.g., funding transaction ouputs) into the wallet's transaction graph when we see
+				// them, so it is reliably able to calculate fees for subsequent spends.
+				//
+				// FIXME: technically, we should also do this for mempool transactions. However, at the
+				// current time fixing the edge case doesn't seem worth the additional conplexity /
+				// additional overhead..
+				let registered_txids = self.chain_source.registered_txids();
+				for tx in &block.txdata {
+					let txid = tx.compute_txid();
+					if registered_txids.contains(&txid) {
+						for (vout, txout) in tx.output.iter().enumerate() {
+							let outpoint = OutPoint { txid, vout: vout as u32 };
+							locked_wallet.insert_txout(outpoint, txout.clone());
+						}
+					}
 				}
-			},
-			Err(e) => {
-				log_error!(
-					self.logger,
-					"Failed to apply connected block to on-chain wallet: {}",
-					e
-				);
+
+				match locked_wallet.apply_block_events(block, height) {
+					Ok(events) => events,
+					Err(e) => {
+						log_error!(
+							self.logger,
+							"Failed to apply connected block to on-chain wallet: {}",
+							e
+						);
+						return;
+					},
+				}
+			};
+
+			if let Err(e) = self.update_payment_store(events).await {
+				log_error!(self.logger, "Failed to update payment store: {}", e);
 				return;
-			},
-		};
+			}
 
-		let mut locked_persister = self.persister.lock().expect("lock");
-		match self.runtime.block_on(locked_wallet.persist_async(&mut locked_persister)) {
-			Ok(_) => (),
-			Err(e) => {
+			let change_set = self.inner.lock().expect("lock").take_staged().unwrap_or_default();
+			if let Err(e) = locked_persister.persist_changeset(change_set).await {
 				log_error!(self.logger, "Failed to persist on-chain wallet: {}", e);
 				return;
-			},
-		};
+			}
+		});
 	}
 
 	fn blocks_disconnected(&self, _fork_point_block: BlockLocator) {
@@ -1895,7 +1927,7 @@ impl WalletSource for Wallet {
 	}
 
 	fn get_change_script<'a>(&'a self) -> impl Future<Output = Result<ScriptBuf, ()>> + Send + 'a {
-		async move { self.get_change_script_inner() }
+		async move { self.get_change_script_inner().await }
 	}
 
 	fn get_prevtx<'a>(
@@ -1932,7 +1964,7 @@ impl CoinSelectionSource for Wallet {
 	) -> impl Future<Output = Result<CoinSelection, ()>> + Send + 'a {
 		debug_assert!(claim_id.is_none());
 		let fee_rate = FeeRate::from_sat_per_kwu(target_feerate_sat_per_1000_weight as u64);
-		async move { self.select_confirmed_utxos(must_spend, must_pay_to, fee_rate) }
+		async move { self.select_confirmed_utxos(must_spend, must_pay_to, fee_rate).await }
 	}
 
 	fn sign_psbt<'a>(
@@ -2056,14 +2088,14 @@ impl SignerProvider for WalletKeysManager {
 	}
 
 	fn get_destination_script(&self, _channel_keys_id: [u8; 32]) -> Result<ScriptBuf, ()> {
-		let address = self.wallet.get_new_address().map_err(|e| {
+		let address = self.wallet.runtime.block_on(self.wallet.get_new_address()).map_err(|e| {
 			log_error!(self.logger, "Failed to retrieve new address from wallet: {}", e);
 		})?;
 		Ok(address.script_pubkey())
 	}
 
 	fn get_shutdown_scriptpubkey(&self) -> Result<ShutdownScript, ()> {
-		let address = self.wallet.get_new_address().map_err(|e| {
+		let address = self.wallet.runtime.block_on(self.wallet.get_new_address()).map_err(|e| {
 			log_error!(self.logger, "Failed to retrieve new address from wallet: {}", e);
 		})?;
 
@@ -2089,6 +2121,7 @@ impl ChangeDestinationSource for WalletKeysManager {
 		async move {
 			self.wallet
 				.get_new_internal_address()
+				.await
 				.map_err(|e| {
 					log_error!(self.logger, "Failed to retrieve new address from wallet: {}", e);
 				})

--- a/src/wallet/persist.rs
+++ b/src/wallet/persist.rs
@@ -22,13 +22,14 @@ use crate::types::DynStore;
 
 pub(crate) struct KVStoreWalletPersister {
 	latest_change_set: Option<ChangeSet>,
+	pending_change_set: ChangeSet,
 	kv_store: Arc<DynStore>,
 	logger: Arc<Logger>,
 }
 
 impl KVStoreWalletPersister {
 	pub(crate) fn new(kv_store: Arc<DynStore>, logger: Arc<Logger>) -> Self {
-		Self { latest_change_set: None, kv_store, logger }
+		Self { latest_change_set: None, pending_change_set: ChangeSet::default(), kv_store, logger }
 	}
 
 	async fn initialize_inner(&mut self) -> Result<ChangeSet, std::io::Error> {
@@ -52,17 +53,19 @@ impl KVStoreWalletPersister {
 		Ok(change_set)
 	}
 
-	async fn persist_inner(&mut self, change_set: &ChangeSet) -> Result<(), std::io::Error> {
+	async fn persist_inner(
+		latest_change_set_opt: &mut Option<ChangeSet>, kv_store: &Arc<DynStore>,
+		logger: &Arc<Logger>, change_set: &ChangeSet,
+	) -> Result<(), std::io::Error> {
 		if change_set.is_empty() {
 			return Ok(());
 		}
 
-		let kv_store = Arc::clone(&self.kv_store);
-		let logger = Arc::clone(&self.logger);
+		let kv_store = kv_store.as_ref();
 
 		// We're allowed to fail here if we're not initialized, BDK docs state: "This method can fail if the
 		// persister is not initialized."
-		let latest_change_set = self.latest_change_set.as_mut().ok_or_else(|| {
+		let latest_change_set = latest_change_set_opt.as_mut().ok_or_else(|| {
 			std::io::Error::new(
 				std::io::ErrorKind::Other,
 				"Wallet must be initialized before calling persist",
@@ -169,6 +172,21 @@ impl KVStoreWalletPersister {
 
 		Ok(())
 	}
+
+	pub(super) async fn persist_changeset(
+		&mut self, change_set: ChangeSet,
+	) -> Result<(), std::io::Error> {
+		self.pending_change_set.merge(change_set);
+		Self::persist_inner(
+			&mut self.latest_change_set,
+			&self.kv_store,
+			&self.logger,
+			&self.pending_change_set,
+		)
+		.await?;
+		let _ = std::mem::take(&mut self.pending_change_set);
+		Ok(())
+	}
 }
 
 impl AsyncWalletPersister for KVStoreWalletPersister {
@@ -189,6 +207,138 @@ impl AsyncWalletPersister for KVStoreWalletPersister {
 	where
 		Self: 'a,
 	{
-		Box::pin(persister.persist_inner(change_set))
+		Box::pin(Self::persist_inner(
+			&mut persister.latest_change_set,
+			&persister.kv_store,
+			&persister.logger,
+			change_set,
+		))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::future::Future;
+	use std::sync::Arc;
+	use std::time::Duration;
+
+	use bdk_wallet::{AsyncWalletPersister, ChangeSet, Wallet as BdkWallet};
+	use bitcoin::Network;
+	use lightning::io;
+	use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
+
+	use super::KVStoreWalletPersister;
+	use crate::io::test_utils::InMemoryStore;
+	use crate::logger::Logger;
+	use crate::types::{DynStore, DynStoreWrapper};
+
+	const EXTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
+	const INTERNAL_DESCRIPTOR: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
+
+	#[derive(Clone)]
+	struct GatedStore {
+		inner: Arc<InMemoryStore>,
+		write_gate: Arc<tokio::sync::RwLock<()>>,
+	}
+
+	impl KVStore for GatedStore {
+		fn read(
+			&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+		) -> impl Future<Output = Result<Vec<u8>, io::Error>> + 'static + Send {
+			KVStore::read(&*self.inner, primary_namespace, secondary_namespace, key)
+		}
+
+		fn write(
+			&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+		) -> impl Future<Output = Result<(), io::Error>> + 'static + Send {
+			let inner = Arc::clone(&self.inner);
+			let write_gate = Arc::clone(&self.write_gate);
+			let primary_namespace = primary_namespace.to_string();
+			let secondary_namespace = secondary_namespace.to_string();
+			let key = key.to_string();
+			async move {
+				let _guard = write_gate.read().await;
+				KVStore::write(&*inner, &primary_namespace, &secondary_namespace, &key, buf).await
+			}
+		}
+
+		fn remove(
+			&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool,
+		) -> impl Future<Output = Result<(), io::Error>> + 'static + Send {
+			KVStore::remove(&*self.inner, primary_namespace, secondary_namespace, key, lazy)
+		}
+
+		fn list(
+			&self, primary_namespace: &str, secondary_namespace: &str,
+		) -> impl Future<Output = Result<Vec<String>, io::Error>> + 'static + Send {
+			KVStore::list(&*self.inner, primary_namespace, secondary_namespace)
+		}
+	}
+
+	impl PaginatedKVStore for GatedStore {
+		fn list_paginated(
+			&self, primary_namespace: &str, secondary_namespace: &str,
+			page_token: Option<PageToken>,
+		) -> impl Future<Output = Result<PaginatedListResponse, io::Error>> + 'static + Send {
+			PaginatedKVStore::list_paginated(
+				&*self.inner,
+				primary_namespace,
+				secondary_namespace,
+				page_token,
+			)
+		}
+	}
+
+	#[tokio::test]
+	async fn retains_pending_changes_when_persist_is_cancelled() {
+		let gated_store = GatedStore {
+			inner: Arc::new(InMemoryStore::new()),
+			write_gate: Arc::new(tokio::sync::RwLock::new(())),
+		};
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(gated_store.clone()));
+		let logger = Arc::new(Logger::new_log_facade());
+		let mut persister = KVStoreWalletPersister::new(Arc::clone(&store), Arc::clone(&logger));
+		AsyncWalletPersister::initialize(&mut persister).await.unwrap();
+
+		let mut wallet = BdkWallet::create(EXTERNAL_DESCRIPTOR, INTERNAL_DESCRIPTOR)
+			.network(Network::Regtest)
+			.create_wallet_no_persist()
+			.unwrap();
+		let change_set = wallet.take_staged().unwrap();
+
+		let gate_guard = gated_store.write_gate.write().await;
+		{
+			let persist_fut = persister.persist_changeset(change_set);
+			tokio::pin!(persist_fut);
+			let poll_res = tokio::time::timeout(Duration::from_millis(100), &mut persist_fut).await;
+			assert!(poll_res.is_err(), "persist should be parked on the gated store write");
+		}
+		drop(gate_guard);
+
+		persister.persist_changeset(ChangeSet::default()).await.unwrap();
+
+		let mut reloaded_persister = KVStoreWalletPersister::new(store, logger);
+		let reloaded = AsyncWalletPersister::initialize(&mut reloaded_persister).await.unwrap();
+		assert_eq!(reloaded.network, Some(Network::Regtest));
+	}
+
+	#[tokio::test]
+	async fn retries_changes_after_persistence_failure() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(Logger::new_log_facade());
+		let mut persister = KVStoreWalletPersister::new(Arc::clone(&store), Arc::clone(&logger));
+		let mut wallet = BdkWallet::create(EXTERNAL_DESCRIPTOR, INTERNAL_DESCRIPTOR)
+			.network(Network::Regtest)
+			.create_wallet_no_persist()
+			.unwrap();
+		let change_set = wallet.take_staged().unwrap();
+
+		assert!(persister.persist_changeset(change_set).await.is_err());
+		AsyncWalletPersister::initialize(&mut persister).await.unwrap();
+		persister.persist_changeset(ChangeSet::default()).await.unwrap();
+
+		let mut reloaded_persister = KVStoreWalletPersister::new(store, logger);
+		let reloaded = AsyncWalletPersister::initialize(&mut reloaded_persister).await.unwrap();
+		assert_eq!(reloaded.network, Some(Network::Regtest));
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -63,7 +63,7 @@ use serde_json::{json, Value};
 
 #[path = "../../src/io/in_memory_store.rs"]
 mod in_memory_store;
-use in_memory_store::InMemoryStore;
+pub(crate) use in_memory_store::InMemoryStore;
 
 /// Shared timeout (in seconds) for waiting on LDK events and external node operations.
 pub(crate) const INTEROP_TIMEOUT_SECS: u64 = 60;

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -8,8 +8,11 @@
 mod common;
 
 use std::collections::HashSet;
+use std::future::Future;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
@@ -24,8 +27,8 @@ use common::{
 	generate_listening_addresses, invalidate_blocks, open_channel, open_channel_push_amt,
 	open_channel_with_all, premine_and_distribute_funds, premine_blocks, prepare_rbf,
 	random_chain_source, random_config, setup_bitcoind_and_electrsd, setup_builder, setup_node,
-	setup_two_nodes, splice_in_with_all, wait_for_block, wait_for_tx, TestChainSource, TestConfig,
-	TestStoreType, TestSyncStore,
+	setup_two_nodes, splice_in_with_all, wait_for_block, wait_for_tx, InMemoryStore,
+	TestChainSource, TestConfig, TestStoreType, TestSyncStore,
 };
 use electrsd::corepc_node::{self, Node as BitcoinD};
 use electrsd::ElectrsD;
@@ -40,6 +43,7 @@ use ldk_node::{BuildError, Builder, Event, Node, NodeError, ReserveType};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::routing::gossip::{NodeAlias, NodeId};
 use lightning::routing::router::RouteParametersConfig;
+use lightning::util::persist::{KVStore, PageToken, PaginatedKVStore, PaginatedListResponse};
 use lightning_invoice::{Bolt11InvoiceDescription, Description};
 use lightning_types::payment::{PaymentHash, PaymentPreimage};
 use log::LevelFilter;
@@ -71,6 +75,145 @@ async fn wait_for_classified_funding_payment(node: &Node, funding_txid: Txid) {
 		.unwrap_or_else(|_| {
 			panic!("timed out waiting for funding broadcast {} to be classified", funding_txid)
 		});
+}
+
+#[derive(Clone)]
+struct ContendedStore {
+	inner: Arc<InMemoryStore>,
+	serializer: Arc<tokio::sync::RwLock<()>>,
+	block_writes: Arc<AtomicBool>,
+	wallet_write_started: Arc<tokio::sync::Notify>,
+}
+
+impl KVStore for ContendedStore {
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> impl Future<Output = Result<Vec<u8>, lightning::io::Error>> + 'static + Send {
+		KVStore::read(&*self.inner, primary_namespace, secondary_namespace, key)
+	}
+
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> impl Future<Output = Result<(), lightning::io::Error>> + 'static + Send {
+		let inner = Arc::clone(&self.inner);
+		let serializer = Arc::clone(&self.serializer);
+		let block_writes = Arc::clone(&self.block_writes);
+		let wallet_write_started = Arc::clone(&self.wallet_write_started);
+		let primary_namespace = primary_namespace.to_string();
+		let secondary_namespace = secondary_namespace.to_string();
+		let key = key.to_string();
+		async move {
+			if block_writes.load(Ordering::Acquire) {
+				wallet_write_started.notify_one();
+			}
+			let _guard = serializer.read().await;
+			KVStore::write(&*inner, &primary_namespace, &secondary_namespace, &key, buf).await
+		}
+	}
+
+	fn remove(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool,
+	) -> impl Future<Output = Result<(), lightning::io::Error>> + 'static + Send {
+		KVStore::remove(&*self.inner, primary_namespace, secondary_namespace, key, lazy)
+	}
+
+	fn list(
+		&self, primary_namespace: &str, secondary_namespace: &str,
+	) -> impl Future<Output = Result<Vec<String>, lightning::io::Error>> + 'static + Send {
+		KVStore::list(&*self.inner, primary_namespace, secondary_namespace)
+	}
+}
+
+impl PaginatedKVStore for ContendedStore {
+	fn list_paginated(
+		&self, primary_namespace: &str, secondary_namespace: &str, page_token: Option<PageToken>,
+	) -> impl Future<Output = Result<PaginatedListResponse, lightning::io::Error>> + 'static + Send
+	{
+		PaginatedKVStore::list_paginated(
+			&*self.inner,
+			primary_namespace,
+			secondary_namespace,
+			page_token,
+		)
+	}
+}
+
+#[test]
+fn wallet_store_contention_does_not_stall_runtime() {
+	let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+	let (result_sender, result_receiver) = mpsc::sync_channel(1);
+	std::thread::spawn(move || {
+		let runtime = tokio::runtime::Builder::new_multi_thread()
+			.worker_threads(1)
+			.enable_all()
+			.build()
+			.expect("test runtime");
+		let result = runtime.block_on(async move {
+			let test_config = random_config();
+			let builder = Builder::from_config(test_config.node_config.clone());
+			let store = ContendedStore {
+				inner: Arc::new(InMemoryStore::new()),
+				serializer: Arc::new(tokio::sync::RwLock::new(())),
+				block_writes: Arc::new(AtomicBool::new(false)),
+				wallet_write_started: Arc::new(tokio::sync::Notify::new()),
+			};
+			let node = builder
+				.build_with_store(test_config.node_entropy.into(), store.clone())
+				.map_err(|e| format!("failed to build node: {e:?}"))?;
+			#[cfg(not(feature = "uniffi"))]
+			let node = Arc::new(node);
+
+			let serializer = Arc::clone(&store.serializer);
+			let release_store = Arc::new(tokio::sync::Notify::new());
+			let release_store_task = Arc::clone(&release_store);
+			let (store_locked_sender, store_locked_receiver) = tokio::sync::oneshot::channel();
+			tokio::spawn(async move {
+				let _guard = serializer.write().await;
+				let _ = store_locked_sender.send(());
+				release_store_task.notified().await;
+			});
+			store_locked_receiver.await.map_err(|e| format!("store lock task failed: {e}"))?;
+			store.block_writes.store(true, Ordering::Release);
+			let _ = ready_sender.send(());
+
+			let address_node = Arc::clone(&node);
+			let (address_sender, address_receiver) = tokio::sync::oneshot::channel();
+			std::thread::spawn(move || {
+				let result = address_node.onchain_payment().new_address().map(|_| ());
+				let _ = address_sender.send(result);
+			});
+			store.wallet_write_started.notified().await;
+
+			let balances_node = Arc::clone(&node);
+			let (balances_started_sender, balances_started_receiver) =
+				tokio::sync::oneshot::channel();
+			let balances_task = tokio::spawn(async move {
+				let _ = balances_started_sender.send(());
+				balances_node.list_balances()
+			});
+			balances_started_receiver
+				.await
+				.map_err(|e| format!("balance task failed to start: {e}"))?;
+			std::thread::spawn(move || {
+				std::thread::sleep(Duration::from_millis(100));
+				release_store.notify_one();
+			});
+			balances_task.await.map_err(|e| format!("balance task failed: {e}"))?;
+			address_receiver
+				.await
+				.map_err(|e| format!("address task failed: {e}"))?
+				.map_err(|e| format!("address generation failed: {e}"))
+		});
+		let _ = result_sender.send(result);
+	});
+
+	ready_receiver
+		.recv_timeout(Duration::from_secs(30))
+		.expect("failed to set up wallet contention test");
+	let result = result_receiver
+		.recv_timeout(Duration::from_secs(3))
+		.expect("wallet contention stalled the single-thread runtime");
+	result.unwrap_or_else(|e| panic!("wallet contention test failed: {e}"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Fixes #978.

Release the synchronous wallet lock before awaiting store I/O while serializing wallet mutations with an asynchronous persistence gate. Retain failed change sets so retries preserve BDK persistence semantics.
