### PR TITLE
eltoo with bip-448

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,23 @@ check-cfg = [
 name = "payments"
 harness = false
 
+# EXPERIMENTAL: redirect all rust-lightning crates to the eltoo PoC tree
+# (LN-Symmetry over BIP-448; forked from upstream main @ 7b115207c, ~3 weeks
+# ahead of the rev pinned above).
+[patch."https://github.com/lightningdevkit/rust-lightning"]
+lightning = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-types = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-invoice = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-net-tokio = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-persister = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-background-processor = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-rapid-gossip-sync = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-block-sync = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-transaction-sync = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-liquidity = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-macros = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+lightning-dns-resolver = { git = "https://github.com/elnosh/rust-lightning", rev = "dbea0f87a6d6c9522612ebb81f94169da854eeef" }
+
 #[patch.crates-io]
 #lightning = { path = "../rust-lightning/lightning" }
 #lightning-types = { path = "../rust-lightning/lightning-types" }

--- a/examples/eltoo_demo.rs
+++ b/examples/eltoo_demo.rs
@@ -1,0 +1,550 @@
+// This file is Copyright its authors and licensed under the Apache License, Version 2.0 or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option. You may not use this
+// file except in accordance with one or both of these licenses.
+
+//! Interactive demo driver for eltoo (LN-Symmetry over BIP-448) channels on regtest.
+//!
+//! Run one instance per node, each pointed at your own BIP-448-patched bitcoind
+//! (<https://github.com/bip448/bitcoin/pull/1>; the opcodes are always active on
+//! regtest). The demo never mines or queries bitcoind itself — you drive the chain
+//! and inspect every transaction with `bitcoin-cli`.
+//!
+//! # Example session
+//!
+//! Terminal 0 — bitcoind:
+//! ```text
+//! $ bitcoind -regtest -fallbackfee=0.00001
+//! $ bitcoin-cli -regtest createwallet mine
+//! $ bitcoin-cli -regtest -generate 101
+//! ```
+//!
+//! Terminals 1 and 2 — the two nodes:
+//! ```text
+//! $ cargo run --example eltoo_demo -- --storage /tmp/eltoo-a --listen 9735 \
+//!       --rpc 127.0.0.1:18443 --rpc-cookie ~/.bitcoin/regtest/.cookie
+//! $ cargo run --example eltoo_demo -- --storage /tmp/eltoo-b --listen 9736 \
+//!       --rpc 127.0.0.1:18443 --rpc-cookie ~/.bitcoin/regtest/.cookie
+//! ```
+//!
+//! Fund both wallets — CPFP fee-bumping needs confirmed UTXOs on *both* sides:
+//! ```text
+//! A> fundaddr
+//! $ bitcoin-cli -regtest sendtoaddress <addr> 0.1 && bitcoin-cli -regtest -generate 1
+//! (repeat for B, then `sync` + `balance` in each REPL)
+//! ```
+//!
+//! Open a channel from A to B (B auto-accepts):
+//! ```text
+//! B> id
+//! A> open <b_node_id> 127.0.0.1:9736 1000000
+//! $ bitcoin-cli -regtest getrawmempool              # the funding tx
+//! $ bitcoin-cli -regtest -generate 3                # minimum_depth = 3
+//! A> events                                         # ChannelReady
+//! A> channels                                       # funding outpoint, state 0
+//! $ bitcoin-cli -regtest getrawtransaction <funding_txid> 2   # plain P2TR output
+//! ```
+//!
+//! Pay (payment hashes travel out-of-band; the PoC has no invoices):
+//! ```text
+//! B> recv
+//! A> pay <chan> 250000000 <hash>                    # amount in msat
+//! A> channels                                       # state 2, balances moved
+//! ```
+//!
+//! The cheat — snapshot a signed state, advance past it, publish the stale tx:
+//! ```text
+//! B> snapshot <chan>                                # held in REPL memory only
+//! B> recv                                           # ...then A> pay ... again
+//! B> cheat <chan>                                   # stale update + CPFP child
+//! $ bitcoin-cli -regtest -generate 1
+//! A> sync                                           # A sees the stale confirm and
+//! A> events                                         #  rebinds its tip update onto it
+//! $ bitcoin-cli -regtest getrawmempool              # rebound update: same signature,
+//! $ bitcoin-cli -regtest -generate 1                #  new prevout
+//! $ bitcoin-cli -regtest -generate 144              # shared_delay matures
+//! A> sync                                           # settlement (no signature at all)
+//! $ bitcoin-cli -regtest getrawmempool
+//! ```
+//! Both nodes rebind the same tip transaction — identical txid, harmless.
+//!
+//! Cooperative close (a single MuSig2 keyspend of the funding output):
+//! ```text
+//! A> close <chan>
+//! $ bitcoin-cli -regtest getrawmempool && bitcoin-cli -regtest -generate 1
+//! ```
+//!
+//! PoC caveats: keep both REPLs running for the life of a channel — peer
+//! reconnect/reestablish is not wired, and after a restart channels are
+//! force-close-only. Direct channels only; no invoices, routing or forwarding.
+
+use ldk_node::bip39::Mnemonic;
+use ldk_node::entropy::NodeEntropy;
+use ldk_node::lightning::ln::eltoo::channelmanager::{EltooChannelDetails, EltooEvent};
+use ldk_node::lightning::ln::msgs::SocketAddress;
+use ldk_node::lightning::ln::types::ChannelId;
+use ldk_node::lightning_types::payment::PaymentHash;
+use ldk_node::{Builder, Node};
+
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::{Network, OutPoint, Transaction};
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::str::FromStr;
+
+const USAGE: &str = "usage: eltoo_demo --storage <dir> --listen <port> --rpc <host:port> \
+                     (--rpc-cookie <path> | --rpc-user <user> --rpc-pass <pass>)";
+
+const HELP: &str = "commands:
+  id                                  node id, listening address, chain tip
+  fundaddr                            new on-chain address (fund it via bitcoin-cli)
+  balance                             on-chain wallet balance
+  open <node_id> <host:port> <cap_sat> [push_msat]
+                                      open an eltoo channel to a peer
+  channels                            list eltoo channels
+  recv                                register a payment; prints the payment hash
+  pay <chan> <amount_msat> <hash>     pay over a channel
+  snapshot <chan>                     hold the current signed update tx (for `cheat`)
+  cheat <chan>                        broadcast the held (now stale) update tx
+  close <chan>                        cooperative close
+  forceclose <chan>                   unilateral close at the latest state
+  events                              drain and print pending eltoo events
+  sync                                sync wallets/chain now
+  help                                this help
+  quit                                stop the node and exit
+
+<chan> may be any unique prefix of a channel id from `channels`.";
+
+fn main() {
+	let args = match Args::parse() {
+		Ok(args) => args,
+		Err(err) => {
+			eprintln!("{}\n{}", err, USAGE);
+			std::process::exit(1);
+		},
+	};
+
+	std::fs::create_dir_all(&args.storage).expect("create storage dir");
+	let entropy = load_or_generate_entropy(&args.storage);
+
+	let mut builder = Builder::new();
+	builder.set_network(Network::Regtest);
+	builder.set_storage_dir_path(args.storage.clone());
+	builder.set_filesystem_logger(None, None);
+	builder
+		.set_listening_addresses(vec![format!("0.0.0.0:{}", args.listen).parse().unwrap()])
+		.unwrap();
+	builder.set_chain_source_bitcoind_rpc(
+		args.rpc_host,
+		args.rpc_port,
+		args.rpc_user,
+		args.rpc_pass,
+		None,
+	);
+	let node = builder.build(entropy).expect("build node");
+	node.start().expect("start node");
+
+	println!("eltoo demo node started");
+	println!("  node id:   {}", node.node_id());
+	println!("  listening: 127.0.0.1:{}", args.listen);
+	println!("  storage:   {}", args.storage);
+	println!("type `help` for commands\n");
+
+	// Stale-state snapshots held for `cheat`, keyed by channel id.
+	let mut snapshots: HashMap<ChannelId, (Transaction, OutPoint)> = HashMap::new();
+
+	let stdin = std::io::stdin();
+	loop {
+		print!("> ");
+		std::io::stdout().flush().unwrap();
+		let mut line = String::new();
+		if stdin.lock().read_line(&mut line).unwrap_or(0) == 0 {
+			break;
+		}
+		let parts: Vec<&str> = line.split_whitespace().collect();
+		let (cmd, args) = match parts.split_first() {
+			Some((cmd, args)) => (*cmd, args),
+			None => continue,
+		};
+		match cmd {
+			"id" => {
+				let status = node.status();
+				println!("node id:   {}", node.node_id());
+				if let Some(addrs) = node.listening_addresses() {
+					for addr in addrs {
+						println!("listening: {}", addr);
+					}
+				}
+				println!(
+					"chain tip: {} ({})",
+					status.current_best_block.height, status.current_best_block.block_hash
+				);
+			},
+			"fundaddr" => match node.onchain_payment().new_address() {
+				Ok(addr) => println!("{}", addr),
+				Err(err) => println!("error: {}", err),
+			},
+			"balance" => {
+				let balances = node.list_balances();
+				println!(
+					"on-chain: {} sat total, {} sat spendable",
+					balances.total_onchain_balance_sats, balances.spendable_onchain_balance_sats
+				);
+			},
+			"open" => {
+				if args.len() < 3 {
+					println!("usage: open <node_id> <host:port> <cap_sat> [push_msat]");
+					continue;
+				}
+				let node_id = match PublicKey::from_str(args[0]) {
+					Ok(id) => id,
+					Err(err) => {
+						println!("bad node id: {}", err);
+						continue;
+					},
+				};
+				let address = match SocketAddress::from_str(args[1]) {
+					Ok(addr) => addr,
+					Err(_) => {
+						println!("bad address (want host:port)");
+						continue;
+					},
+				};
+				let cap_sat: u64 = match args[2].parse() {
+					Ok(cap) => cap,
+					Err(_) => {
+						println!("bad capacity");
+						continue;
+					},
+				};
+				let push_msat: u64 = args.get(3).and_then(|arg| arg.parse().ok()).unwrap_or(0);
+				match node.open_eltoo_channel(node_id, address, cap_sat, push_msat) {
+					Ok(temp_id) => {
+						println!("opening; temporary channel id {}", hex(&temp_id.0));
+						println!("(funding broadcasts once the peer accepts; mine 3 blocks, then `events` for ChannelReady)");
+					},
+					Err(err) => println!("error: {}", err),
+				}
+			},
+			"channels" => {
+				let channels = node.list_eltoo_channels();
+				if channels.is_empty() {
+					println!("no eltoo channels");
+				}
+				for details in &channels {
+					print_channel(details);
+				}
+			},
+			"recv" => {
+				let payment_hash = node.eltoo_receive_payment();
+				println!("payment hash: {}", hex(&payment_hash.0));
+				println!("(give this to the payer; it has no amount attached)");
+			},
+			"pay" => {
+				if args.len() != 3 {
+					println!("usage: pay <chan> <amount_msat> <hash>");
+					continue;
+				}
+				let channel_id = match resolve_channel(&node, args[0]) {
+					Some(id) => id,
+					None => continue,
+				};
+				let amount_msat: u64 = match args[1].parse() {
+					Ok(amount) => amount,
+					Err(_) => {
+						println!("bad amount (msat)");
+						continue;
+					},
+				};
+				let payment_hash = match parse_hash(args[2]) {
+					Some(hash) => hash,
+					None => {
+						println!("bad payment hash (want 64 hex chars)");
+						continue;
+					},
+				};
+				match node.send_eltoo_payment(channel_id, amount_msat, payment_hash) {
+					Ok(()) => println!("payment sent; `events` shows the outcome"),
+					Err(err) => println!("error: {}", err),
+				}
+			},
+			"snapshot" => {
+				let channel_id = match args.first().and_then(|arg| resolve_channel(&node, arg)) {
+					Some(id) => id,
+					None => {
+						println!("usage: snapshot <chan>");
+						continue;
+					},
+				};
+				match node.eltoo_signed_update_package(channel_id) {
+					Ok((tx, anchor)) => {
+						println!(
+							"holding state-{} update tx {} (broadcast later with `cheat`)",
+							state_of(&tx),
+							tx.compute_txid()
+						);
+						snapshots.insert(channel_id, (tx, anchor));
+					},
+					Err(err) => println!("error: {}", err),
+				}
+			},
+			"cheat" => {
+				let channel_id = match args.first().and_then(|arg| resolve_channel(&node, arg)) {
+					Some(id) => id,
+					None => {
+						println!("usage: cheat <chan>");
+						continue;
+					},
+				};
+				let (tx, anchor) =
+					match snapshots.remove(&channel_id) {
+						Some(snapshot) => snapshot,
+						None => {
+							println!("no snapshot held for that channel (take one with `snapshot` first)");
+							continue;
+						},
+					};
+				let state = state_of(&tx);
+				let txid = tx.compute_txid();
+				match node.broadcast_eltoo_package(tx, anchor) {
+					Ok(()) => println!(
+						"broadcast stale state-{} update {} — mine a block and watch the peer respond",
+						state, txid
+					),
+					Err(err) => println!("error: {}", err),
+				}
+			},
+			"close" => {
+				let channel_id = match args.first().and_then(|arg| resolve_channel(&node, arg)) {
+					Some(id) => id,
+					None => {
+						println!("usage: close <chan>");
+						continue;
+					},
+				};
+				match node.close_eltoo_channel(channel_id) {
+					Ok(()) => {
+						println!("cooperative close negotiated; `events` shows the closing tx")
+					},
+					Err(err) => println!("error: {}", err),
+				}
+			},
+			"forceclose" => {
+				let channel_id = match args.first().and_then(|arg| resolve_channel(&node, arg)) {
+					Some(id) => id,
+					None => {
+						println!("usage: forceclose <chan>");
+						continue;
+					},
+				};
+				node.force_close_eltoo_channel(channel_id);
+				println!("force-closing; `events` shows the update tx; settlement follows after shared_delay (144 blocks)");
+			},
+			"events" => {
+				let events = node.eltoo_events();
+				if events.is_empty() {
+					println!("no pending events");
+				}
+				for event in &events {
+					print_event(event);
+				}
+			},
+			"sync" => match node.sync_wallets() {
+				Ok(()) => println!("synced to height {}", node.status().current_best_block.height),
+				Err(err) => println!("error: {}", err),
+			},
+			"help" => println!("{}", HELP),
+			"quit" | "exit" => break,
+			other => println!("unknown command `{}`; try `help`", other),
+		}
+	}
+
+	println!("stopping node...");
+	let _ = node.stop();
+}
+
+struct Args {
+	storage: String,
+	listen: u16,
+	rpc_host: String,
+	rpc_port: u16,
+	rpc_user: String,
+	rpc_pass: String,
+}
+
+impl Args {
+	fn parse() -> Result<Self, String> {
+		let mut storage = None;
+		let mut listen = None;
+		let mut rpc = None;
+		let mut cookie = None;
+		let mut user = None;
+		let mut pass = None;
+		let mut args = std::env::args().skip(1);
+		while let Some(flag) = args.next() {
+			let mut value = || args.next().ok_or_else(|| format!("{} needs a value", flag));
+			match flag.as_str() {
+				"--storage" => storage = Some(value()?),
+				"--listen" => listen = Some(value()?),
+				"--rpc" => rpc = Some(value()?),
+				"--rpc-cookie" => cookie = Some(value()?),
+				"--rpc-user" => user = Some(value()?),
+				"--rpc-pass" => pass = Some(value()?),
+				other => return Err(format!("unknown flag {}", other)),
+			}
+		}
+		let storage = storage.ok_or("--storage is required")?;
+		let listen =
+			listen.ok_or("--listen is required")?.parse().map_err(|_| "bad --listen port")?;
+		let rpc = rpc.ok_or("--rpc is required")?;
+		let (rpc_host, rpc_port_str) = rpc.rsplit_once(':').ok_or("--rpc wants host:port")?;
+		let rpc_port = rpc_port_str.parse().map_err(|_| "bad --rpc port")?;
+		let (rpc_user, rpc_pass) = match (cookie, user, pass) {
+			(Some(path), None, None) => {
+				let contents = std::fs::read_to_string(&path)
+					.map_err(|err| format!("cannot read cookie file {}: {}", path, err))?;
+				let (user, pass) =
+					contents.trim().split_once(':').ok_or("malformed cookie file")?;
+				(user.to_string(), pass.to_string())
+			},
+			(None, Some(user), Some(pass)) => (user, pass),
+			_ => return Err("need either --rpc-cookie or --rpc-user + --rpc-pass".to_string()),
+		};
+		Ok(Self { storage, listen, rpc_host: rpc_host.to_string(), rpc_port, rpc_user, rpc_pass })
+	}
+}
+
+/// Loads the node's mnemonic from the storage dir, generating and saving one on first
+/// run, so the node keeps its identity (and wallet) across restarts.
+fn load_or_generate_entropy(storage: &str) -> NodeEntropy {
+	let path = std::path::Path::new(storage).join("demo_mnemonic");
+	let mnemonic = match std::fs::read_to_string(&path) {
+		Ok(contents) => Mnemonic::from_str(contents.trim()).expect("valid saved mnemonic"),
+		Err(_) => {
+			let mnemonic = ldk_node::entropy::generate_entropy_mnemonic(None);
+			std::fs::write(&path, mnemonic.to_string()).expect("write mnemonic");
+			mnemonic
+		},
+	};
+	NodeEntropy::from_bip39_mnemonic(mnemonic, None)
+}
+
+fn hex(bytes: &[u8]) -> String {
+	bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
+fn parse_hash(hash_hex: &str) -> Option<PaymentHash> {
+	if hash_hex.len() != 64 || !hash_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+		return None;
+	}
+	let mut bytes = [0u8; 32];
+	for (i, byte) in bytes.iter_mut().enumerate() {
+		*byte = u8::from_str_radix(&hash_hex[2 * i..2 * i + 2], 16).ok()?;
+	}
+	Some(PaymentHash(bytes))
+}
+
+/// Resolves a (prefix of a) channel id against the node's eltoo channels.
+fn resolve_channel(node: &Node, prefix: &str) -> Option<ChannelId> {
+	let matches: Vec<ChannelId> = node
+		.list_eltoo_channels()
+		.iter()
+		.map(|details| details.channel_id)
+		.filter(|id| hex(&id.0).starts_with(prefix))
+		.collect();
+	match matches.as_slice() {
+		[id] => Some(*id),
+		[] => {
+			println!("no channel matches `{}`", prefix);
+			None
+		},
+		_ => {
+			println!("`{}` is ambiguous; give more of the id", prefix);
+			None
+		},
+	}
+}
+
+/// The state number an update transaction is pinned to, per `TL(n)` in `nLockTime`.
+fn state_of(tx: &Transaction) -> u64 {
+	tx.lock_time.to_consensus_u32().saturating_sub(500_000_000) as u64
+}
+
+fn print_channel(details: &EltooChannelDetails) {
+	println!("channel {}", hex(&details.channel_id.0));
+	println!("  peer:     {}", details.counterparty_node_id);
+	match details.funding_outpoint {
+		Some(outpoint) => println!("  funding:  {}", outpoint),
+		None => println!("  funding:  (not yet negotiated)"),
+	}
+	match details.state_number {
+		Some(state) => println!(
+			"  state:    {} | ours {} msat / theirs {} msat / {} HTLC(s) in flight",
+			state, details.our_balance_msat, details.their_balance_msat, details.pending_htlcs
+		),
+		None => println!("  state:    (state 0 not yet signed)"),
+	}
+	println!(
+		"  ready:    {} | on-chain: {}",
+		details.is_ready,
+		details.onchain_status.unwrap_or("(no monitor yet)")
+	);
+}
+
+fn print_event(event: &EltooEvent) {
+	match event {
+		EltooEvent::ChannelReady { channel_id } => {
+			println!("* channel ready: {}", hex(&channel_id.0));
+		},
+		EltooEvent::BroadcastTransaction { tx, anchor_outpoint } => {
+			// Update spends carry [sig, script, control]; settlement covenant spends
+			// only [script, control]; everything else (closings, claims) varies.
+			let kind = if tx.lock_time.to_consensus_u32() >= 500_000_000 {
+				match tx.input[0].witness.len() {
+					3 => format!("update tx (state {})", state_of(tx)),
+					2 => format!("settlement tx (state {}, no signature)", state_of(tx)),
+					_ => format!("claim tx (locktime {})", tx.lock_time),
+				}
+			} else if tx.input[0].witness.len() == 1 {
+				"closing tx (MuSig2 keyspend)".to_string()
+			} else {
+				"transaction".to_string()
+			};
+			println!("* broadcast {}: {}", kind, tx.compute_txid());
+			if anchor_outpoint.is_some() {
+				println!("  (zero-fee parent; fees attached via CPFP child on its P2A anchor)");
+			}
+		},
+		EltooEvent::HtlcReceived {
+			channel_id,
+			htlc_id,
+			payment_hash,
+			amount_msat,
+			cltv_expiry,
+		} => {
+			println!(
+				"* HTLC received on {}: id {}, {} msat, hash {}, expiry {}",
+				hex(&channel_id.0),
+				htlc_id,
+				amount_msat,
+				hex(&payment_hash.0),
+				cltv_expiry
+			);
+		},
+		EltooEvent::PaymentClaimed { payment_hash, amount_msat } => {
+			println!("* payment claimed: {} msat, hash {}", amount_msat, hex(&payment_hash.0));
+		},
+		EltooEvent::PaymentFulfilled { payment_hash } => {
+			println!("* payment fulfilled: hash {}", hex(&payment_hash.0));
+		},
+		EltooEvent::PaymentFailed { payment_hash } => {
+			println!("* payment FAILED: hash {}", hex(&payment_hash.0));
+		},
+		EltooEvent::PreimageLearnedOnchain { payment_hash, .. } => {
+			println!("* preimage learned on-chain for hash {}", hex(&payment_hash.0));
+		},
+		EltooEvent::HtlcTimedOutOnchain { payment_hash } => {
+			println!("* HTLC timed out on-chain: hash {}", hex(&payment_hash.0));
+		},
+	}
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1939,12 +1939,12 @@ fn build_with_store_internal(
 
 	let channel_manager = Arc::new(channel_manager);
 
-	// The experimental eltoo stack, sharing wallet, chain source and broadcaster.
-	// Channels are in-memory only (PoC: no persistence).
+	// The experimental eltoo stack, sharing wallet, chain source, broadcaster and the
+	// node's KVStore (channels + monitors are persisted per-update and reloaded here).
 	let eltoo_runtime = {
 		let best_height = channel_manager.current_best_block().height;
 		let node_id = channel_manager.get_our_node_id();
-		Arc::new(crate::eltoo::EltooRuntime::new(
+		let eltoo_runtime = Arc::new(crate::eltoo::EltooRuntime::new(
 			node_id,
 			Arc::clone(&keys_manager),
 			config.network.into(),
@@ -1952,7 +1952,11 @@ fn build_with_store_internal(
 			Arc::clone(&wallet),
 			Arc::clone(&tx_broadcaster),
 			Arc::clone(&logger),
-		))
+			Arc::clone(&kv_store),
+		));
+		let reload = Arc::clone(&eltoo_runtime);
+		runtime.block_on(async move { reload.load_persisted_channels().await });
+		eltoo_runtime
 	};
 
 	// Give ChannelMonitors to ChainMonitor

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1939,6 +1939,22 @@ fn build_with_store_internal(
 
 	let channel_manager = Arc::new(channel_manager);
 
+	// The experimental eltoo stack, sharing wallet, chain source and broadcaster.
+	// Channels are in-memory only (PoC: no persistence).
+	let eltoo_runtime = {
+		let best_height = channel_manager.current_best_block().height;
+		let node_id = channel_manager.get_our_node_id();
+		Arc::new(crate::eltoo::EltooRuntime::new(
+			node_id,
+			Arc::clone(&keys_manager),
+			config.network.into(),
+			best_height,
+			Arc::clone(&wallet),
+			Arc::clone(&tx_broadcaster),
+			Arc::clone(&logger),
+		))
+	};
+
 	// Give ChannelMonitors to ChainMonitor
 	for (_blockhash, channel_monitor) in channel_monitors.into_iter() {
 		let channel_id = channel_monitor.channel_id();
@@ -2012,6 +2028,9 @@ fn build_with_store_internal(
 				Arc::clone(&channel_manager),
 				Arc::clone(&om_resolver),
 				IgnoringMessageHandler {},
+				// Only intercept messages for offline peers, not for unknown SCIDs (the
+				// event handler relies on interceptions carrying a node id).
+				false,
 			))
 		} else {
 			Arc::new(OnionMessenger::new(
@@ -2091,9 +2110,15 @@ fn build_with_store_internal(
 		(liquidity_source, custom_message_handler)
 	};
 
+	// Route channel messages to the regular ChannelManager or the eltoo manager.
+	let dual_chan_handler = Arc::new(crate::eltoo::DualChannelMessageHandler {
+		ldk: Arc::clone(&channel_manager),
+		eltoo: Arc::clone(&eltoo_runtime.handler),
+	});
+
 	let msg_handler = match gossip_source.as_gossip_sync() {
 		GossipSync::P2P(p2p_gossip_sync) => MessageHandler {
-			chan_handler: Arc::clone(&channel_manager),
+			chan_handler: Arc::clone(&dual_chan_handler),
 			route_handler: Arc::clone(&p2p_gossip_sync)
 				as Arc<dyn RoutingMessageHandler + Sync + Send>,
 			onion_message_handler: Arc::clone(&onion_messenger),
@@ -2101,7 +2126,7 @@ fn build_with_store_internal(
 			send_only_message_handler: Arc::clone(&chain_monitor),
 		},
 		GossipSync::Rapid(_) => MessageHandler {
-			chan_handler: Arc::clone(&channel_manager),
+			chan_handler: Arc::clone(&dual_chan_handler),
 			route_handler: Arc::new(IgnoringMessageHandler {})
 				as Arc<dyn RoutingMessageHandler + Sync + Send>,
 			onion_message_handler: Arc::clone(&onion_messenger),
@@ -2251,6 +2276,7 @@ fn build_with_store_internal(
 		om_mailbox,
 		async_payments_role,
 		hrn_resolver,
+		eltoo: eltoo_runtime,
 		#[cfg(cycle_tests)]
 		_leak_checker,
 	})

--- a/src/chain/bitcoind.rs
+++ b/src/chain/bitcoind.rs
@@ -123,6 +123,7 @@ impl BitcoindChainSource {
 		&self, mut stop_sync_receiver: tokio::sync::watch::Receiver<()>,
 		onchain_wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>,
 		chain_monitor: Arc<ChainMonitor>, output_sweeper: Arc<Sweeper>,
+		eltoo: Arc<crate::eltoo::EltooRuntime>,
 	) {
 		// First register for the wallet polling status to make sure `Node::sync_wallets` calls
 		// wait on the result before proceeding.
@@ -156,6 +157,8 @@ impl BitcoindChainSource {
 				(onchain_wallet_best_block, &*onchain_wallet as &(dyn Listen + Send + Sync)),
 				(channel_manager_best_block, &*channel_manager as &(dyn Listen + Send + Sync)),
 				(sweeper_best_block, &*output_sweeper as &(dyn Listen + Send + Sync)),
+				// The eltoo runtime was initialized at the channel manager's best block.
+				(channel_manager_best_block, &*eltoo as &(dyn Listen + Send + Sync)),
 			];
 
 			// TODO: Eventually we might want to see if we can synchronize `ChannelMonitor`s
@@ -299,7 +302,8 @@ impl BitcoindChainSource {
 							Arc::clone(&onchain_wallet),
 							Arc::clone(&channel_manager),
 							Arc::clone(&chain_monitor),
-							Arc::clone(&output_sweeper)
+							Arc::clone(&output_sweeper),
+							Arc::clone(&eltoo)
 						) => {}
 					}
 				}
@@ -356,6 +360,7 @@ impl BitcoindChainSource {
 	pub(super) async fn poll_and_update_listeners(
 		&self, onchain_wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>,
 		chain_monitor: Arc<ChainMonitor>, output_sweeper: Arc<Sweeper>,
+		eltoo: Arc<crate::eltoo::EltooRuntime>,
 	) -> Result<(), Error> {
 		let receiver_res = {
 			let mut status_lock = self.wallet_polling_status.lock().expect("lock");
@@ -377,6 +382,7 @@ impl BitcoindChainSource {
 				channel_manager,
 				chain_monitor,
 				output_sweeper,
+				eltoo,
 			)
 			.await;
 
@@ -388,6 +394,7 @@ impl BitcoindChainSource {
 	async fn poll_and_update_listeners_inner(
 		&self, onchain_wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>,
 		chain_monitor: Arc<ChainMonitor>, output_sweeper: Arc<Sweeper>,
+		eltoo: Arc<crate::eltoo::EltooRuntime>,
 	) -> Result<(), Error> {
 		let latest_chain_tip_opt = self.latest_chain_tip.read().expect("lock").clone();
 		let chain_tip =
@@ -399,6 +406,7 @@ impl BitcoindChainSource {
 			channel_manager: Arc::clone(&channel_manager),
 			chain_monitor: Arc::clone(&chain_monitor),
 			output_sweeper,
+			eltoo,
 		};
 		let mut spv_client =
 			SpvClient::new(chain_tip, chain_poller, HeaderCache::new(), &chain_listener);
@@ -572,10 +580,33 @@ impl BitcoindChainSource {
 	}
 
 	pub(crate) async fn process_broadcast_package(&self, package: Vec<Transaction>) {
-		// While it's a bit unclear when we'd be able to lean on Bitcoin Core >v28
-		// features, we should eventually switch to use `submitpackage` via the
-		// `rust-bitcoind-json-rpc` crate rather than just broadcasting individual
-		// transactions.
+		// Multi-transaction packages (e.g. a zero-fee TRUC parent with its P2A CPFP
+		// child) must enter the mempool atomically: `submitpackage` them.
+		if package.len() > 1 {
+			let timeout_fut = tokio::time::timeout(
+				Duration::from_secs(DEFAULT_TX_BROADCAST_TIMEOUT_SECS),
+				self.api_client.submit_package(&package),
+			);
+			match timeout_fut.await {
+				Ok(Ok(res)) if res.package_msg == "success" => {
+					log_trace!(
+						self.logger,
+						"Successfully submitted package of {} transactions",
+						package.len()
+					);
+				},
+				Ok(Ok(res)) => {
+					log_error!(self.logger, "Package not accepted: {}", res.package_msg);
+				},
+				Ok(Err(e)) => {
+					log_error!(self.logger, "Failed to submit package: {}", e);
+				},
+				Err(e) => {
+					log_error!(self.logger, "Failed to submit package due to timeout: {}", e);
+				},
+			}
+			return;
+		}
 		for tx in &package {
 			let txid = tx.compute_txid();
 			let timeout_fut = tokio::time::timeout(
@@ -774,6 +805,26 @@ impl BitcoindClient {
 		let tx_serialized = bitcoin::consensus::encode::serialize_hex(tx);
 		let tx_json = serde_json::json!(tx_serialized);
 		rpc_client.call_method::<Txid>("sendrawtransaction", &[tx_json]).await
+	}
+
+	/// Submits a package of transactions atomically via `submitpackage` (Core v28+),
+	/// allowing zero-fee (e.g. TRUC/P2A-anchored) parents to enter the mempool with
+	/// their fee-paying children.
+	pub(crate) async fn submit_package(
+		&self, package: &[Transaction],
+	) -> Result<SubmitPackageResponse, BitcoindClientError> {
+		let rpc_client = match self {
+			BitcoindClient::Rpc { rpc_client, .. } => Arc::clone(rpc_client),
+			// The REST interface does not support broadcasting, so we use the RPC client.
+			BitcoindClient::Rest { rpc_client, .. } => Arc::clone(rpc_client),
+		};
+		let hex_txs: Vec<String> =
+			package.iter().map(bitcoin::consensus::encode::serialize_hex).collect();
+		let package_json = serde_json::json!(hex_txs);
+		rpc_client
+			.call_method::<SubmitPackageResponse>("submitpackage", &[package_json])
+			.await
+			.map_err(BitcoindClientError::Rpc)
 	}
 
 	/// Retrieve the fee estimate needed for a transaction to begin
@@ -1235,6 +1286,21 @@ impl TryInto<FeeResponse> for JsonResponse {
 	}
 }
 
+pub(crate) struct SubmitPackageResponse {
+	pub(crate) package_msg: String,
+}
+
+impl TryInto<SubmitPackageResponse> for JsonResponse {
+	type Error = String;
+	fn try_into(self) -> Result<SubmitPackageResponse, String> {
+		let package_msg = self.0["package_msg"]
+			.as_str()
+			.ok_or_else(|| "submitpackage response missing package_msg".to_string())?
+			.to_string();
+		Ok(SubmitPackageResponse { package_msg })
+	}
+}
+
 pub(crate) struct MempoolMinFeeResponse(pub FeeRate);
 
 impl TryInto<MempoolMinFeeResponse> for JsonResponse {
@@ -1349,6 +1415,7 @@ pub(crate) struct ChainListener {
 	pub(crate) channel_manager: Arc<ChannelManager>,
 	pub(crate) chain_monitor: Arc<ChainMonitor>,
 	pub(crate) output_sweeper: Arc<Sweeper>,
+	pub(crate) eltoo: Arc<crate::eltoo::EltooRuntime>,
 }
 
 impl Listen for ChainListener {
@@ -1360,12 +1427,14 @@ impl Listen for ChainListener {
 		self.channel_manager.filtered_block_connected(header, txdata, height);
 		self.chain_monitor.filtered_block_connected(header, txdata, height);
 		self.output_sweeper.filtered_block_connected(header, txdata, height);
+		self.eltoo.filtered_block_connected(header, txdata, height);
 	}
 	fn block_connected(&self, block: &bitcoin::Block, height: u32) {
 		self.onchain_wallet.block_connected(block, height);
 		self.channel_manager.block_connected(block, height);
 		self.chain_monitor.block_connected(block, height);
 		self.output_sweeper.block_connected(block, height);
+		self.eltoo.block_connected(block, height);
 	}
 
 	fn blocks_disconnected(&self, fork_point_block: lightning::chain::BlockLocator) {
@@ -1373,6 +1442,7 @@ impl Listen for ChainListener {
 		self.channel_manager.blocks_disconnected(fork_point_block);
 		self.chain_monitor.blocks_disconnected(fork_point_block);
 		self.output_sweeper.blocks_disconnected(fork_point_block);
+		self.eltoo.blocks_disconnected(fork_point_block);
 	}
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -229,7 +229,7 @@ impl ChainSource {
 	pub(crate) async fn continuously_sync_wallets(
 		&self, stop_sync_receiver: tokio::sync::watch::Receiver<()>, onchain_wallet: Arc<Wallet>,
 		channel_manager: Arc<ChannelManager>, chain_monitor: Arc<ChainMonitor>,
-		output_sweeper: Arc<Sweeper>,
+		output_sweeper: Arc<Sweeper>, eltoo: Arc<crate::eltoo::EltooRuntime>,
 	) {
 		match &self.kind {
 			ChainSourceKind::Esplora(esplora_chain_source) => {
@@ -286,6 +286,7 @@ impl ChainSource {
 						channel_manager,
 						chain_monitor,
 						output_sweeper,
+						eltoo,
 					)
 					.await
 			},
@@ -399,6 +400,7 @@ impl ChainSource {
 	pub(crate) async fn poll_and_update_listeners(
 		&self, onchain_wallet: Arc<Wallet>, channel_manager: Arc<ChannelManager>,
 		chain_monitor: Arc<ChainMonitor>, output_sweeper: Arc<Sweeper>,
+		eltoo: Arc<crate::eltoo::EltooRuntime>,
 	) -> Result<(), Error> {
 		match &self.kind {
 			ChainSourceKind::Esplora { .. } => {
@@ -418,6 +420,7 @@ impl ChainSource {
 						channel_manager,
 						chain_monitor,
 						output_sweeper,
+						eltoo,
 					)
 					.await
 			},

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -223,7 +223,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use lightning::impl_writeable_tlv_based;
+	use lightning::impl_ser_tlv_based;
 	use lightning::io;
 	use lightning::util::persist::{PageToken, PaginatedKVStore, PaginatedListResponse};
 	use lightning::util::test_utils::TestLogger;
@@ -243,7 +243,7 @@ mod tests {
 			hex_utils::to_string(&self.id)
 		}
 	}
-	impl_writeable_tlv_based!(TestObjectId, { (0, id, required) });
+	impl_ser_tlv_based!(TestObjectId, { (0, id, required) });
 
 	struct TestObjectUpdate {
 		id: TestObjectId,
@@ -283,7 +283,7 @@ mod tests {
 		}
 	}
 
-	impl_writeable_tlv_based!(TestObject, {
+	impl_ser_tlv_based!(TestObject, {
 		(0, id, required),
 		(2, data, required),
 	});

--- a/src/eltoo.rs
+++ b/src/eltoo.rs
@@ -1,0 +1,495 @@
+// This file is Copyright its authors and licensed under the Apache License, Version 2.0 or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option. You may not use this
+// file except in accordance with one or both of these licenses.
+
+//! Experimental support for eltoo (LN-Symmetry over BIP-448) channels.
+//!
+//! This wires the eltoo PoC stack of our rust-lightning fork into the node:
+//! [`EltooChannelManager`] runs alongside the regular `ChannelManager`, sharing the
+//! peer transport (via [`DualChannelMessageHandler`]), the BDK on-chain wallet
+//! (funding + P2A anchor CPFP fee-bumping), the bitcoind chain source (block feed)
+//! and the transaction broadcaster. Only the bitcoind chain source feeds eltoo
+//! channels; esplora/electrum do not.
+//!
+//! Scope mirrors the PoC: no persistence (channels do not survive restarts), no
+//! reorg handling, no routed payments (direct channels only, with out-of-band
+//! payment hashes standing in for invoices).
+
+use crate::logger::{log_debug, log_error, LdkLogger, Logger};
+use crate::types::{Broadcaster, ChannelManager, KeysManager, Wallet};
+
+use lightning::chain::chaininterface::{BroadcasterInterface, TransactionType};
+use lightning::chain::{BlockLocator, Listen};
+use lightning::ln::eltoo::channel::EltooChannelConfig;
+use lightning::ln::eltoo::channelmanager::{EltooChannelManager, EltooEvent};
+use lightning::ln::eltoo::peer_glue::EltooMessageHandler;
+use lightning::ln::msgs;
+use lightning::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, MessageSendEvent};
+use lightning::ln::types::ChannelId;
+use lightning::types::features::{InitFeatures, NodeFeatures};
+use lightning::util::wallet_utils::WalletSource;
+
+use bitcoin::absolute::LockTime;
+use bitcoin::constants::ChainHash;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::transaction::Version;
+use bitcoin::{
+	Amount, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+};
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+pub(crate) type EltooManager = EltooChannelManager<Arc<KeysManager>>;
+pub(crate) type EltooHandler = EltooMessageHandler<Arc<KeysManager>>;
+
+/// Fee reserved for a P2A anchor CPFP child (PoC: fixed, no estimation).
+const ANCHOR_CHILD_FEE: Amount = Amount::from_sat(20_000);
+
+/// An eltoo channel we opened, between channel creation and `channel_ready`.
+struct PendingFunding {
+	/// The channel id — temporary until the funding tx is created, final afterwards.
+	channel_id: ChannelId,
+	capacity: Amount,
+	funding_txid: Option<Txid>,
+	ready_signalled: bool,
+}
+
+/// Owns the node-side glue around the sans-IO [`EltooChannelManager`]: the funding
+/// state machine, the broadcast/CPFP pump and the chain feed. Driven by a periodic
+/// background task (see [`EltooRuntime::process`]).
+pub(crate) struct EltooRuntime {
+	pub(crate) manager: Arc<EltooManager>,
+	pub(crate) handler: Arc<EltooHandler>,
+	config: EltooChannelConfig,
+	network: bitcoin::Network,
+	wallet: Arc<Wallet>,
+	tx_broadcaster: Arc<Broadcaster>,
+	logger: Arc<Logger>,
+	pending_funding: Mutex<Vec<PendingFunding>>,
+	/// Watched funding txids → confirmation height (once seen in a block).
+	confirmations: Mutex<HashMap<Txid, u32>>,
+	tip: AtomicU32,
+	/// Non-broadcast events, drained by the user via `Node::eltoo_events`.
+	events: Mutex<Vec<EltooEvent>>,
+}
+
+impl EltooRuntime {
+	pub(crate) fn new(
+		node_id: PublicKey, keys_manager: Arc<KeysManager>, network: bitcoin::Network,
+		best_height: u32, wallet: Arc<Wallet>, tx_broadcaster: Arc<Broadcaster>,
+		logger: Arc<Logger>,
+	) -> Self {
+		let chain_hash = ChainHash::using_genesis_block(network);
+		let config = EltooChannelConfig::default();
+		let manager = Arc::new(EltooChannelManager::new(
+			keys_manager,
+			node_id,
+			config,
+			chain_hash,
+			best_height,
+		));
+		let handler = Arc::new(EltooMessageHandler::new(Arc::clone(&manager), chain_hash));
+		Self {
+			manager,
+			handler,
+			config,
+			network,
+			wallet,
+			tx_broadcaster,
+			logger,
+			pending_funding: Mutex::new(Vec::new()),
+			confirmations: Mutex::new(HashMap::new()),
+			tip: AtomicU32::new(best_height),
+			events: Mutex::new(Vec::new()),
+		}
+	}
+
+	pub(crate) fn tip(&self) -> u32 {
+		self.tip.load(Ordering::Acquire)
+	}
+
+	/// Registers a just-created channel; the periodic task funds it once the peer's
+	/// accept has provided the funding address.
+	pub(crate) fn register_pending_channel(&self, channel_id: ChannelId, capacity_sat: u64) {
+		self.pending_funding.lock().unwrap().push(PendingFunding {
+			channel_id,
+			capacity: Amount::from_sat(capacity_sat),
+			funding_txid: None,
+			ready_signalled: false,
+		});
+	}
+
+	/// Drains the events the user should see (payment outcomes, channels ready, ...).
+	pub(crate) fn take_events(&self) -> Vec<EltooEvent> {
+		core::mem::take(&mut *self.events.lock().unwrap())
+	}
+
+	/// One pass of the periodic driver: fund accepted channels, signal funding depth,
+	/// pump broadcasts (attaching CPFP children to zero-fee TRUC parents).
+	pub(crate) async fn process(&self) {
+		self.fund_accepted_channels();
+		self.signal_confirmed_fundings();
+		self.pump_events().await;
+	}
+
+	/// For each pending channel whose handshake completed, build, broadcast and
+	/// register the funding transaction from the BDK wallet.
+	fn fund_accepted_channels(&self) {
+		let to_fund: Vec<(ChannelId, Amount, bitcoin::Address)> = {
+			let pending = self.pending_funding.lock().unwrap();
+			pending
+				.iter()
+				.filter(|entry| entry.funding_txid.is_none())
+				.filter_map(|entry| {
+					self.manager
+						.funding_address(entry.channel_id, self.network)
+						.map(|address| (entry.channel_id, entry.capacity, address))
+				})
+				.collect()
+		};
+		for (temp_id, capacity, address) in to_fund {
+			let locktime = LockTime::from_height(self.tip()).unwrap_or(LockTime::ZERO);
+			let funding_tx = match self.wallet.create_funding_transaction(
+				address.script_pubkey(),
+				capacity,
+				crate::fee_estimator::ConfirmationTarget::ChannelFunding,
+				locktime,
+			) {
+				Ok(tx) => tx,
+				Err(e) => {
+					log_error!(self.logger, "Failed to create eltoo funding tx: {}", e);
+					continue;
+				},
+			};
+			let txid = funding_tx.compute_txid();
+			let vout = funding_tx
+				.output
+				.iter()
+				.position(|out| out.script_pubkey == address.script_pubkey())
+				.expect("funding output present") as u16;
+			let final_id = match self.manager.funding_ready(temp_id, txid, vout) {
+				Ok(id) => id,
+				Err(e) => {
+					log_error!(self.logger, "eltoo funding_ready failed: {:?}", e);
+					continue;
+				},
+			};
+			self.tx_broadcaster.broadcast_transactions(&[(
+				&funding_tx,
+				TransactionType::Sweep { channels: vec![] },
+			)]);
+			self.confirmations.lock().unwrap().insert(txid, 0);
+			let mut pending = self.pending_funding.lock().unwrap();
+			if let Some(entry) = pending.iter_mut().find(|entry| entry.channel_id == temp_id) {
+				entry.channel_id = final_id;
+				entry.funding_txid = Some(txid);
+			}
+			log_debug!(self.logger, "Broadcast eltoo funding tx {} for channel {}", txid, final_id);
+		}
+	}
+
+	/// Signals `funding_confirmed` once a funding tx has the configured depth.
+	fn signal_confirmed_fundings(&self) {
+		let tip = self.tip();
+		let mut ready = Vec::new();
+		{
+			let confirmations = self.confirmations.lock().unwrap();
+			let mut pending = self.pending_funding.lock().unwrap();
+			for entry in pending.iter_mut() {
+				if entry.ready_signalled {
+					continue;
+				}
+				let txid = match entry.funding_txid {
+					Some(txid) => txid,
+					None => continue,
+				};
+				match confirmations.get(&txid) {
+					Some(&height) if height > 0 => {
+						let depth = tip + 1 - height;
+						if depth >= self.config.minimum_depth {
+							entry.ready_signalled = true;
+							ready.push(entry.channel_id);
+						}
+					},
+					_ => {},
+				}
+			}
+		}
+		for channel_id in ready {
+			if let Err(e) = self.manager.funding_confirmed(channel_id) {
+				log_error!(self.logger, "eltoo funding_confirmed failed: {:?}", e);
+			}
+		}
+	}
+
+	/// Drains manager events: broadcasts go out (zero-fee TRUC parents packaged with
+	/// a wallet-funded CPFP child), everything else is queued for the user.
+	async fn pump_events(&self) {
+		for event in self.manager.get_and_clear_events() {
+			match event {
+				EltooEvent::BroadcastTransaction { tx, anchor_outpoint: None } => {
+					self.tx_broadcaster.broadcast_transactions(&[(
+						&tx,
+						TransactionType::Sweep { channels: vec![] },
+					)]);
+				},
+				EltooEvent::BroadcastTransaction { tx, anchor_outpoint: Some(anchor) } => {
+					match self.build_anchor_child(&tx, anchor).await {
+						Ok(child) => {
+							self.tx_broadcaster.broadcast_transactions(&[
+								(&tx, TransactionType::Sweep { channels: vec![] }),
+								(&child, TransactionType::Sweep { channels: vec![] }),
+							]);
+						},
+						Err(()) => {
+							log_error!(
+								self.logger,
+								"Failed to build CPFP child for eltoo tx {}",
+								tx.compute_txid()
+							);
+						},
+					}
+				},
+				other => self.events.lock().unwrap().push(other),
+			}
+		}
+	}
+
+	/// Builds the CPFP child spending the P2A anchor (empty witness) plus one
+	/// confirmed wallet UTXO for fees, change back to the wallet. TRUC requires the
+	/// child to be v3 like its parent.
+	async fn build_anchor_child(
+		&self, parent: &Transaction, anchor: OutPoint,
+	) -> Result<Transaction, ()> {
+		debug_assert_eq!(anchor.txid, parent.compute_txid());
+		let utxos = self.wallet.list_confirmed_utxos().await?;
+		let utxo = utxos
+			.into_iter()
+			.find(|utxo| utxo.output.value > ANCHOR_CHILD_FEE * 2)
+			.ok_or_else(|| {
+				log_error!(self.logger, "No confirmed wallet UTXO available for eltoo CPFP");
+			})?;
+		let change_script = self.wallet.get_change_script().await?;
+		let anchor_output = parent
+			.output
+			.get(anchor.vout as usize)
+			.cloned()
+			.ok_or_else(|| log_error!(self.logger, "Anchor outpoint missing from parent"))?;
+		let unsigned = Transaction {
+			version: Version::non_standard(3),
+			lock_time: LockTime::ZERO,
+			input: vec![
+				TxIn {
+					previous_output: anchor,
+					script_sig: ScriptBuf::new(),
+					sequence: Sequence::MAX,
+					witness: Witness::new(),
+				},
+				TxIn {
+					previous_output: utxo.outpoint,
+					script_sig: ScriptBuf::new(),
+					sequence: Sequence::MAX,
+					witness: Witness::new(),
+				},
+			],
+			output: vec![TxOut {
+				value: utxo.output.value + anchor_output.value - ANCHOR_CHILD_FEE,
+				script_pubkey: change_script,
+			}],
+		};
+		let mut psbt = Psbt::from_unsigned_tx(unsigned)
+			.map_err(|e| log_error!(self.logger, "Failed to build CPFP psbt: {}", e))?;
+		// The wallet signs its own input; the P2A anchor input spends with an empty
+		// witness and needs no signature.
+		psbt.inputs[0].witness_utxo = Some(anchor_output);
+		psbt.inputs[1].witness_utxo = Some(utxo.output.clone());
+		self.wallet.sign_psbt(psbt).await
+	}
+}
+
+/// Feeds the block-oriented chain source into the eltoo stack: confirmation heights
+/// for the funding tracker, then the manager itself (which implements [`Listen`]).
+impl Listen for EltooRuntime {
+	fn filtered_block_connected(
+		&self, header: &bitcoin::block::Header,
+		txdata: &lightning::chain::transaction::TransactionData, height: u32,
+	) {
+		self.tip.store(height, Ordering::Release);
+		{
+			let mut confirmations = self.confirmations.lock().unwrap();
+			for (_, tx) in txdata {
+				let txid = tx.compute_txid();
+				if let Some(entry) = confirmations.get_mut(&txid) {
+					if *entry == 0 {
+						*entry = height;
+					}
+				}
+			}
+		}
+		self.manager.filtered_block_connected(header, txdata, height);
+	}
+
+	fn blocks_disconnected(&self, _fork_point_block: BlockLocator) {
+		// Reorgs are unsupported in the eltoo PoC.
+	}
+}
+
+/// The peer-facing channel message handler: LN-penalty messages go to the regular
+/// [`ChannelManager`], eltoo messages (and the BOLT 2 HTLC updates, which eltoo
+/// reuses — this node routes them by which stack knows the channel: the PoC only
+/// ever has them on eltoo channels when the regular manager doesn't know them) go to
+/// the [`EltooHandler`].
+pub(crate) struct DualChannelMessageHandler {
+	pub(crate) ldk: Arc<ChannelManager>,
+	pub(crate) eltoo: Arc<EltooHandler>,
+}
+
+impl BaseMessageHandler for DualChannelMessageHandler {
+	fn get_and_clear_pending_msg_events(&self) -> Vec<MessageSendEvent> {
+		let mut events = self.ldk.get_and_clear_pending_msg_events();
+		events.append(&mut self.eltoo.get_and_clear_pending_msg_events());
+		events
+	}
+
+	fn peer_connected(
+		&self, their_node_id: PublicKey, msg: &msgs::Init, inbound: bool,
+	) -> Result<(), ()> {
+		self.eltoo.peer_connected(their_node_id, msg, inbound)?;
+		self.ldk.peer_connected(their_node_id, msg, inbound)
+	}
+
+	fn peer_disconnected(&self, their_node_id: PublicKey) {
+		self.eltoo.peer_disconnected(their_node_id);
+		self.ldk.peer_disconnected(their_node_id);
+	}
+
+	fn provided_node_features(&self) -> NodeFeatures {
+		let mut features = self.ldk.provided_node_features();
+		features.set_eltoo_optional();
+		features
+	}
+
+	fn provided_init_features(&self, their_node_id: PublicKey) -> InitFeatures {
+		let mut features = self.ldk.provided_init_features(their_node_id);
+		features.set_eltoo_optional();
+		features
+	}
+}
+
+macro_rules! delegate_to_ldk {
+	($($method:ident($msg:ty)),* $(,)?) => {
+		$(
+			fn $method(&self, their_node_id: PublicKey, msg: $msg) {
+				self.ldk.$method(their_node_id, msg);
+			}
+		)*
+	};
+}
+
+macro_rules! delegate_to_eltoo {
+	($($method:ident($msg:ty)),* $(,)?) => {
+		$(
+			fn $method(&self, their_node_id: PublicKey, msg: $msg) {
+				self.eltoo.$method(their_node_id, msg);
+			}
+		)*
+	};
+}
+
+impl ChannelMessageHandler for DualChannelMessageHandler {
+	delegate_to_ldk!(
+		handle_open_channel(&msgs::OpenChannel),
+		handle_open_channel_v2(&msgs::OpenChannelV2),
+		handle_accept_channel(&msgs::AcceptChannel),
+		handle_accept_channel_v2(&msgs::AcceptChannelV2),
+		handle_funding_created(&msgs::FundingCreated),
+		handle_funding_signed(&msgs::FundingSigned),
+		handle_channel_ready(&msgs::ChannelReady),
+		handle_peer_storage(msgs::PeerStorage),
+		handle_peer_storage_retrieval(msgs::PeerStorageRetrieval),
+		handle_shutdown(&msgs::Shutdown),
+		handle_closing_signed(&msgs::ClosingSigned),
+		handle_stfu(&msgs::Stfu),
+		handle_splice_init(&msgs::SpliceInit),
+		handle_splice_ack(&msgs::SpliceAck),
+		handle_splice_locked(&msgs::SpliceLocked),
+		handle_tx_add_input(&msgs::TxAddInput),
+		handle_tx_add_output(&msgs::TxAddOutput),
+		handle_tx_remove_input(&msgs::TxRemoveInput),
+		handle_tx_remove_output(&msgs::TxRemoveOutput),
+		handle_tx_complete(&msgs::TxComplete),
+		handle_tx_signatures(&msgs::TxSignatures),
+		handle_tx_init_rbf(&msgs::TxInitRbf),
+		handle_tx_ack_rbf(&msgs::TxAckRbf),
+		handle_tx_abort(&msgs::TxAbort),
+		handle_update_fail_malformed_htlc(&msgs::UpdateFailMalformedHTLC),
+		handle_commitment_signed(&msgs::CommitmentSigned),
+		handle_revoke_and_ack(&msgs::RevokeAndACK),
+		handle_update_fee(&msgs::UpdateFee),
+		handle_announcement_signatures(&msgs::AnnouncementSignatures),
+		handle_channel_reestablish(&msgs::ChannelReestablish),
+		handle_channel_update(&msgs::ChannelUpdate),
+		handle_error(&msgs::ErrorMessage),
+	);
+
+	fn handle_commitment_signed_batch(
+		&self, their_node_id: PublicKey, channel_id: ChannelId, batch: Vec<msgs::CommitmentSigned>,
+	) {
+		self.ldk.handle_commitment_signed_batch(their_node_id, channel_id, batch);
+	}
+
+	delegate_to_eltoo!(
+		handle_open_channel_eltoo(&lightning::ln::eltoo::msgs::OpenChannelEltoo),
+		handle_accept_channel_eltoo(&lightning::ln::eltoo::msgs::AcceptChannelEltoo),
+		handle_funding_created_eltoo(&lightning::ln::eltoo::msgs::FundingCreatedEltoo),
+		handle_funding_signed_eltoo(&lightning::ln::eltoo::msgs::FundingSignedEltoo),
+		handle_channel_ready_eltoo(&lightning::ln::eltoo::msgs::ChannelReadyEltoo),
+		handle_shutdown_eltoo(&lightning::ln::eltoo::msgs::ShutdownEltoo),
+		handle_closing_signed_eltoo(&lightning::ln::eltoo::msgs::ClosingSignedEltoo),
+		handle_update_signed(&lightning::ln::eltoo::msgs::UpdateSigned),
+		handle_update_signed_ack(&lightning::ln::eltoo::msgs::UpdateSignedAck),
+		handle_channel_reestablish_eltoo(&lightning::ln::eltoo::msgs::ChannelReestablishEltoo),
+		handle_update_noop(&lightning::ln::eltoo::msgs::UpdateNoop),
+		handle_yield(&lightning::ln::eltoo::msgs::Yield),
+	);
+
+	// The BOLT 2 HTLC update messages are shared between the two protocols. Route by
+	// which manager knows the channel; the regular manager takes precedence.
+	fn handle_update_add_htlc(&self, their_node_id: PublicKey, msg: &msgs::UpdateAddHTLC) {
+		if self.is_ldk_channel(msg.channel_id) {
+			self.ldk.handle_update_add_htlc(their_node_id, msg);
+		} else {
+			self.eltoo.handle_update_add_htlc(their_node_id, msg);
+		}
+	}
+	fn handle_update_fulfill_htlc(&self, their_node_id: PublicKey, msg: msgs::UpdateFulfillHTLC) {
+		if self.is_ldk_channel(msg.channel_id) {
+			self.ldk.handle_update_fulfill_htlc(their_node_id, msg);
+		} else {
+			self.eltoo.handle_update_fulfill_htlc(their_node_id, msg);
+		}
+	}
+	fn handle_update_fail_htlc(&self, their_node_id: PublicKey, msg: &msgs::UpdateFailHTLC) {
+		if self.is_ldk_channel(msg.channel_id) {
+			self.ldk.handle_update_fail_htlc(their_node_id, msg);
+		} else {
+			self.eltoo.handle_update_fail_htlc(their_node_id, msg);
+		}
+	}
+
+	fn get_chain_hashes(&self) -> Option<Vec<ChainHash>> {
+		self.ldk.get_chain_hashes()
+	}
+
+	fn message_received(&self) {
+		self.ldk.message_received();
+	}
+}
+
+impl DualChannelMessageHandler {
+	fn is_ldk_channel(&self, channel_id: ChannelId) -> bool {
+		self.ldk.list_channels().iter().any(|details| details.channel_id == channel_id)
+	}
+}

--- a/src/eltoo.rs
+++ b/src/eltoo.rs
@@ -343,32 +343,49 @@ impl EltooRuntime {
 	async fn pump_events(&self) {
 		for event in self.manager.get_and_clear_events() {
 			match event {
-				EltooEvent::BroadcastTransaction { tx, anchor_outpoint: None } => {
-					self.tx_broadcaster.broadcast_transactions(&[(
-						&tx,
-						TransactionType::Sweep { channels: vec![] },
-					)]);
-				},
-				EltooEvent::BroadcastTransaction { tx, anchor_outpoint: Some(anchor) } => {
-					match self.build_anchor_child(&tx, anchor).await {
-						Ok(child) => {
-							self.tx_broadcaster.broadcast_transactions(&[
-								(&tx, TransactionType::Sweep { channels: vec![] }),
-								(&child, TransactionType::Sweep { channels: vec![] }),
-							]);
-						},
-						Err(()) => {
-							log_error!(
-								self.logger,
-								"Failed to build CPFP child for eltoo tx {}",
-								tx.compute_txid()
-							);
-						},
-					}
+				EltooEvent::BroadcastTransaction { tx, anchor_outpoint } => {
+					self.broadcast_package(tx, anchor_outpoint).await;
 				},
 				other => self.events.lock().unwrap().push(other),
 			}
 		}
+	}
+
+	/// Broadcasts an eltoo transaction — packaged with a wallet-funded CPFP child when
+	/// it carries a P2A anchor — and, on success, queues the broadcast as a user event
+	/// so the txid can be followed on-chain.
+	pub(crate) async fn broadcast_package(
+		&self, tx: Transaction, anchor_outpoint: Option<OutPoint>,
+	) {
+		match anchor_outpoint {
+			None => {
+				self.tx_broadcaster
+					.broadcast_transactions(&[(&tx, TransactionType::Sweep { channels: vec![] })]);
+			},
+			Some(anchor) => match self.build_anchor_child(&tx, anchor).await {
+				Ok(child) => {
+					log_debug!(
+						self.logger,
+						"Broadcasting eltoo package: parent {}, CPFP child {}",
+						tx.compute_txid(),
+						child.compute_txid()
+					);
+					self.tx_broadcaster.broadcast_transactions(&[
+						(&tx, TransactionType::Sweep { channels: vec![] }),
+						(&child, TransactionType::Sweep { channels: vec![] }),
+					]);
+				},
+				Err(()) => {
+					log_error!(
+						self.logger,
+						"Failed to build CPFP child for eltoo tx {}",
+						tx.compute_txid()
+					);
+					return;
+				},
+			},
+		}
+		self.events.lock().unwrap().push(EltooEvent::BroadcastTransaction { tx, anchor_outpoint });
 	}
 
 	/// Builds the CPFP child spending the P2A anchor (empty witness) plus one

--- a/src/eltoo.rs
+++ b/src/eltoo.rs
@@ -47,13 +47,12 @@ pub(crate) type EltooHandler = EltooMessageHandler<Arc<KeysManager>>;
 /// Fee reserved for a P2A anchor CPFP child (PoC: fixed, no estimation).
 const ANCHOR_CHILD_FEE: Amount = Amount::from_sat(20_000);
 
-/// An eltoo channel we opened, between channel creation and `channel_ready`.
+/// An eltoo channel we opened, between channel creation and its funding broadcast.
 struct PendingFunding {
 	/// The channel id — temporary until the funding tx is created, final afterwards.
 	channel_id: ChannelId,
 	capacity: Amount,
 	funding_txid: Option<Txid>,
-	ready_signalled: bool,
 }
 
 /// Owns the node-side glue around the sans-IO [`EltooChannelManager`]: the funding
@@ -70,6 +69,8 @@ pub(crate) struct EltooRuntime {
 	pending_funding: Mutex<Vec<PendingFunding>>,
 	/// Watched funding txids → confirmation height (once seen in a block).
 	confirmations: Mutex<HashMap<Txid, u32>>,
+	/// Channels whose `funding_confirmed` we already signalled.
+	ready_signalled: Mutex<Vec<ChannelId>>,
 	tip: AtomicU32,
 	/// Non-broadcast events, drained by the user via `Node::eltoo_events`.
 	events: Mutex<Vec<EltooEvent>>,
@@ -101,6 +102,7 @@ impl EltooRuntime {
 			logger,
 			pending_funding: Mutex::new(Vec::new()),
 			confirmations: Mutex::new(HashMap::new()),
+			ready_signalled: Mutex::new(Vec::new()),
 			tip: AtomicU32::new(best_height),
 			events: Mutex::new(Vec::new()),
 		}
@@ -117,7 +119,6 @@ impl EltooRuntime {
 			channel_id,
 			capacity: Amount::from_sat(capacity_sat),
 			funding_txid: None,
-			ready_signalled: false,
 		});
 	}
 
@@ -190,34 +191,26 @@ impl EltooRuntime {
 		}
 	}
 
-	/// Signals `funding_confirmed` once a funding tx has the configured depth.
+	/// Watches every not-yet-ready channel's funding txid — whether we or the peer
+	/// initiated — and signals `funding_confirmed` once it has the configured depth.
 	fn signal_confirmed_fundings(&self) {
 		let tip = self.tip();
 		let mut ready = Vec::new();
 		{
-			let confirmations = self.confirmations.lock().unwrap();
-			let mut pending = self.pending_funding.lock().unwrap();
-			for entry in pending.iter_mut() {
-				if entry.ready_signalled {
+			let mut confirmations = self.confirmations.lock().unwrap();
+			let signalled = self.ready_signalled.lock().unwrap();
+			for (channel_id, txid) in self.manager.channels_awaiting_funding() {
+				let height = *confirmations.entry(txid).or_insert(0);
+				if signalled.contains(&channel_id) || height == 0 {
 					continue;
 				}
-				let txid = match entry.funding_txid {
-					Some(txid) => txid,
-					None => continue,
-				};
-				match confirmations.get(&txid) {
-					Some(&height) if height > 0 => {
-						let depth = tip + 1 - height;
-						if depth >= self.config.minimum_depth {
-							entry.ready_signalled = true;
-							ready.push(entry.channel_id);
-						}
-					},
-					_ => {},
+				if tip + 1 - height >= self.config.minimum_depth {
+					ready.push(channel_id);
 				}
 			}
 		}
 		for channel_id in ready {
+			self.ready_signalled.lock().unwrap().push(channel_id);
 			if let Err(e) = self.manager.funding_confirmed(channel_id) {
 				log_error!(self.logger, "eltoo funding_confirmed failed: {:?}", e);
 			}

--- a/src/eltoo.rs
+++ b/src/eltoo.rs
@@ -11,12 +11,15 @@
 //! and the transaction broadcaster. Only the bitcoind chain source feeds eltoo
 //! channels; esplora/electrum do not.
 //!
-//! Scope mirrors the PoC: no persistence (channels do not survive restarts), no
-//! reorg handling, no routed payments (direct channels only, with out-of-band
-//! payment hashes standing in for invoices).
+//! Channels and their monitors are persisted to the node's KVStore per-update and
+//! reloaded on startup (see [`EltooRuntime::load_persisted_channels`] /
+//! [`EltooRuntime::persist_dirty_channels`]), so a channel survives a restart and can
+//! still be force-closed and settled afterwards. Scope otherwise mirrors the PoC: no
+//! reorg handling, no routed payments (direct channels only, with out-of-band payment
+//! hashes standing in for invoices).
 
 use crate::logger::{log_debug, log_error, LdkLogger, Logger};
-use crate::types::{Broadcaster, ChannelManager, KeysManager, Wallet};
+use crate::types::{Broadcaster, ChannelManager, DynStore, KeysManager, Wallet};
 
 use lightning::chain::chaininterface::{BroadcasterInterface, TransactionType};
 use lightning::chain::{BlockLocator, Listen};
@@ -27,6 +30,7 @@ use lightning::ln::msgs;
 use lightning::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, MessageSendEvent};
 use lightning::ln::types::ChannelId;
 use lightning::types::features::{InitFeatures, NodeFeatures};
+use lightning::util::persist::KVStore;
 use lightning::util::wallet_utils::WalletSource;
 
 use bitcoin::absolute::LockTime;
@@ -46,6 +50,18 @@ pub(crate) type EltooHandler = EltooMessageHandler<Arc<KeysManager>>;
 
 /// Fee reserved for a P2A anchor CPFP child (PoC: fixed, no estimation).
 const ANCHOR_CHILD_FEE: Amount = Amount::from_sat(20_000);
+
+/// KVStore namespace under which each eltoo channel's `(channel, monitor)` blob is
+/// persisted, keyed by channel id. Mirrors the persistence discipline of the regular
+/// `ChainMonitor`: the tip state (with its aggregate signature) must survive a restart,
+/// or the channel can no longer be force-closed or rebound against a stale broadcast.
+const ELTOO_PERSIST_PRIMARY_NAMESPACE: &str = "eltoo_channels";
+const ELTOO_PERSIST_SECONDARY_NAMESPACE: &str = "";
+
+/// The KVStore key for a channel's persisted state: its channel id, hex-encoded.
+fn channel_persist_key(channel_id: &ChannelId) -> String {
+	channel_id.0.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
 
 /// An eltoo channel we opened, between channel creation and its funding broadcast.
 struct PendingFunding {
@@ -74,13 +90,17 @@ pub(crate) struct EltooRuntime {
 	tip: AtomicU32,
 	/// Non-broadcast events, drained by the user via `Node::eltoo_events`.
 	events: Mutex<Vec<EltooEvent>>,
+	/// The persistence backend and the last bytes written per channel, so a channel is
+	/// only re-persisted when its serialized state actually changed (persist-on-update).
+	kv_store: Arc<DynStore>,
+	last_persisted: Mutex<HashMap<ChannelId, Vec<u8>>>,
 }
 
 impl EltooRuntime {
 	pub(crate) fn new(
 		node_id: PublicKey, keys_manager: Arc<KeysManager>, network: bitcoin::Network,
 		best_height: u32, wallet: Arc<Wallet>, tx_broadcaster: Arc<Broadcaster>,
-		logger: Arc<Logger>,
+		logger: Arc<Logger>, kv_store: Arc<DynStore>,
 	) -> Self {
 		let chain_hash = ChainHash::using_genesis_block(network);
 		let config = EltooChannelConfig::default();
@@ -105,6 +125,104 @@ impl EltooRuntime {
 			ready_signalled: Mutex::new(Vec::new()),
 			tip: AtomicU32::new(best_height),
 			events: Mutex::new(Vec::new()),
+			kv_store,
+			last_persisted: Mutex::new(HashMap::new()),
+		}
+	}
+
+	/// Reloads eltoo channels persisted before a restart. Each stored blob rebuilds a
+	/// channel and its monitor (their signers re-derived from the shared keys manager),
+	/// so the node can still force-close and settle a channel it opened in a prior run.
+	/// Called once at startup, before the background driver begins.
+	pub(crate) async fn load_persisted_channels(&self) {
+		let keys = match KVStore::list(
+			&*self.kv_store,
+			ELTOO_PERSIST_PRIMARY_NAMESPACE,
+			ELTOO_PERSIST_SECONDARY_NAMESPACE,
+		)
+		.await
+		{
+			Ok(keys) => keys,
+			Err(e) => {
+				log_error!(self.logger, "Failed to list persisted eltoo channels: {}", e);
+				return;
+			},
+		};
+		for key in keys {
+			let bytes = match KVStore::read(
+				&*self.kv_store,
+				ELTOO_PERSIST_PRIMARY_NAMESPACE,
+				ELTOO_PERSIST_SECONDARY_NAMESPACE,
+				&key,
+			)
+			.await
+			{
+				Ok(bytes) => bytes,
+				Err(e) => {
+					log_error!(
+						self.logger,
+						"Failed to read persisted eltoo channel {}: {}",
+						key,
+						e
+					);
+					continue;
+				},
+			};
+			match self.manager.load_persisted_channel(&bytes) {
+				Ok(channel_id) => {
+					self.last_persisted.lock().unwrap().insert(channel_id, bytes);
+					// A persisted channel is already ready (it owns a monitor); make sure
+					// the funding tracker never tries to re-signal its funding depth.
+					self.ready_signalled.lock().unwrap().push(channel_id);
+					log_debug!(self.logger, "Reloaded eltoo channel {}", channel_id);
+				},
+				Err(e) => {
+					log_error!(self.logger, "Failed to deserialize eltoo channel {}: {:?}", key, e);
+				},
+			}
+		}
+	}
+
+	/// Persists every ready channel whose serialized state changed since it was last
+	/// written. Called after each driver pass (persist-on-update): the blob is O(1) per
+	/// channel, so re-serializing to diff it is cheap.
+	async fn persist_dirty_channels(&self) {
+		let to_write: Vec<(ChannelId, String, Vec<u8>)> = {
+			let cache = self.last_persisted.lock().unwrap();
+			self.manager
+				.persistable_channel_ids()
+				.into_iter()
+				.filter_map(|channel_id| {
+					let bytes = self.manager.serialize_channel_state(channel_id)?;
+					if cache.get(&channel_id) == Some(&bytes) {
+						return None;
+					}
+					Some((channel_id, channel_persist_key(&channel_id), bytes))
+				})
+				.collect()
+		};
+		for (channel_id, key, bytes) in to_write {
+			match KVStore::write(
+				&*self.kv_store,
+				ELTOO_PERSIST_PRIMARY_NAMESPACE,
+				ELTOO_PERSIST_SECONDARY_NAMESPACE,
+				&key,
+				bytes.clone(),
+			)
+			.await
+			{
+				Ok(()) => {
+					self.last_persisted.lock().unwrap().insert(channel_id, bytes);
+				},
+				Err(e) => {
+					log_error!(
+						self.logger,
+						"Failed to persist eltoo channel {}: {}",
+						channel_id,
+						e
+					);
+				},
+			}
 		}
 	}
 
@@ -133,6 +251,9 @@ impl EltooRuntime {
 		self.fund_accepted_channels();
 		self.signal_confirmed_fundings();
 		self.pump_events().await;
+		// Persist any channel whose state changed this pass (a new state was committed or
+		// advanced, a preimage learned, an on-chain status moved).
+		self.persist_dirty_channels().await;
 	}
 
 	/// For each pending channel whose handshake completed, build, broadcast and

--- a/src/event.rs
+++ b/src/event.rs
@@ -29,7 +29,7 @@ use lightning::util::config::{ChannelConfigOverrides, ChannelConfigUpdate};
 use lightning::util::errors::APIError;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
-use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 use lightning_liquidity::lsps2::utils::compute_opening_fee;
 use lightning_types::payment::{PaymentHash, PaymentPreimage};
 
@@ -78,7 +78,7 @@ pub struct HTLCLocator {
 	pub node_id: Option<PublicKey>,
 }
 
-impl_writeable_tlv_based!(HTLCLocator, {
+impl_ser_tlv_based!(HTLCLocator, {
 	(1, channel_id, required),
 	(3, user_channel_id, option),
 	(5, node_id, option),
@@ -294,7 +294,7 @@ pub enum Event {
 	},
 }
 
-impl_writeable_tlv_based_enum!(Event,
+impl_ser_tlv_based_enum!(Event,
 	(0, PaymentSuccessful) => {
 		(0, payment_hash, required),
 		(1, fee_paid_msat, option),
@@ -1725,7 +1725,21 @@ where
 
 				self.bump_tx_event_handler.handle_event(&bte).await;
 			},
-			LdkEvent::OnionMessageIntercepted { peer_node_id, message } => {
+			LdkEvent::OnionMessageIntercepted { prev_hop: _, next_hop, message } => {
+				// We only intercept messages for offline peers (known node ids), never for
+				// unknown SCIDs (`intercept_for_unknown_scids` is disabled at construction).
+				let peer_node_id = match next_hop {
+					lightning::blinded_path::message::NextMessageHop::NodeId(node_id) => node_id,
+					lightning::blinded_path::message::NextMessageHop::ShortChannelId(scid) => {
+						debug_assert!(false, "Unexpected onion message interception for SCID");
+						log_trace!(
+							self.logger,
+							"Ignoring intercepted onion message for unknown SCID {}",
+							scid
+						);
+						return Ok(());
+					},
+				};
 				if let Some(om_mailbox) = self.om_mailbox.as_ref() {
 					om_mailbox.onion_message_intercepted(peer_node_id, message);
 				} else {

--- a/src/io/vss_store.rs
+++ b/src/io/vss_store.rs
@@ -21,7 +21,7 @@ use bitcoin::bip32::{ChildNumber, Xpriv};
 use bitcoin::hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use bitcoin::key::Secp256k1;
 use bitcoin::Network;
-use lightning::impl_writeable_tlv_based_enum;
+use lightning::impl_ser_tlv_based_enum;
 use lightning::io::{self, Error, ErrorKind};
 use lightning::sign::{EntropySource as LdkEntropySource, RandomBytes};
 use lightning::util::persist::{
@@ -67,7 +67,7 @@ enum VssSchemaVersion {
 	V1,
 }
 
-impl_writeable_tlv_based_enum!(VssSchemaVersion,
+impl_ser_tlv_based_enum!(VssSchemaVersion,
 	(0, V0) => {},
 	(1, V1) => {},
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod chain;
 pub mod config;
 mod connection;
 mod data_store;
+mod eltoo;
 pub mod entropy;
 mod error;
 mod event;
@@ -146,13 +147,14 @@ use graph::NetworkGraph;
 use io::utils::update_and_persist_node_metrics;
 pub use lightning;
 use lightning::chain::BlockLocator;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::chan_utils::FUNDING_TRANSACTION_WITNESS_WEIGHT;
 use lightning::ln::channel_state::ChannelDetails as LdkChannelDetails;
 pub use lightning::ln::channel_state::ChannelShutdownState;
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::msgs::{BaseMessageHandler, SocketAddress};
 use lightning::ln::peer_handler::CustomMessageHandler;
+use lightning::ln::types::ChannelId;
 use lightning::routing::gossip::NodeAlias;
 use lightning::sign::EntropySource;
 use lightning::util::persist::KVStore;
@@ -162,6 +164,7 @@ pub use lightning_invoice;
 pub use lightning_liquidity;
 pub use lightning_types;
 use lightning_types::features::NodeFeatures as LdkNodeFeatures;
+use lightning_types::payment::{PaymentHash, PaymentPreimage};
 use liquidity::LiquiditySource;
 use lnurl_auth::LnurlAuth;
 use logger::{log_debug, log_error, log_info, log_trace, LdkLogger, Logger};
@@ -250,6 +253,7 @@ pub struct Node {
 	om_mailbox: Option<Arc<OnionMessageMailbox>>,
 	async_payments_role: Option<AsyncPaymentsRole>,
 	hrn_resolver: HRNResolver,
+	eltoo: Arc<crate::eltoo::EltooRuntime>,
 	#[cfg(cycle_tests)]
 	_leak_checker: LeakChecker,
 }
@@ -296,6 +300,7 @@ impl Node {
 		let sync_cman = Arc::clone(&self.channel_manager);
 		let sync_cmon = Arc::clone(&self.chain_monitor);
 		let sync_sweeper = Arc::clone(&self.output_sweeper);
+		let sync_eltoo = Arc::clone(&self.eltoo);
 		self.runtime.spawn_background_task(async move {
 			chain_source
 				.continuously_sync_wallets(
@@ -304,8 +309,31 @@ impl Node {
 					sync_cman,
 					sync_cmon,
 					sync_sweeper,
+					sync_eltoo,
 				)
 				.await;
+		});
+
+		// Spawn the eltoo driver: funds accepted eltoo channels, pumps broadcasts
+		// (with P2A CPFP children) and flushes outbound eltoo messages.
+		let eltoo_runtime = Arc::clone(&self.eltoo);
+		let eltoo_peer_manager = Arc::clone(&self.peer_manager);
+		let mut stop_eltoo = self.stop_sender.subscribe();
+		self.runtime.spawn_cancellable_background_task(async move {
+			let mut interval = tokio::time::interval(Duration::from_millis(100));
+			interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+			loop {
+				tokio::select! {
+					biased;
+					_ = stop_eltoo.changed() => {
+						return;
+					}
+					_ = interval.tick() => {
+						eltoo_runtime.process().await;
+						eltoo_peer_manager.process_events();
+					}
+				}
+			}
 		});
 
 		if self.gossip_source.is_rgs() {
@@ -1924,6 +1952,7 @@ impl Node {
 		let sync_cman = Arc::clone(&self.channel_manager);
 		let sync_cmon = Arc::clone(&self.chain_monitor);
 		let sync_sweeper = Arc::clone(&self.output_sweeper);
+		let sync_eltoo = Arc::clone(&self.eltoo);
 		self.runtime.block_on(async move {
 			if chain_source.is_transaction_based() {
 				chain_source.update_fee_rate_estimates().await?;
@@ -1939,12 +1968,87 @@ impl Node {
 						sync_cman,
 						sync_cmon,
 						Arc::clone(&sync_sweeper),
+						sync_eltoo,
 					)
 					.await?;
 			}
 			let _ = sync_sweeper.regenerate_and_broadcast_spend_if_necessary().await;
 			Ok(())
 		})
+	}
+
+	/// Opens an experimental eltoo (LN-Symmetry over BIP-448) channel with the given peer,
+	/// funded from the on-chain wallet. Returns the temporary channel id; the final id is
+	/// reported via the `ChannelReady` event in [`Node::eltoo_events`] once the funding
+	/// transaction (created and broadcast automatically after the peer accepts) confirms.
+	///
+	/// Eltoo channels are in-memory only (they do not survive restarts) and require a
+	/// bitcoind chain source and a BIP-448-patched Bitcoin Core.
+	pub fn open_eltoo_channel(
+		&self, node_id: PublicKey, address: SocketAddress, channel_amount_sats: u64,
+		push_to_counterparty_msat: u64,
+	) -> Result<ChannelId, Error> {
+		if !*self.is_running.read().expect("lock") {
+			return Err(Error::NotRunning);
+		}
+		self.connect(node_id, address, false)?;
+		let temp_id = self.eltoo.manager.create_channel(
+			node_id,
+			channel_amount_sats,
+			push_to_counterparty_msat,
+		);
+		self.eltoo.register_pending_channel(temp_id, channel_amount_sats);
+		self.peer_manager.process_events();
+		Ok(temp_id)
+	}
+
+	/// Registers a payment to be received over an eltoo channel, returning the payment
+	/// hash for the sender (communicated out-of-band; the PoC has no invoices).
+	pub fn eltoo_receive_payment(&self) -> PaymentHash {
+		let preimage = PaymentPreimage(self.keys_manager.get_secure_random_bytes());
+		self.eltoo.manager.register_payment(preimage)
+	}
+
+	/// Sends a payment over the given (direct) eltoo channel.
+	pub fn send_eltoo_payment(
+		&self, channel_id: ChannelId, amount_msat: u64, payment_hash: PaymentHash,
+	) -> Result<(), Error> {
+		let cltv_expiry = self.eltoo.tip() + 300;
+		self.eltoo
+			.manager
+			.send_payment(channel_id, amount_msat, payment_hash, cltv_expiry)
+			.map_err(|e| {
+				log_error!(self.logger, "Failed to send eltoo payment: {:?}", e);
+				Error::PaymentSendingFailed
+			})?;
+		self.peer_manager.process_events();
+		Ok(())
+	}
+
+	/// Cooperatively closes the given eltoo channel, paying our balance to the on-chain
+	/// wallet.
+	pub fn close_eltoo_channel(&self, channel_id: ChannelId) -> Result<(), Error> {
+		let address = self.wallet.get_new_address().map_err(|e| {
+			log_error!(self.logger, "Failed to retrieve new address from wallet: {}", e);
+			Error::ChannelClosingFailed
+		})?;
+		self.eltoo.manager.close_channel(channel_id, address.script_pubkey()).map_err(|e| {
+			log_error!(self.logger, "Failed to close eltoo channel: {:?}", e);
+			Error::ChannelClosingFailed
+		})?;
+		self.peer_manager.process_events();
+		Ok(())
+	}
+
+	/// Force-closes the given eltoo channel by broadcasting the latest state; the
+	/// settlement follows after the shared delay, driven by chain sync.
+	pub fn force_close_eltoo_channel(&self, channel_id: ChannelId) {
+		self.eltoo.manager.force_close_channel(channel_id);
+	}
+
+	/// Drains the pending eltoo events (channels becoming ready, payment outcomes, ...).
+	pub fn eltoo_events(&self) -> Vec<lightning::ln::eltoo::channelmanager::EltooEvent> {
+		self.eltoo.take_events()
 	}
 
 	/// Close a previously opened channel.
@@ -2365,7 +2469,7 @@ impl PersistedNodeMetrics {
 	}
 }
 
-impl_writeable_tlv_based!(NodeMetrics, {
+impl_ser_tlv_based!(NodeMetrics, {
 	(0, latest_lightning_wallet_sync_timestamp, option),
 	(1, latest_pathfinding_scores_sync_timestamp, option),
 	(2, latest_onchain_wallet_sync_timestamp, option),
@@ -2435,7 +2539,7 @@ mod tests {
 			latest_pathfinding_scores_sync_timestamp: Option<u64>,
 			latest_node_announcement_broadcast_timestamp: Option<u64>,
 		}
-		impl_writeable_tlv_based!(OldNodeMetrics, {
+		impl_ser_tlv_based!(OldNodeMetrics, {
 			(0, latest_lightning_wallet_sync_timestamp, option),
 			(1, latest_pathfinding_scores_sync_timestamp, option),
 			(2, latest_onchain_wallet_sync_timestamp, option),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2046,9 +2046,40 @@ impl Node {
 		self.eltoo.manager.force_close_channel(channel_id);
 	}
 
-	/// Drains the pending eltoo events (channels becoming ready, payment outcomes, ...).
+	/// Drains the pending eltoo events (channels becoming ready, payment outcomes,
+	/// transactions broadcast, ...).
 	pub fn eltoo_events(&self) -> Vec<lightning::ln::eltoo::channelmanager::EltooEvent> {
 		self.eltoo.take_events()
+	}
+
+	/// Lists all eltoo channels with a point-in-time summary of each.
+	pub fn list_eltoo_channels(
+		&self,
+	) -> Vec<lightning::ln::eltoo::channelmanager::EltooChannelDetails> {
+		self.eltoo.manager.list_channels()
+	}
+
+	/// Returns the given eltoo channel's latest fully-signed update transaction and its
+	/// P2A anchor outpoint, exactly as a force-close would broadcast them right now —
+	/// without broadcasting anything. A caller can hold the result while the channel
+	/// advances further and later hand it to [`Node::broadcast_eltoo_package`] to
+	/// deliberately publish a stale state (for demos/testing of the rebind response).
+	pub fn eltoo_signed_update_package(
+		&self, channel_id: ChannelId,
+	) -> Result<(bitcoin::Transaction, bitcoin::OutPoint), Error> {
+		self.eltoo.manager.signed_update_package(channel_id).ok_or(Error::InvalidChannelId)
+	}
+
+	/// Broadcasts an eltoo update transaction, attaching a wallet-funded CPFP child on
+	/// its P2A anchor for fees.
+	pub fn broadcast_eltoo_package(
+		&self, tx: bitcoin::Transaction, anchor_outpoint: bitcoin::OutPoint,
+	) -> Result<(), Error> {
+		if !*self.is_running.read().expect("lock") {
+			return Err(Error::NotRunning);
+		}
+		self.runtime.block_on(self.eltoo.broadcast_package(tx, Some(anchor_outpoint)));
+		Ok(())
 	}
 
 	/// Close a previously opened channel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1982,8 +1982,8 @@ impl Node {
 	/// reported via the `ChannelReady` event in [`Node::eltoo_events`] once the funding
 	/// transaction (created and broadcast automatically after the peer accepts) confirms.
 	///
-	/// Eltoo channels are in-memory only (they do not survive restarts) and require a
-	/// bitcoind chain source and a BIP-448-patched Bitcoin Core.
+	/// Eltoo channels are persisted (channel + monitor) and survive restarts, but require
+	/// a bitcoind chain source and a BIP-448-patched Bitcoin Core.
 	pub fn open_eltoo_channel(
 		&self, node_id: PublicKey, address: SocketAddress, channel_amount_sats: u64,
 		push_to_counterparty_msat: u64,

--- a/src/payment/asynchronous/static_invoice_store.rs
+++ b/src/payment/asynchronous/static_invoice_store.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use lightning::blinded_path::message::BlindedMessagePath;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::offers::static_invoice::StaticInvoice;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::{Readable, Writeable};
@@ -28,7 +28,7 @@ struct PersistedStaticInvoice {
 	request_path: BlindedMessagePath,
 }
 
-impl_writeable_tlv_based!(PersistedStaticInvoice, {
+impl_ser_tlv_based!(PersistedStaticInvoice, {
 	(0, invoice, required),
 	(2, request_path, required)
 });

--- a/src/payment/bolt11.rs
+++ b/src/payment/bolt11.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock};
 
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::channelmanager::{
 	Bolt11InvoiceParameters, OptionalBolt11PaymentParams, PaymentId,
 };
@@ -55,7 +55,7 @@ pub(crate) struct PaymentMetadata {
 	pub(crate) lsps2_parameters: Option<LSPS2Parameters>,
 }
 
-impl_writeable_tlv_based!(PaymentMetadata, {
+impl_ser_tlv_based!(PaymentMetadata, {
 	(0, lsps2_parameters, option),
 });
 
@@ -313,7 +313,7 @@ impl Bolt11Payment {
 				let payee_pubkey = invoice.recover_payee_pub_key();
 				log_info!(
 					self.logger,
-					"Initiated sending {} msat to {}",
+					"Initiated sending {} msat to {:?}",
 					payment_amount_msat,
 					payee_pubkey
 				);

--- a/src/payment/pending_payment_store.rs
+++ b/src/payment/pending_payment_store.rs
@@ -6,7 +6,7 @@
 // accordance with one or both of these licenses.
 
 use bitcoin::Txid;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::channelmanager::PaymentId;
 
 use crate::data_store::{StorableObject, StorableObjectUpdate};
@@ -30,7 +30,7 @@ pub(crate) struct FundingTxCandidate {
 	pub fee_paid_msat: Option<u64>,
 }
 
-impl_writeable_tlv_based!(FundingTxCandidate, {
+impl_ser_tlv_based!(FundingTxCandidate, {
 	(0, txid, required),
 	(2, amount_msat, option),
 	(4, fee_paid_msat, option),
@@ -62,7 +62,7 @@ impl PendingPaymentDetails {
 	}
 }
 
-impl_writeable_tlv_based!(PendingPaymentDetails, {
+impl_ser_tlv_based!(PendingPaymentDetails, {
 	(0, details, required),
 	(2, conflicting_txids, optional_vec),
 	(4, candidates, optional_vec),

--- a/src/payment/store.rs
+++ b/src/payment/store.rs
@@ -16,8 +16,8 @@ use lightning::ln::types::ChannelId;
 use lightning::offers::offer::OfferId;
 use lightning::util::ser::{Readable, Writeable};
 use lightning::{
-	_init_and_read_len_prefixed_tlv_fields, impl_writeable_tlv_based,
-	impl_writeable_tlv_based_enum, write_tlv_fields,
+	_init_and_read_len_prefixed_tlv_fields, impl_ser_tlv_based, impl_ser_tlv_based_enum,
+	write_tlv_fields,
 };
 use lightning_types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning_types::string::UntrustedString;
@@ -319,7 +319,7 @@ pub enum PaymentDirection {
 	Outbound,
 }
 
-impl_writeable_tlv_based_enum!(PaymentDirection,
+impl_ser_tlv_based_enum!(PaymentDirection,
 	(0, Inbound) => {},
 	(1, Outbound) => {}
 );
@@ -336,7 +336,7 @@ pub enum PaymentStatus {
 	Failed,
 }
 
-impl_writeable_tlv_based_enum!(PaymentStatus,
+impl_ser_tlv_based_enum!(PaymentStatus,
 	(0, Pending) => {},
 	(2, Succeeded) => {},
 	(4, Failed) => {}
@@ -352,7 +352,7 @@ pub struct Channel {
 	pub channel_id: ChannelId,
 }
 
-impl_writeable_tlv_based!(Channel, {
+impl_ser_tlv_based!(Channel, {
 	(0, counterparty_node_id, required),
 	(2, channel_id, required),
 });
@@ -412,7 +412,7 @@ pub enum TransactionType {
 	},
 }
 
-impl_writeable_tlv_based_enum!(TransactionType,
+impl_ser_tlv_based_enum!(TransactionType,
 	(0, Funding) => {
 		(0, channels, optional_vec),
 	},
@@ -587,7 +587,7 @@ pub enum PaymentKind {
 	},
 }
 
-impl_writeable_tlv_based_enum!(PaymentKind,
+impl_ser_tlv_based_enum!(PaymentKind,
 	(0, Onchain) => {
 		(0, txid, required),
 		(1, tx_type, option),
@@ -647,7 +647,7 @@ pub enum ConfirmationStatus {
 	Unconfirmed,
 }
 
-impl_writeable_tlv_based_enum!(ConfirmationStatus,
+impl_ser_tlv_based_enum!(ConfirmationStatus,
 	(0, Confirmed) => {
 		(0, block_hash, required),
 		(2, height, required),
@@ -672,7 +672,7 @@ pub struct LSPS2Parameters {
 	pub max_proportional_opening_fee_ppm_msat: Option<u64>,
 }
 
-impl_writeable_tlv_based!(LSPS2Parameters, {
+impl_ser_tlv_based!(LSPS2Parameters, {
 	(0, max_total_opening_fee_msat, option),
 	(2, max_proportional_opening_fee_ppm_msat, option),
 });
@@ -777,7 +777,7 @@ mod tests {
 		pub status: PaymentStatus,
 	}
 
-	impl_writeable_tlv_based!(OldPaymentDetails, {
+	impl_ser_tlv_based!(OldPaymentDetails, {
 		(0, hash, required),
 		(2, preimage, required),
 		(4, secret, required),
@@ -876,7 +876,7 @@ mod tests {
 		status: ConfirmationStatus,
 	}
 
-	impl_writeable_tlv_based!(OldOnchainKind, {
+	impl_ser_tlv_based!(OldOnchainKind, {
 		(0, txid, required),
 		(2, status, required),
 	});
@@ -930,7 +930,7 @@ mod tests {
 		lsp_fee_limits: LSPS2Parameters,
 	}
 
-	impl_writeable_tlv_based!(LegacyBolt11JitKind, {
+	impl_ser_tlv_based!(LegacyBolt11JitKind, {
 		(0, hash, required),
 		(1, counterparty_skimmed_fee_msat, option),
 		(2, preimage, option),

--- a/src/peer_store.rs
+++ b/src/peer_store.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
 use bitcoin::secp256k1::PublicKey;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
 
@@ -160,7 +160,7 @@ pub(crate) struct PeerInfo {
 	pub address: SocketAddress,
 }
 
-impl_writeable_tlv_based!(PeerInfo, {
+impl_ser_tlv_based!(PeerInfo, {
 	(0, node_id, required),
 	(2, address, required),
 });

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ use bitcoin_payment_instructions::hrn_resolution::{
 };
 use bitcoin_payment_instructions::onion_message_resolver::LDKOnionMessageDNSSECHrnResolver;
 use lightning::chain::chainmonitor;
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::channel_state::{
 	ChannelDetails as LdkChannelDetails, ChannelShutdownState, CounterpartyForwardingInfo,
 };
@@ -238,7 +238,9 @@ pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
 
 pub(crate) type PeerManager = lightning::ln::peer_handler::PeerManager<
 	SocketDescriptor,
-	Arc<ChannelManager>,
+	// Routes LN-penalty channel messages to the ChannelManager and eltoo channel
+	// messages to the EltooChannelManager.
+	Arc<crate::eltoo::DualChannelMessageHandler>,
 	Arc<dyn RoutingMessageHandler + Send + Sync>,
 	Arc<OnionMessenger>,
 	Arc<Logger>,
@@ -744,7 +746,7 @@ pub struct CustomTlvRecord {
 	pub value: Vec<u8>,
 }
 
-impl_writeable_tlv_based!(CustomTlvRecord, {
+impl_ser_tlv_based!(CustomTlvRecord, {
 	(0, type_num, required),
 	(2, value, required),
 });

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2072,6 +2072,13 @@ impl lightning::sign::eltoo::EltooSignerProvider for WalletKeysManager {
 	fn derive_eltoo_channel_signer(&self, channel_keys_id: [u8; 32]) -> Self::EltooSigner {
 		self.inner.derive_eltoo_channel_signer(channel_keys_id)
 	}
+
+	fn get_shutdown_scriptpubkey(&self) -> Result<ScriptBuf, ()> {
+		let address = self.wallet.get_new_address().map_err(|e| {
+			log_error!(self.logger, "Failed to retrieve new address from wallet: {}", e);
+		})?;
+		Ok(address.script_pubkey())
+	}
 }
 
 impl ChangeDestinationSource for WalletKeysManager {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2062,6 +2062,18 @@ impl SignerProvider for WalletKeysManager {
 	}
 }
 
+impl lightning::sign::eltoo::EltooSignerProvider for WalletKeysManager {
+	type EltooSigner = lightning::sign::eltoo::InMemoryEltooSigner;
+
+	fn generate_eltoo_channel_keys_id(&self, inbound: bool, user_channel_id: u128) -> [u8; 32] {
+		self.inner.generate_eltoo_channel_keys_id(inbound, user_channel_id)
+	}
+
+	fn derive_eltoo_channel_signer(&self, channel_keys_id: [u8; 32]) -> Self::EltooSigner {
+		self.inner.derive_eltoo_channel_signer(channel_keys_id)
+	}
+}
+
 impl ChangeDestinationSource for WalletKeysManager {
 	fn get_change_destination_script<'a>(
 		&'a self,

--- a/tests/integration_tests_eltoo.rs
+++ b/tests/integration_tests_eltoo.rs
@@ -84,22 +84,33 @@ impl Harness {
 	}
 
 	fn make_node(&self) -> Node {
-		let mut storage: PathBuf = std::env::temp_dir();
-		storage.push(format!("eltoo-node-{}", NEXT_PORT.fetch_add(0, Ordering::Relaxed)));
-		storage.push(format!("{}", rand_suffix()));
-		let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+		self.start_node(&self.new_node_setup())
+	}
 
+	/// Fresh, restart-stable node identity: a storage directory, wallet entropy and
+	/// listening port that stay fixed across restarts (so the KVStore-backed state — the
+	/// BDK wallet and now the eltoo channels/monitors — is reloaded).
+	fn new_node_setup(&self) -> NodeSetup {
+		let mut storage: PathBuf = std::env::temp_dir();
+		storage.push(format!("eltoo-node-{}", rand_suffix()));
+		let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+		let entropy = NodeEntropy::from_bip39_mnemonic(generate_entropy_mnemonic(None), None);
+		NodeSetup { storage: storage.to_str().unwrap().to_string(), entropy, port }
+	}
+
+	/// Builds and starts a node for the given (possibly reused) setup.
+	fn start_node(&self, setup: &NodeSetup) -> Node {
 		let rpc_host = self.bitcoind.params.rpc_socket.ip().to_string();
 		let rpc_port = self.bitcoind.params.rpc_socket.port();
 		let cookie = self.bitcoind.params.get_cookie_values().unwrap().unwrap();
 
 		let mut builder = Builder::new();
 		builder.set_network(Network::Regtest);
-		eprintln!("node storage: {}", storage.display());
-		builder.set_storage_dir_path(storage.to_str().unwrap().to_string());
+		eprintln!("node storage: {}", setup.storage);
+		builder.set_storage_dir_path(setup.storage.clone());
 		builder.set_filesystem_logger(None, Some(ldk_node::logger::LogLevel::Trace));
 		builder
-			.set_listening_addresses(vec![format!("127.0.0.1:{}", port).parse().unwrap()])
+			.set_listening_addresses(vec![format!("127.0.0.1:{}", setup.port).parse().unwrap()])
 			.unwrap();
 		builder.set_chain_source_bitcoind_rpc(
 			rpc_host,
@@ -108,11 +119,41 @@ impl Harness {
 			cookie.password,
 			None,
 		);
-		let entropy = NodeEntropy::from_bip39_mnemonic(generate_entropy_mnemonic(None), None);
-		let node = builder.build(entropy).unwrap();
+		let node = builder.build(setup.entropy).unwrap();
 		node.start().unwrap();
 		node
 	}
+
+	/// Scans confirmed blocks for the channel funding output (the capacity-value output).
+	fn find_funding_outpoint(&self) -> OutPoint {
+		let mut found = None;
+		for height in 100..=self.tip() {
+			let hash = self
+				.bitcoind
+				.client
+				.get_block_hash(height as u64)
+				.expect("getblockhash")
+				.into_model()
+				.expect("hash")
+				.0;
+			let block = self.bitcoind.client.get_block(hash).expect("getblock");
+			for tx in block.txdata {
+				if let Some(vout) =
+					tx.output.iter().position(|out| out.value == Amount::from_sat(CAPACITY_SAT))
+				{
+					found = Some(OutPoint { txid: tx.compute_txid(), vout: vout as u32 });
+				}
+			}
+		}
+		found.expect("funding tx confirmed")
+	}
+}
+
+/// A restart-stable node identity (storage + entropy + port).
+struct NodeSetup {
+	storage: String,
+	entropy: NodeEntropy,
+	port: u16,
 }
 
 fn rand_suffix() -> u64 {
@@ -304,6 +345,97 @@ fn eltoo_force_close_settles_over_tcp() {
 	let state_outpoint = OutPoint { txid: update_tx.compute_txid(), vout: 2 };
 	let settlement_tx =
 		harness.find_spending_tx(state_outpoint, settle_from).expect("settlement must confirm");
+	assert_eq!(settlement_tx.input[0].witness.len(), 2, "covenant spend: [leaf, control]");
+
+	a.stop().unwrap();
+	b.stop().unwrap();
+}
+
+#[test]
+fn eltoo_channel_survives_restart_and_force_closes() {
+	let harness = match Harness::start() {
+		Some(harness) => harness,
+		None => return,
+	};
+	// Both nodes get restart-stable identities so their KVStore-backed state (BDK wallet
+	// + eltoo channels/monitors) reloads after a stop/start.
+	let setup_a = harness.new_node_setup();
+	let setup_b = harness.new_node_setup();
+	let a = harness.start_node(&setup_a);
+	let b = harness.start_node(&setup_b);
+
+	let addr_a = a.onchain_payment().new_address().expect("address");
+	harness.fund(&addr_a, Amount::from_sat(10_000_000));
+	settle(&[&a, &b]);
+
+	// Open an eltoo channel and make one payment, so the persisted tip is not state 0.
+	let b_addr = b.listening_addresses().unwrap()[0].clone();
+	a.open_eltoo_channel(b.node_id(), b_addr, CAPACITY_SAT, 0).expect("open");
+	let channel_id: ChannelId = wait_for_event(&harness, &[&a, &b], &a, 30, |event| match event {
+		EltooEvent::ChannelReady { channel_id } => Some(*channel_id),
+		_ => None,
+	});
+	wait_for_event(&harness, &[&a, &b], &b, 10, |event| match event {
+		EltooEvent::ChannelReady { channel_id: id } if *id == channel_id => Some(()),
+		_ => None,
+	});
+
+	let payment_hash = b.eltoo_receive_payment();
+	a.send_eltoo_payment(channel_id, 100_000_000, payment_hash).expect("send");
+	wait_for_event(&harness, &[&a, &b], &a, 10, |event| match event {
+		EltooEvent::PaymentFulfilled { .. } => Some(()),
+		_ => None,
+	});
+
+	// Give the background driver a few passes to flush the per-update persistence.
+	settle(&[&a, &b]);
+	settle(&[&a, &b]);
+
+	let funding_outpoint = harness.find_funding_outpoint();
+
+	// Restart both nodes from their existing storage: the eltoo channels and monitors are
+	// re-read from the KVStore (their signers re-derived from the persisted key ids).
+	a.stop().unwrap();
+	b.stop().unwrap();
+	drop(a);
+	drop(b);
+	let a = harness.start_node(&setup_a);
+	let b = harness.start_node(&setup_b);
+	settle(&[&a, &b]);
+
+	// The reloaded node force-closes: this only succeeds if the monitor's tip state — and
+	// its aggregate signature — survived the restart. A lost monitor could not produce a
+	// valid update transaction here.
+	let close_from = harness.tip() + 1;
+	a.force_close_eltoo_channel(channel_id);
+	settle(&[&a, &b]);
+	harness.mine(1);
+	settle(&[&a, &b]);
+	let update_tx = harness
+		.find_spending_tx(funding_outpoint, close_from)
+		.expect("update tx must confirm after restart");
+	assert_eq!(update_tx.input[0].witness.len(), 3, "script-path: [sig, leaf, control]");
+
+	// And its signature-free settlement follows after the shared delay, exactly as for a
+	// channel that never restarted.
+	harness.mine(144);
+	let state_outpoint = OutPoint { txid: update_tx.compute_txid(), vout: 2 };
+	let settle_from = harness.tip() + 1;
+	// Poll: let the reloaded monitor broadcast the settlement once the delay matures, then
+	// mine it in. (The broadcast lands a driver tick after the maturing block is synced.)
+	let settlement_tx = {
+		let mut found = None;
+		for _ in 0..20 {
+			settle(&[&a, &b]);
+			harness.mine(1);
+			settle(&[&a, &b]);
+			if let Some(tx) = harness.find_spending_tx(state_outpoint, settle_from) {
+				found = Some(tx);
+				break;
+			}
+		}
+		found.expect("settlement must confirm after restart")
+	};
 	assert_eq!(settlement_tx.input[0].witness.len(), 2, "covenant spend: [leaf, control]");
 
 	a.stop().unwrap();

--- a/tests/integration_tests_eltoo.rs
+++ b/tests/integration_tests_eltoo.rs
@@ -1,0 +1,311 @@
+// This file is Copyright its authors and licensed under the Apache License, Version 2.0 or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option. You may not use this
+// file except in accordance with one or both of these licenses.
+
+//! Two-node eltoo integration test: two `Node`s talking over real TCP, backed by a
+//! real regtest bitcoind, open an eltoo channel funded by the BDK wallet, pay over
+//! it, and close it — cooperatively and by force (update → shared delay →
+//! settlement), with every transaction accepted by real consensus.
+//!
+//! Requires `BITCOIND_EXE` to point at a bitcoind built from the BIP-448 branch
+//! (https://github.com/bip448/bitcoin/pull/1); the test is skipped otherwise.
+
+use ldk_node::entropy::{generate_entropy_mnemonic, NodeEntropy};
+use ldk_node::lightning::ln::eltoo::channelmanager::EltooEvent;
+use ldk_node::lightning::ln::types::ChannelId;
+use ldk_node::{Builder, Node};
+
+use electrsd::corepc_node::{Conf, Node as BitcoinD};
+
+use bitcoin::{Address, Amount, Network, OutPoint, Transaction};
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::Duration;
+
+const CAPACITY_SAT: u64 = 1_000_000;
+static NEXT_PORT: AtomicU16 = AtomicU16::new(23_000);
+
+struct Harness {
+	bitcoind: BitcoinD,
+}
+
+impl Harness {
+	fn start() -> Option<Self> {
+		let exe = match std::env::var("BITCOIND_EXE") {
+			Ok(exe) => exe,
+			Err(_) => {
+				eprintln!(
+					"BITCOIND_EXE unset; skipping eltoo integration test (needs a BIP-448 bitcoind)"
+				);
+				return None;
+			},
+		};
+		let conf = Conf::default();
+		let bitcoind = BitcoinD::with_conf(exe, &conf).expect("failed to start bitcoind");
+		let harness = Harness { bitcoind };
+		harness.mine(101);
+		Some(harness)
+	}
+
+	fn mine(&self, blocks: usize) {
+		let addr = self.bitcoind.client.new_address().expect("new address");
+		self.bitcoind.client.generate_to_address(blocks, &addr).expect("generate");
+	}
+
+	fn fund(&self, address: &Address, amount: Amount) {
+		self.bitcoind.client.send_to_address(address, amount).expect("sendtoaddress");
+		self.mine(1);
+	}
+
+	fn tip(&self) -> u32 {
+		self.bitcoind.client.get_block_count().expect("getblockcount").0 as u32
+	}
+
+	/// Finds a confirmed transaction spending `outpoint`, scanning from `from_height`.
+	fn find_spending_tx(&self, outpoint: OutPoint, from_height: u32) -> Option<Transaction> {
+		for height in from_height..=self.tip() {
+			let hash = self
+				.bitcoind
+				.client
+				.get_block_hash(height as u64)
+				.expect("getblockhash")
+				.into_model()
+				.expect("hash")
+				.0;
+			let block = self.bitcoind.client.get_block(hash).expect("getblock");
+			for tx in block.txdata {
+				if tx.input.iter().any(|input| input.previous_output == outpoint) {
+					return Some(tx);
+				}
+			}
+		}
+		None
+	}
+
+	fn make_node(&self) -> Node {
+		let mut storage: PathBuf = std::env::temp_dir();
+		storage.push(format!("eltoo-node-{}", NEXT_PORT.fetch_add(0, Ordering::Relaxed)));
+		storage.push(format!("{}", rand_suffix()));
+		let port = NEXT_PORT.fetch_add(1, Ordering::Relaxed);
+
+		let rpc_host = self.bitcoind.params.rpc_socket.ip().to_string();
+		let rpc_port = self.bitcoind.params.rpc_socket.port();
+		let cookie = self.bitcoind.params.get_cookie_values().unwrap().unwrap();
+
+		let mut builder = Builder::new();
+		builder.set_network(Network::Regtest);
+		eprintln!("node storage: {}", storage.display());
+		builder.set_storage_dir_path(storage.to_str().unwrap().to_string());
+		builder.set_filesystem_logger(None, Some(ldk_node::logger::LogLevel::Trace));
+		builder
+			.set_listening_addresses(vec![format!("127.0.0.1:{}", port).parse().unwrap()])
+			.unwrap();
+		builder.set_chain_source_bitcoind_rpc(
+			rpc_host,
+			rpc_port,
+			cookie.user,
+			cookie.password,
+			None,
+		);
+		let entropy = NodeEntropy::from_bip39_mnemonic(generate_entropy_mnemonic(None), None);
+		let node = builder.build(entropy).unwrap();
+		node.start().unwrap();
+		node
+	}
+}
+
+fn rand_suffix() -> u64 {
+	use std::time::{SystemTime, UNIX_EPOCH};
+	SystemTime::now().duration_since(UNIX_EPOCH).unwrap().subsec_nanos() as u64
+}
+
+/// Syncs both nodes and lets the eltoo background driver tick.
+fn settle(nodes: &[&Node]) {
+	for node in nodes {
+		node.sync_wallets().expect("sync");
+	}
+	std::thread::sleep(Duration::from_millis(400));
+}
+
+/// Drives sync/tick until `check` extracts a value from a node's eltoo events, or
+/// panics after `tries` rounds. Events not consumed by `check` are dropped.
+fn wait_for_event<T>(
+	harness: &Harness, nodes: &[&Node], node: &Node, tries: usize,
+	check: impl Fn(&EltooEvent) -> Option<T>,
+) -> T {
+	for _ in 0..tries {
+		settle(nodes);
+		for event in node.eltoo_events() {
+			if let Some(value) = check(&event) {
+				return value;
+			}
+		}
+		harness.mine(1);
+	}
+	panic!("timed out waiting for eltoo event");
+}
+
+#[test]
+fn eltoo_channel_full_cycle_over_tcp() {
+	let harness = match Harness::start() {
+		Some(harness) => harness,
+		None => return,
+	};
+	let a = harness.make_node();
+	let b = harness.make_node();
+
+	// Fund a's on-chain wallet (it pays for funding txs and CPFP children).
+	let addr_a = a.onchain_payment().new_address().expect("address");
+	harness.fund(&addr_a, Amount::from_sat(10_000_000));
+	settle(&[&a, &b]);
+
+	// Open an eltoo channel over TCP; the wallet funds it automatically once the
+	// peer accepts, and it becomes ready at funding depth.
+	let b_addr = b.listening_addresses().unwrap()[0].clone();
+	a.open_eltoo_channel(b.node_id(), b_addr, CAPACITY_SAT, 0).expect("open");
+	let channel_id: ChannelId = wait_for_event(&harness, &[&a, &b], &a, 30, |event| match event {
+		EltooEvent::ChannelReady { channel_id } => Some(*channel_id),
+		_ => None,
+	});
+	wait_for_event(&harness, &[&a, &b], &b, 10, |event| match event {
+		EltooEvent::ChannelReady { channel_id: id } if *id == channel_id => Some(()),
+		_ => None,
+	});
+
+	// The funding tx is on-chain, paying the channel capacity.
+	let funding_outpoint = {
+		let txid_bytes: [u8; 32] = channel_id.0;
+		// The channel id is funding_txid XOR vout (BOLT 2 v1); recover by scanning
+		// recent blocks for a tx with a capacity-value output instead.
+		let mut found = None;
+		for height in 100..=harness.tip() {
+			let hash = harness
+				.bitcoind
+				.client
+				.get_block_hash(height as u64)
+				.expect("getblockhash")
+				.into_model()
+				.expect("hash")
+				.0;
+			let block = harness.bitcoind.client.get_block(hash).expect("getblock");
+			for tx in block.txdata {
+				if let Some(vout) =
+					tx.output.iter().position(|out| out.value == Amount::from_sat(CAPACITY_SAT))
+				{
+					found = Some(OutPoint { txid: tx.compute_txid(), vout: vout as u32 });
+				}
+			}
+		}
+		let _ = txid_bytes;
+		found.expect("funding tx confirmed")
+	};
+
+	// A payment over real TCP: 6 messages, one round trip each way.
+	let payment_hash = b.eltoo_receive_payment();
+	a.send_eltoo_payment(channel_id, 100_000_000, payment_hash).expect("send");
+	wait_for_event(&harness, &[&a, &b], &b, 10, |event| match event {
+		EltooEvent::PaymentClaimed { payment_hash: hash, amount_msat }
+			if *hash == payment_hash && *amount_msat == 100_000_000 =>
+		{
+			Some(())
+		},
+		_ => None,
+	});
+	wait_for_event(&harness, &[&a, &b], &a, 10, |event| match event {
+		EltooEvent::PaymentFulfilled { payment_hash: hash } if *hash == payment_hash => Some(()),
+		_ => None,
+	});
+
+	// Cooperative close: the MuSig2 keyspend confirms and spends the funding output.
+	let close_from = harness.tip() + 1;
+	a.close_eltoo_channel(channel_id).expect("close");
+	settle(&[&a, &b]);
+	harness.mine(1);
+	settle(&[&a, &b]);
+	let closing_tx = harness
+		.find_spending_tx(funding_outpoint, close_from)
+		.expect("cooperative close must confirm");
+	assert_eq!(closing_tx.input.len(), 1);
+	assert_eq!(closing_tx.input[0].witness.len(), 1, "keyspend: single signature");
+
+	a.stop().unwrap();
+	b.stop().unwrap();
+}
+
+#[test]
+fn eltoo_force_close_settles_over_tcp() {
+	let harness = match Harness::start() {
+		Some(harness) => harness,
+		None => return,
+	};
+	let a = harness.make_node();
+	let b = harness.make_node();
+
+	let addr_a = a.onchain_payment().new_address().expect("address");
+	harness.fund(&addr_a, Amount::from_sat(10_000_000));
+	settle(&[&a, &b]);
+
+	let b_addr = b.listening_addresses().unwrap()[0].clone();
+	a.open_eltoo_channel(b.node_id(), b_addr, CAPACITY_SAT, 0).expect("open");
+	let channel_id: ChannelId = wait_for_event(&harness, &[&a, &b], &a, 30, |event| match event {
+		EltooEvent::ChannelReady { channel_id } => Some(*channel_id),
+		_ => None,
+	});
+	b.eltoo_events();
+
+	// One payment so the broadcast state is not state 0.
+	let payment_hash = b.eltoo_receive_payment();
+	a.send_eltoo_payment(channel_id, 100_000_000, payment_hash).expect("send");
+	wait_for_event(&harness, &[&a, &b], &a, 10, |event| match event {
+		EltooEvent::PaymentFulfilled { .. } => Some(()),
+		_ => None,
+	});
+
+	// Locate the funding outpoint (capacity-value output).
+	let mut funding_outpoint = None;
+	for height in 100..=harness.tip() {
+		let hash = harness
+			.bitcoind
+			.client
+			.get_block_hash(height as u64)
+			.expect("getblockhash")
+			.into_model()
+			.expect("hash")
+			.0;
+		let block = harness.bitcoind.client.get_block(hash).expect("getblock");
+		for tx in block.txdata {
+			if let Some(vout) =
+				tx.output.iter().position(|out| out.value == Amount::from_sat(CAPACITY_SAT))
+			{
+				funding_outpoint = Some(OutPoint { txid: tx.compute_txid(), vout: vout as u32 });
+			}
+		}
+	}
+	let funding_outpoint = funding_outpoint.expect("funding tx confirmed");
+
+	// Force close: the zero-fee TRUC update tx enters the mempool as a package with
+	// its wallet-funded P2A CPFP child.
+	let close_from = harness.tip() + 1;
+	a.force_close_eltoo_channel(channel_id);
+	settle(&[&a, &b]);
+	harness.mine(1);
+	settle(&[&a, &b]);
+	let update_tx =
+		harness.find_spending_tx(funding_outpoint, close_from).expect("update tx must confirm");
+	assert_eq!(update_tx.input[0].witness.len(), 3, "script-path: [sig, leaf, control]");
+
+	// After the shared delay the signature-free settlement follows automatically.
+	harness.mine(144);
+	settle(&[&a, &b]);
+	let settle_from = harness.tip() + 1;
+	harness.mine(1);
+	settle(&[&a, &b]);
+	let state_outpoint = OutPoint { txid: update_tx.compute_txid(), vout: 2 };
+	let settlement_tx =
+		harness.find_spending_tx(state_outpoint, settle_from).expect("settlement must confirm");
+	assert_eq!(settlement_tx.input[0].witness.len(), 2, "covenant spend: [leaf, control]");
+
+	a.stop().unwrap();
+	b.stop().unwrap();
+}


### PR DESCRIPTION
This builds on top of https://github.com/bip448/rust-lightning/pull/2 to implement a node that can create eltoo channels.
Integration tests need to point a bitcoind binary with support for it which I was using https://github.com/bip448/bitcoin/pull/1

Comes with a repl to drive the demo node creating a channel, can broadcast an old state and rebind to broadcast newest update and then the settlement tx.