### PR TITLE
Bump CI Bitcoin Core to 31.1

### DIFF
--- a/.github/workflows/0fc-integration.yml
+++ b/.github/workflows/0fc-integration.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-31.1-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-31.1-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4

--- a/.github/workflows/hrn-integration.yml
+++ b/.github/workflows/hrn-integration.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-31.1-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-27_2-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-31.1-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
-          key: bitcoind-29.0-${{ runner.os }}-${{ runner.arch }}
+          key: bitcoind-31.1-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         id: cache-electrs
         uses: actions/cache@v4

--- a/scripts/download_bitcoind_electrs.sh
+++ b/scripts/download_bitcoind_electrs.sh
@@ -10,17 +10,17 @@ HOST_PLATFORM="$(rustc --version --verbose | grep "host:" | awk '{ print $2 }')"
 ELECTRS_DL_ENDPOINT="https://github.com/RCasatta/electrsd/releases/download/electrs_releases"
 ELECTRS_VERSION="esplora_a33e97e1a1fc63fa9c20a116bb92579bbf43b254"
 BITCOIND_DL_ENDPOINT="https://bitcoincore.org/bin/"
-BITCOIND_VERSION="29.0"
+BITCOIND_VERSION="31.1"
 if [[ "$HOST_PLATFORM" == *linux* ]]; then
 	ELECTRS_DL_FILE_NAME=electrs_linux_"$ELECTRS_VERSION".zip
 	ELECTRS_DL_HASH="865e26a96e8df77df01d96f2f569dcf9622fc87a8d99a9b8fe30861a4db9ddf1"
 	BITCOIND_DL_FILE_NAME=bitcoin-"$BITCOIND_VERSION"-x86_64-linux-gnu.tar.gz
-	BITCOIND_DL_HASH="a681e4f6ce524c338a105f214613605bac6c33d58c31dc5135bbc02bc458bb6c"
+	BITCOIND_DL_HASH="b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e"
 elif [[ "$HOST_PLATFORM" == *darwin* ]]; then
 	ELECTRS_DL_FILE_NAME=electrs_macos_"$ELECTRS_VERSION".zip
 	ELECTRS_DL_HASH="2d5ff149e8a2482d3658e9b386830dfc40c8fbd7c175ca7cbac58240a9505bcd"
 	BITCOIND_DL_FILE_NAME=bitcoin-"$BITCOIND_VERSION"-x86_64-apple-darwin.tar.gz
-	BITCOIND_DL_HASH="5bb824fc86a15318d6a83a1b821ff4cd4b3d3d0e1ec3d162b805ccf7cae6fca8"
+	BITCOIND_DL_HASH="bc506958d0f387c1ea770bdc7c7192a505fa645ff62cabcc7761fa7eb89e867e"
 else
 	printf "\n\n"
 	echo "Unsupported platform: $HOST_PLATFORM Exiting.."

--- a/tests/docker/docker-compose-cln.yml
+++ b/tests/docker/docker-compose-cln.yml
@@ -1,6 +1,6 @@
 services:
   bitcoin:
-    image: blockstream/bitcoind:29.1
+    image: blockstream/bitcoind:31.1
     platform: linux/amd64
     command:
       [

--- a/tests/docker/docker-compose-eclair.yml
+++ b/tests/docker/docker-compose-eclair.yml
@@ -5,7 +5,7 @@ services:
   # causing Eclair to fall behind the chain tip. Host networking avoids
   # this by keeping all inter-process communication on localhost.
   bitcoin:
-    image: blockstream/bitcoind:30.2
+    image: blockstream/bitcoind:31.1
     platform: linux/amd64
     network_mode: host
     command:

--- a/tests/docker/docker-compose-lnd.yml
+++ b/tests/docker/docker-compose-lnd.yml
@@ -1,6 +1,6 @@
 services:
   bitcoin:
-    image: blockstream/bitcoind:29.1
+    image: blockstream/bitcoind:31.1
     platform: linux/amd64
     command:
       [

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   bitcoin:
-    image: blockstream/bitcoind:27.2
+    image: blockstream/bitcoind:31.1
     platform: linux/amd64
     command:
       [


### PR DESCRIPTION
Eclair now requires Bitcoin Core 31 or newer, while the CI environments still run several older releases. Align the downloaded and containerized test daemons on 31.1 and invalidate caches so every job picks up the new binary.

(Necessary to fix CI)