### PR TITLE
Bump LDK to 0.3-rc1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,18 +86,18 @@ uniffi-default = [
 #lightning-macros = { version = "0.2.0" }
 #lightning-dns-resolver = { version = "0.3.0" }
 
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["std"] }
-lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb" }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["std"] }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["tokio"], optional = true }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["rest-client", "rpc-client", "tokio"], optional = true }
-lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", optional = true }
-lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["std"] }
-lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb" }
-lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", optional = true }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["std"] }
+lightning-types = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a" }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["std"] }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["tokio"], optional = true }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["rest-client", "rpc-client", "tokio"], optional = true }
+lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", optional = true }
+lightning-liquidity = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["std"] }
+lightning-macros = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a" }
+lightning-dns-resolver = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", optional = true }
 
 bdk_chain = { version = "0.23.3", default-features = false, features = ["std"] }
 bdk_esplora = { version = "0.22.2", default-features = false, features = ["async-https-rustls", "tokio"], optional = true }
@@ -132,14 +132,14 @@ postgres-native-tls = { version = "0.5", default-features = false, features = ["
 vss-client = { package = "vss-client-ng", version = "0.6", optional = true }
 prost = { version = "0.11.6", default-features = false, optional = true}
 #bitcoin-payment-instructions = { version = "0.6" }
-bitcoin-payment-instructions = { git = "https://github.com/tnull/bitcoin-payment-instructions", rev = "1d6ffaa8962391ddc84aeef98bd7439e55ccae9d", optional = true }
+bitcoin-payment-instructions = { git = "https://github.com/jkczyz/bitcoin-payment-instructions", rev = "c359b125e972ff49b5c2e9f6865afb11500286a0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["std", "_test_utils"] }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "9174965af9437196c527a9aa0df36bbcf050c8bb", features = ["tokio"] }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["std", "_test_utils"] }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "4219131b05e44663a1b417e4f6cf09c7740ead2a", features = ["tokio"] }
 rand = { version = "0.9.2", default-features = false, features = ["std", "thread_rng", "os_rng"] }
 proptest = "1.0.0"
 regex = "1.5.6"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1926,7 +1926,7 @@ fn build_with_store_internal(
 	let logger_ref = Arc::clone(&logger);
 	let (monitor_read_res, network_graph_res) = runtime.block_on(async {
 		tokio::join!(
-			monitor_reader.read_all_channel_monitors_with_updates_parallel(),
+			monitor_reader.read_all_channel_monitors_with_updates(),
 			read_network_graph(&*kv_store_ref, logger_ref),
 		)
 	});

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,8 +19,9 @@ use lightning::events::bump_transaction::BumpTransactionEvent;
 #[cfg(not(feature = "uniffi"))]
 use lightning::events::PaidBolt12Invoice;
 use lightning::events::{
-	ClosureReason, Event as LdkEvent, FundingInfo, HTLCLocator as LdkHtlcLocator,
-	PaymentFailureReason, PaymentPurpose, ReplayEvent,
+	ClosureReason, Event as LdkEvent, FundingInfo, InboundHTLCLocator as LdkInboundHtlcLocator,
+	OutboundHTLCLocator as LdkOutboundHtlcLocator, PaymentFailureReason, PaymentPurpose,
+	ReplayEvent,
 };
 use lightning::ln::channelmanager::{PaymentId, TrustedChannelFeatures};
 use lightning::ln::types::ChannelId;
@@ -91,8 +92,19 @@ impl_writeable_tlv_based!(HTLCLocator, {
 	(7, amount_msat, option),
 });
 
-impl From<LdkHtlcLocator> for HTLCLocator {
-	fn from(value: LdkHtlcLocator) -> Self {
+impl From<LdkInboundHtlcLocator> for HTLCLocator {
+	fn from(value: LdkInboundHtlcLocator) -> Self {
+		HTLCLocator {
+			channel_id: value.channel_id,
+			amount_msat: value.amount_msat,
+			user_channel_id: value.user_channel_id.map(|u| UserChannelId(u)),
+			node_id: value.node_id,
+		}
+	}
+}
+
+impl From<LdkOutboundHtlcLocator> for HTLCLocator {
+	fn from(value: LdkOutboundHtlcLocator) -> Self {
 		HTLCLocator {
 			channel_id: value.channel_id,
 			amount_msat: value.amount_msat,


### PR DESCRIPTION
Bumps the pinned rust-lightning revision to [`4219131b0`](https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/commit/4219131b05e44663a1b417e4f6cf09c7740ead2a), the `v0.3-rc1` tag. The rc1 backports ([rust-lightning #4937](https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/pulls/4937)) include failing queued splice contributions on `ChannelManager` reload and force-close ([rust-lightning #4918](https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/pulls/4918)): a splice contribution dropped by a restart now replays `SpliceNegotiationFailed` and `DiscardFunding` events instead of dying silently, which upcoming splice-tracking work relies on.

API fallout is small: `HTLCLocator` split into `InboundHTLCLocator`/`OutboundHTLCLocator` (both convert into our single `HTLCLocator` event type), and the async channel-monitor reader dropped its `_parallel` suffix. rc1 also changed `Event::SpliceNegotiationFailed::contribution` from `Option<FundingContribution>` to `Option<FailedSpliceContribution>`, but our handler doesn't consume that field, so no change was needed.

`bitcoin-payment-instructions` pins LDK by git rev and must move in lockstep. No rev on the previously pinned fork pins rc1 yet, so the dependency moves to an equivalent fork rev (`jkczyz/bitcoin-payment-instructions@c359b125` — the same tree as the previous pin plus the LDK bump).

One dev-only caveat: a `ChannelManager` written by v0.3-beta1 with a pending splice-failure event is unreadable by rc1, due to the TLV collision fix ([rust-lightning `879f640e7`](https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/commit/879f640e7ee2a89b0c834c0313292d120fb9ab8a)). No ldk-node release shipped beta1, so only development nodes that ran against beta1 are affected.

Developed with assistance from Claude Code.