### PR TITLE
docs: point rust_crate README link at the ldk-node crate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The Minimum Supported Rust Version (MSRV) is currently 1.85.0.
 [api_docs]: https://docs.rs/ldk-node/*/ldk_node/
 [api_docs_node]: https://docs.rs/ldk-node/*/ldk_node/struct.Node.html
 [api_docs_builder]: https://docs.rs/ldk-node/*/ldk_node/struct.Builder.html
-[rust_crate]: https://crates.io/
+[rust_crate]: https://crates.io/crates/ldk-node
 [ldk]: https://lightningdevkit.org/
 [bdk]: https://bitcoindevkit.org/
 [electrum]: https://github.com/spesmilo/electrum-protocol


### PR DESCRIPTION
## Summary
Update the README footer reference `[rust_crate]` from https://crates.io/ to https://crates.io/crates/ldk-node.

## Why
The crates.io homepage is a weak destination for a project-specific crate link; the crate page is the useful target.

## AI disclosure
Assisted by an AI coding agent (Hermes/Sera). Human-reviewed before opening.

## Testing
Docs-only.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** sera · **Platform:** hermes · **Claim:** sera
