### PR TITLE
Fix uniffi feature breaking postgres/migration integration tests

### DIFF
--- a/tests/integration_tests_migration.rs
+++ b/tests/integration_tests_migration.rs
@@ -88,10 +88,12 @@ macro_rules! with_opened_store {
 async fn build_migration_node(
 	instance: &BackendInstance, node_config: ldk_node::config::Config, node_entropy: NodeEntropy,
 	esplora_url: &str,
-) -> ldk_node::Node {
+) -> common::TestNode {
 	let mut builder = Builder::from_config(node_config);
 	builder.set_chain_source_esplora(esplora_url.to_string(), None);
-	with_opened_store!(instance, |store| builder.build_with_store(node_entropy, store).unwrap())
+	with_opened_store!(instance, |store| builder
+		.build_with_store(node_entropy.into(), store)
+		.unwrap())
 }
 
 fn open_fs_store(data_dir: &str) -> FilesystemStoreV2 {

--- a/tests/integration_tests_postgres.rs
+++ b/tests/integration_tests_postgres.rs
@@ -27,7 +27,7 @@ async fn channel_full_cycle_with_postgres_store() {
 	builder_a.set_chain_source_esplora(esplora_url.clone(), None);
 	let node_a = builder_a
 		.build_with_postgres_store(
-			config_a.node_entropy,
+			config_a.node_entropy.into(),
 			test_connection_string(),
 			None,
 			Some("channel_cycle_a".to_string()),
@@ -43,7 +43,7 @@ async fn channel_full_cycle_with_postgres_store() {
 	builder_b.set_chain_source_esplora(esplora_url.clone(), None);
 	let node_b = builder_b
 		.build_with_postgres_store(
-			config_b.node_entropy,
+			config_b.node_entropy.into(),
 			test_connection_string(),
 			None,
 			Some("channel_cycle_b".to_string()),
@@ -79,6 +79,9 @@ async fn postgres_node_restart() {
 	let storage_path = common::random_storage_path().to_str().unwrap().to_owned();
 	let mut seed_bytes = [42u8; 64];
 	rand::rng().fill_bytes(&mut seed_bytes);
+	#[cfg(feature = "uniffi")]
+	let node_entropy = NodeEntropy::from_seed_bytes(seed_bytes.to_vec()).unwrap();
+	#[cfg(not(feature = "uniffi"))]
 	let node_entropy = NodeEntropy::from_seed_bytes(seed_bytes);
 
 	// Setup initial node and fund it.
@@ -89,7 +92,7 @@ async fn postgres_node_restart() {
 		builder.set_chain_source_esplora(esplora_url.clone(), None);
 		let node = builder
 			.build_with_postgres_store(
-				node_entropy,
+				node_entropy.into(),
 				connection_string.clone(),
 				None,
 				Some("restart_test".to_string()),
@@ -124,7 +127,7 @@ async fn postgres_node_restart() {
 
 	let node = builder
 		.build_with_postgres_store(
-			node_entropy,
+			node_entropy.into(),
 			connection_string.clone(),
 			None,
 			Some("restart_test".to_string()),


### PR DESCRIPTION


## Context

`cargo test --all-features` fails to compile `tests/integration_tests_postgres.rs`
and `tests/integration_tests_migration.rs` with  type
mismatches (`Arc<NodeEntropy>` expected, `NodeEntropy` found; `Vec<u8>`
expected, `[u8; 64]` found; `Node` vs `Arc<Node>`).

## Cause

The `uniffi` feature changes the public shape of `NodeEntropy`, `Node`, and
related builder methods for FFI  — wrapping return types in `Arc<T>`
and switching `NodeEntropy::from_seed_bytes` to take `Vec<u8>` instead of a
fixed `[u8; 64]` array. 

## Fix

Both files now follow the same `#[cfg(feature = "uniffi")]` /
`#[cfg(not(feature = "uniffi"))]`  pattern similar
to `tests/integration_tests_rust.rs` and `tests/common/mod.rs`

## Testing

`cargo test --features postgres --test integration_tests_postgres` —
  3/3 passing, against  local Postgres instance

Open to feedback if a different approach is preferred — e.g. expanding CI
coverage to catch this combination going forward, in addition to or instead
of this fix