### PR TITLE
Wait for latest funding outpoint on close

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1689,7 +1689,7 @@ pub(crate) async fn do_channel_full_cycle<E: ElectrumApi>(
 	expect_event!(node_a, ChannelClosed);
 	expect_event!(node_b, ChannelClosed);
 
-	wait_for_outpoint_spend(electrsd, funding_txo_b).await;
+	wait_for_outpoint_spend(electrsd, splice_in_txo).await;
 
 	generate_blocks_and_wait(&bitcoind, electrsd, 1).await;
 	node_a.sync_wallets().unwrap();


### PR DESCRIPTION
```
    Wait for latest funding outpoint on close

    After splicing, the original funding output is already spent, so waiting
    on it can race block generation with the force-close broadcast. Wait for
    the final splice outpoint to be spent instead.

    Co-Authored-By: HAL 9000
```