### PR TITLE
Fix CI: Keep Python README within package builds

### DIFF
--- a/bindings/python/hatch_build.py
+++ b/bindings/python/hatch_build.py
@@ -1,7 +1,26 @@
+import os
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+
+def readme_path(root):
+    local_readme_path = os.path.join(root, "README.md")
+    if os.path.isfile(local_readme_path):
+        return local_readme_path
+
+    return os.path.normpath(os.path.join(root, "..", "..", "README.md"))
+
+
+class CustomMetadataHook(MetadataHookInterface):
+    def update(self, metadata):
+        with open(readme_path(self.root), encoding="utf-8") as readme_file:
+            metadata["readme"] = {"content-type": "text/markdown", "text": readme_file.read()}
 
 
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version, build_data):
         build_data["pure_python"] = False
         build_data["infer_tag"] = True
+        if self.target_name == "sdist":
+            build_data["force_include"][readme_path(self.root)] = "README.md"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="Elias Rohrer", email="dev@tnull.de" },
 ]
 description = "A ready-to-go Lightning node library built using LDK and BDK."
-readme = "../../README.md"
+dynamic = ["readme"]
 requires-python = ">=3.8"
 classifiers = [
     "Topic :: Software Development :: Libraries",
@@ -29,5 +29,7 @@ dev = ["requests"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ldk_node"]
+
+[tool.hatch.metadata.hooks.custom]
 
 [tool.hatch.build.hooks.custom]


### PR DESCRIPTION
Load the repository README through Hatchling metadata so builds accept the Python package configuration. Include a regular copy in source distributions so archive extraction remains safe.

(As latest `hatchlings` release broke our CI)