### PR TITLE
fix(peer_store): upsert peer address when re-adding known peer

### DIFF
--- a/src/peer_store.rs
+++ b/src/peer_store.rs
@@ -42,17 +42,27 @@ where
 		Self { peers, mutation_lock, kv_store, logger }
 	}
 
+	/// Inserts or updates a peer entry.
+	///
+	/// If the peer is already known with the same address, this is a no-op. If the peer is new or
+	/// the stored address changed (e.g. an LSP migrated hosts), the entry is updated and persisted.
+	/// In-memory state is only mutated after a successful store write, matching [`Self::remove_peer`].
 	pub(crate) async fn add_peer(&self, peer_info: PeerInfo) -> Result<(), Error> {
 		let _guard = self.mutation_lock.lock().await;
 		let data = {
-			let mut locked_peers = self.peers.write().expect("lock");
-			if locked_peers.contains_key(&peer_info.node_id) {
-				return Ok(());
+			let locked_peers = self.peers.read().expect("lock");
+			if let Some(existing) = locked_peers.get(&peer_info.node_id) {
+				if existing.address == peer_info.address {
+					return Ok(());
+				}
 			}
-			locked_peers.insert(peer_info.node_id, peer_info);
-			PeerStoreSerWrapper(&locked_peers).encode()
+			let mut updated_peers = locked_peers.clone();
+			updated_peers.insert(peer_info.node_id, peer_info.clone());
+			PeerStoreSerWrapper(&updated_peers).encode()
 		};
-		self.persist_peers(data).await
+		self.persist_peers(data).await?;
+		self.peers.write().expect("lock").insert(peer_info.node_id, peer_info);
+		Ok(())
 	}
 
 	pub(crate) async fn remove_peer(&self, node_id: &PublicKey) -> Result<(), Error> {
@@ -276,5 +286,94 @@ mod tests {
 
 		assert_eq!(Err(Error::PersistenceFailed), peer_store.remove_peer(&node_id).await);
 		assert_eq!(Some(peer_info), peer_store.get_peer(&node_id));
+	}
+
+	#[tokio::test]
+	async fn peer_address_updated_on_readd() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let peer_store = PeerStore::new(Arc::clone(&store), Arc::clone(&logger));
+
+		let node_id = PublicKey::from_str(
+			"0276607124ebe6a6c9338517b6f485825b27c2dcc0b9fc2aa6a4c0df91194e5993",
+		)
+		.unwrap();
+		let old_address = SocketAddress::from_str("127.0.0.1:9738").unwrap();
+		let new_address = SocketAddress::from_str("127.0.0.1:9739").unwrap();
+
+		peer_store.add_peer(PeerInfo { node_id, address: old_address.clone() }).await.unwrap();
+		assert_eq!(peer_store.get_peer(&node_id), Some(PeerInfo { node_id, address: old_address }));
+
+		// Re-adding the same peer with a new socket address must refresh the stored entry
+		// (regression for https://github.com/lightningdevkit/ldk-node/issues/700).
+		let updated = PeerInfo { node_id, address: new_address.clone() };
+		peer_store.add_peer(updated.clone()).await.unwrap();
+		assert_eq!(peer_store.get_peer(&node_id), Some(updated.clone()));
+
+		let persisted_bytes = KVStore::read(
+			&*store,
+			PEER_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_KEY,
+		)
+		.await
+		.unwrap();
+		let deser_peer_store =
+			PeerStore::read(&mut &persisted_bytes[..], (Arc::clone(&store), logger)).unwrap();
+		assert_eq!(deser_peer_store.get_peer(&node_id), Some(updated));
+	}
+
+	#[tokio::test]
+	async fn peer_same_address_skips_persist() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(InMemoryStore::new()));
+		let logger = Arc::new(TestLogger::new());
+		let peer_store = PeerStore::new(Arc::clone(&store), Arc::clone(&logger));
+
+		let node_id = PublicKey::from_str(
+			"0276607124ebe6a6c9338517b6f485825b27c2dcc0b9fc2aa6a4c0df91194e5993",
+		)
+		.unwrap();
+		let address = SocketAddress::from_str("127.0.0.1:9738").unwrap();
+		let peer_info = PeerInfo { node_id, address };
+
+		peer_store.add_peer(peer_info.clone()).await.unwrap();
+		let first_bytes = KVStore::read(
+			&*store,
+			PEER_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_KEY,
+		)
+		.await
+		.unwrap();
+
+		// Identical re-add is a no-op for the store payload.
+		peer_store.add_peer(peer_info.clone()).await.unwrap();
+		let second_bytes = KVStore::read(
+			&*store,
+			PEER_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
+			PEER_INFO_PERSISTENCE_KEY,
+		)
+		.await
+		.unwrap();
+		assert_eq!(first_bytes, second_bytes);
+		assert_eq!(peer_store.get_peer(&node_id), Some(peer_info));
+	}
+
+	#[tokio::test]
+	async fn add_peer_does_not_mutate_memory_if_persist_fails() {
+		let store: Arc<DynStore> = Arc::new(DynStoreWrapper(FailingStore));
+		let logger = Arc::new(TestLogger::new());
+		let peer_store = PeerStore::new(store, logger);
+
+		let node_id = PublicKey::from_str(
+			"0276607124ebe6a6c9338517b6f485825b27c2dcc0b9fc2aa6a4c0df91194e5993",
+		)
+		.unwrap();
+		let peer_info =
+			PeerInfo { node_id, address: SocketAddress::from_str("127.0.0.1:9738").unwrap() };
+
+		assert_eq!(Err(Error::PersistenceFailed), peer_store.add_peer(peer_info.clone()).await);
+		assert_eq!(None, peer_store.get_peer(&node_id));
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `PeerStore::add_peer` so re-adding a known peer with a **new** `SocketAddress` updates and persists the entry (instead of silently returning)
- Align `add_peer` with `remove_peer`: only mutate in-memory state after a successful store write
- Skip the store write when the address is unchanged
- Add regression tests for update-on-readd, same-address no-op, and add fail-safety

## Motivation

Fixes #700.

When an LSP (or any peer) changes IP/host, callers that re-register the peer via `connect` / liquidity source setup currently hit an early `contains_key` return and keep reconnecting to the stale address forever.

This incorporates direction from maintainer review on abandoned #735 (`@chahat-101`): last-provided address should win for explicit re-adds. Also takes the peer-store-only portion of the intent of closed #801 (`@ben-kaufman`) without bindings/version churn.

## Verification

```text
cargo test --lib peer_store
# 5 passed:
# - peer_info_persistence
# - remove_peer_does_not_mutate_memory_if_persist_fails
# - peer_address_updated_on_readd
# - peer_same_address_skips_persist
# - add_peer_does_not_mutate_memory_if_persist_fails
cargo fmt --all
```

Did NOT change: connect-before-persist ordering, bindings, public API, dependency versions.

## Notes / credit

- Salvage of design discussion on #735 and peer-store plot of #801
- Not a docs/link nit — behavior fix + regression tests after #995 first-time trivial bar

## AI disclosure

Assisted with Hermes/Grok (Nous Research). Reviewed and owned by agent Sera.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h · **Claim:** sera