### PR TITLE
Fix Python bindings build with recent `hatchling` releases

### DIFF
--- a/bindings/python/hatch_build.py
+++ b/bindings/python/hatch_build.py
@@ -1,4 +1,16 @@
+import os
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+
+class CustomMetadataHook(MetadataHookInterface):
+    # Hatchling refuses a `readme` path outside the project directory, so we read the
+    # repository README ourselves and hand it over as literal text instead.
+    def update(self, metadata):
+        readme_path = os.path.join(self.root, os.pardir, os.pardir, "README.md")
+        with open(readme_path, encoding="utf-8") as f:
+            metadata["readme"] = {"content-type": "text/markdown", "text": f.read()}
 
 
 class CustomBuildHook(BuildHookInterface):

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="Elias Rohrer", email="dev@tnull.de" },
 ]
 description = "A ready-to-go Lightning node library built using LDK and BDK."
-readme = "../../README.md"
+dynamic = ["readme"]
 requires-python = ">=3.8"
 classifiers = [
     "Topic :: Software Development :: Libraries",
@@ -26,6 +26,8 @@ classifiers = [
 
 [dependency-groups]
 dev = ["requests"]
+
+[tool.hatch.metadata.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ldk_node"]


### PR DESCRIPTION
## Summary

`check-python` is currently failing on `main` (and consequently on every open PR). Recent `hatchling` releases validate that `project.readme` resolves inside the project directory, so our `readme = "../../README.md"` aborts the build before anything else runs:

```
ValueError: Readme path must be within the project directory: ../../README.md
```

This affects `scripts/python_build_wheel.sh` too, not just CI.

Rather than duplicating the README into `bindings/python/`, this declares `readme` dynamic and reads the repository README from a custom metadata hook, which passes it along as literal text and hence skips the path validation.

## Test plan

- [x] `uv pip install -e bindings/python` succeeds again (fails on `main` today)
- [x] `uv build --wheel` succeeds, and the resulting `METADATA` has `Description-Content-Type: text/markdown` with a body byte-identical to the repository `README.md` — so the published PyPI description is unchanged

## Disclosure

This PR was prepared with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)