### PR TITLE
Pin `encoding_rs` for MSRV builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
         if: matrix.msrv
         run: |
           cargo update -p idna_adapter --precise "1.2.0" --verbose # idna_adapter 1.2.1 uses ICU4X 2.2.0, requiring 1.86 and newer
+          cargo update -p encoding_rs --precise "0.8.35" --verbose # encoding_rs 0.8.40 and newer require 1.88 and newer
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == 'stable'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"


### PR DESCRIPTION
Keep the Rust 1.85 CI job resolving `encoding_rs` 0.8.35 because newer releases require Rust 1.88.