### PR TITLE
Raise CI workflow timeouts

### DIFF
--- a/.github/workflows/0fc-integration.yml
+++ b/.github/workflows/0fc-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: self-hosted
     steps:
       - name: Checkout source code

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   audit:
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       issues: write
       checks: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   benchmark:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: self-hosted
     env:
       TOOLCHAIN: stable

--- a/.github/workflows/cln-integration.yml
+++ b/.github/workflows/cln-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   check-cln:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/cron-weekly-rustfmt.yml
+++ b/.github/workflows/cron-weekly-rustfmt.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   format:
     name: Nightly rustfmt
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/eclair-integration.yml
+++ b/.github/workflows/eclair-integration.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   check-eclair:
     name: check-eclair (${{ matrix.name }})
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/hrn-integration.yml
+++ b/.github/workflows/hrn-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: self-hosted
     
     steps:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   check-kotlin:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/lnd-integration.yml
+++ b/.github/workflows/lnd-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   check-lnd:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     services:
       postgres:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   check-python:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       matrix:
         platform: [
@@ -93,7 +93,7 @@ jobs:
 
   linting:
     name: Linting
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: self-hosted
     steps:
       - name: Checkout source code
@@ -110,7 +110,7 @@ jobs:
 
   doc:
     name: Documentation
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: self-hosted
     env:
       RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   semver-checks:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   check-swift:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/vss-integration.yml
+++ b/.github/workflows/vss-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/vss-no-auth-integration.yml
+++ b/.github/workflows/vss-no-auth-integration.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
We recently reduced CI workflow timeouts to 60 minutes, but jobs now somewhat consistently hit the limit. Raise it to 120 minutes because the previous limit was chosen too low.

