### PR TITLE
Fix task-slot collision when pathfinding scores sync is enabled

### DIFF
--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -26,7 +26,7 @@ pub fn setup_background_pathfinding_scores_sync(
 
 	let logger = Arc::clone(&logger);
 
-	runtime.spawn_background_processor_task(async move {
+	runtime.spawn_cancellable_background_task(async move {
 		let mut interval = tokio::time::interval(EXTERNAL_PATHFINDING_SCORES_SYNC_INTERVAL);
 		loop {
 			tokio::select! {

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -676,6 +676,26 @@ async fn start_stop_reinit() {
 	reinitialized_node.stop().unwrap();
 }
 
+// The scores-sync task runs alongside LDK's background processor, which claims the runtime's
+// single background-processor slot; startup must not panic with both configured.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn start_stop_with_pathfinding_scores_sync() {
+	let (_bitcoind, electrsd) = setup_bitcoind_and_electrsd();
+	let config = random_config();
+
+	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
+
+	let mut sync_config = EsploraSyncConfig::default();
+	sync_config.background_sync_config = None;
+	setup_builder!(builder, config.node_config);
+	builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
+	builder.set_pathfinding_scores_source(esplora_url);
+
+	let node = builder.build(config.node_entropy.into()).unwrap();
+	node.start().unwrap();
+	node.stop().unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn onchain_send_receive() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();


### PR DESCRIPTION
The pathfinding scores sync task claimed the runtime's single background-processor slot, which LDK's background processor also claims later during startup. With a scores sync URL configured, node startup tripped a `debug_assert` in debug builds; in release builds the second spawn silently dropped the scores-sync task's join handle, so the task was detached and never joined at shutdown.

Spawn it as a regular background task instead: it already exits on the general stop signal, so it is now joined gracefully alongside the other background tasks in `Node::stop`.

Developed with assistance from Claude Code.