### PR TITLE
Fix LSPS2 variable-amount JIT fee ceiling to cover the full payment

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -692,13 +692,18 @@ where
 		}
 	}
 
-	fn lsps2_max_total_opening_fee_msat(payment_metadata: &[u8], amount_msat: u64) -> Option<u64> {
+	fn lsps2_max_total_opening_fee_msat(
+		payment_metadata: &[u8], amount_msat: u64, counterparty_skimmed_fee_msat: u64,
+	) -> Option<u64> {
 		let metadata = PaymentMetadata::read(&mut &payment_metadata[..]).ok()?;
 		let lsps2_parameters = metadata.lsps2_parameters?;
 		lsps2_parameters.max_total_opening_fee_msat.or_else(|| {
 			lsps2_parameters.max_proportional_opening_fee_ppm_msat.and_then(|max_prop_fee| {
-				// If it's a variable amount payment, compute the actual fee.
-				compute_opening_fee(amount_msat, 0, max_prop_fee)
+				// If it's a variable amount payment, compute the actual fee. Per bLIP-52 the
+				// opening fee is proportional to what the *payer* sent, which is what we were
+				// forwarded plus what the LSP skimmed off the top.
+				let payment_size_msat = amount_msat.saturating_add(counterparty_skimmed_fee_msat);
+				compute_opening_fee(payment_size_msat, 0, max_prop_fee)
 			})
 		})
 	}
@@ -920,7 +925,11 @@ where
 							.as_ref()
 							.and_then(|fields| fields.payment_metadata.as_ref())
 							.and_then(|metadata| {
-								Self::lsps2_max_total_opening_fee_msat(metadata, amount_msat)
+								Self::lsps2_max_total_opening_fee_msat(
+									metadata,
+									amount_msat,
+									counterparty_skimmed_fee_msat,
+								)
 							}),
 						_ => None,
 					};
@@ -2261,7 +2270,8 @@ mod tests {
 		assert_eq!(
 			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
 				&metadata.encode(),
-				100_000
+				100_000,
+				0
 			),
 			Some(42_000)
 		);
@@ -2281,21 +2291,134 @@ mod tests {
 		assert_eq!(
 			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
 				&empty_metadata,
-				100_000
+				100_000,
+				0
 			),
 			None
 		);
 		assert_eq!(
-			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(&[0xff], 100_000),
+			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(&[0xff], 100_000, 0),
 			None
 		);
 		assert_eq!(
 			EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
 				&metadata_without_fee_limit,
-				100_000
+				100_000,
+				0
 			),
 			None
 		);
+	}
+
+	/// The variable-amount JIT flow stores only a proportional (ppm) limit, so the ceiling has
+	/// to be recomputed from the payment at claim time. bLIP-52 defines the opening fee over the
+	/// amount the *payer* sent, while `PaymentClaimable::amount_msat` is what is left after the
+	/// LSP skimmed that fee -- so the ceiling must be computed over `amount + skimmed`.
+	#[test]
+	fn lsps2_proportional_fee_limit_admits_the_agreed_fee() {
+		// What the client agreed to in `lsps2_receive_variable_amount_to_jit_channel`.
+		const AGREED_PPM: u64 = 10_000; // 1%
+		let metadata = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: None,
+				max_proportional_opening_fee_ppm_msat: Some(AGREED_PPM),
+			}),
+		}
+		.encode();
+
+		for payment_size_msat in [100_000u64, 1_000_000, 50_000_000, 1_000_000_000] {
+			// The LSP computes its fee over the amount the payer sent, exactly as bLIP-52
+			// specifies, and forwards the remainder.
+			let lsp_fee_msat = compute_opening_fee(payment_size_msat, 0, AGREED_PPM).unwrap();
+			let amount_msat = payment_size_msat - lsp_fee_msat;
+
+			// This is what `PaymentClaimable` hands the event handler.
+			let ceiling = EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+				&metadata,
+				amount_msat,
+				lsp_fee_msat,
+			)
+			.expect("metadata carries a proportional limit");
+
+			assert!(
+				lsp_fee_msat <= ceiling,
+				"payment of {}msat: LSP skimmed the agreed {}msat but our ceiling is {}msat, \
+				 so the HTLC is failed back",
+				payment_size_msat,
+				lsp_fee_msat,
+				ceiling,
+			);
+			// Reconstructing the payment size from `amount_msat + counterparty_skimmed_fee_msat`
+			// loses nothing (both are exact integers), so the recomputed ceiling matches the
+			// LSP's fee exactly, not just as an upper bound.
+			assert_eq!(ceiling, lsp_fee_msat);
+		}
+	}
+
+	/// A zero proportional fee must yield a zero ceiling, and a zero skimmed fee must be
+	/// admitted by it -- the ordinary "no fee was withheld" case must keep working.
+	#[test]
+	fn lsps2_proportional_fee_limit_of_zero_admits_no_skimmed_fee() {
+		let metadata = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: None,
+				max_proportional_opening_fee_ppm_msat: Some(0),
+			}),
+		}
+		.encode();
+
+		let ceiling = EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+			&metadata, 100_000, 0,
+		);
+		assert_eq!(ceiling, Some(0));
+	}
+
+	/// `max_total_opening_fee_msat`, when present, is an absolute cap that does not depend on
+	/// the payment size at all, so it must take precedence and stay unaffected by whatever is
+	/// passed as `counterparty_skimmed_fee_msat` -- guards against a future change accidentally
+	/// threading the skimmed fee into that branch too.
+	#[test]
+	fn lsps2_absolute_fee_limit_ignores_skimmed_fee_argument() {
+		let metadata = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: Some(42_000),
+				max_proportional_opening_fee_ppm_msat: Some(999_999),
+			}),
+		}
+		.encode();
+
+		for skimmed in [0u64, 1, 1_000_000, u64::MAX] {
+			assert_eq!(
+				EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+					&metadata, 100_000, skimmed,
+				),
+				Some(42_000),
+			);
+		}
+	}
+
+	/// An adversarial or corrupted `counterparty_skimmed_fee_msat` near `u64::MAX` must not
+	/// panic (`saturating_add` rather than a bare `+`), and an internal overflow inside
+	/// `compute_opening_fee` must fail closed -- `None`, i.e. the payment gets refused -- rather
+	/// than panicking or silently wrapping into an admissible-looking ceiling.
+	#[test]
+	fn lsps2_proportional_fee_limit_saturates_instead_of_panicking_on_overflow() {
+		let metadata = PaymentMetadata {
+			lsps2_parameters: Some(LSPS2Parameters {
+				max_total_opening_fee_msat: None,
+				max_proportional_opening_fee_ppm_msat: Some(10_000),
+			}),
+		}
+		.encode();
+
+		let ceiling = EventHandler::<Arc<TestLogger>>::lsps2_max_total_opening_fee_msat(
+			&metadata,
+			u64::MAX - 10,
+			u64::MAX, // saturating_add(amount_msat, this) clamps to u64::MAX
+		);
+		// `compute_opening_fee` internally does `payment_size_msat.checked_mul(proportional)`,
+		// which overflows for a payment size this large; fails closed rather than panicking.
+		assert_eq!(ceiling, None);
 	}
 
 	#[tokio::test]

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -3684,6 +3684,125 @@ async fn do_lsps2_client_service_integration(client_trusts_lsp: bool) {
 	);
 }
 
+/// Regression test for the variable-amount LSPS2 JIT-channel fee ceiling: with the LSP charging
+/// a non-zero proportional opening fee, `lsps2_max_total_opening_fee_msat` used to compute the
+/// admissible-fee ceiling over the *post-skim* `PaymentClaimable::amount_msat` instead of the
+/// amount the payer actually sent, so the ceiling always ended up below the LSP's real fee and
+/// every such payment was refused after the LSP had already opened and funded the channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn lsps2_variable_amount_jit_channel_with_proportional_fee_succeeds() {
+	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
+	let esplora_url = format!("http://{}", electrsd.esplora_url.as_ref().unwrap());
+
+	let mut sync_config = EsploraSyncConfig::default();
+	sync_config.background_sync_config = None;
+
+	// A non-zero proportional fee and no per-payment cap is exactly the configuration the buggy
+	// ceiling calculation always rejected, regardless of how small the fee actually is.
+	let channel_opening_fee_ppm = 10_000; // 1%
+	let channel_over_provisioning_ppm = 100_000;
+	let lsps2_service_config = LSPS2ServiceConfig {
+		require_token: None,
+		advertise_service: false,
+		channel_opening_fee_ppm,
+		channel_over_provisioning_ppm,
+		max_payment_size_msat: 1_000_000_000,
+		min_payment_size_msat: 0,
+		min_channel_lifetime: 100,
+		min_channel_opening_fee_msat: 0,
+		max_client_to_self_delay: 1024,
+		client_trusts_lsp: true,
+		disable_client_reserve: false,
+	};
+
+	let service_config = random_config();
+	setup_builder!(service_builder, service_config.node_config);
+	service_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
+	service_builder.enable_liquidity_provider(lsps2_service_config);
+	let service_node = service_builder.build(service_config.node_entropy.into()).unwrap();
+	service_node.start().unwrap();
+
+	let service_node_id = service_node.node_id();
+	let service_addr = service_node.listening_addresses().unwrap().first().unwrap().clone();
+
+	let client_config = random_config();
+	setup_builder!(client_builder, client_config.node_config);
+	client_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
+	client_builder.add_liquidity_source(service_node_id, service_addr, None, true);
+	let client_node = client_builder.build(client_config.node_entropy.into()).unwrap();
+	client_node.start().unwrap();
+
+	let payer_config = random_config();
+	setup_builder!(payer_builder, payer_config.node_config);
+	payer_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
+	let payer_node = payer_builder.build(payer_config.node_entropy.into()).unwrap();
+	payer_node.start().unwrap();
+
+	let service_addr = service_node.onchain_payment().new_address().unwrap();
+	let client_addr = client_node.onchain_payment().new_address().unwrap();
+	let payer_addr = payer_node.onchain_payment().new_address().unwrap();
+
+	let premine_amount_sat = 10_000_000;
+	premine_and_distribute_funds(
+		&bitcoind.client,
+		&electrsd.client,
+		vec![service_addr, client_addr, payer_addr],
+		Amount::from_sat(premine_amount_sat),
+	)
+	.await;
+	service_node.sync_wallets().unwrap();
+	client_node.sync_wallets().unwrap();
+	payer_node.sync_wallets().unwrap();
+
+	// Open a channel payer -> service that will allow paying the JIT invoice.
+	open_channel(&payer_node, &service_node, 5_000_000, false, &electrsd).await;
+
+	generate_blocks_and_wait(&bitcoind.client, &electrsd.client, 6).await;
+	service_node.sync_wallets().unwrap();
+	payer_node.sync_wallets().unwrap();
+	expect_channel_ready_event!(payer_node, service_node.node_id());
+	expect_channel_ready_event!(service_node, payer_node.node_id());
+
+	// A *variable-amount* JIT invoice: this is the zero-amount-invoice path that always failed
+	// once the LSP took a non-zero proportional cut, because the fee ceiling was computed over
+	// the wrong base amount.
+	let invoice_description =
+		Bolt11InvoiceDescription::Direct(Description::new(String::from("asdf")).unwrap());
+	let jit_invoice = client_node
+		.bolt11_payment()
+		.receive_variable_amount_via_jit_channel(&invoice_description.into(), 1024, None)
+		.unwrap();
+	assert_eq!(jit_invoice.amount_milli_satoshis(), None, "invoice must be zero-amount");
+
+	let jit_amount_msat = 100_000_000;
+	println!("Paying variable-amount JIT invoice!");
+	let payer_payment_id =
+		payer_node.bolt11_payment().send_using_amount(&jit_invoice, jit_amount_msat, None).unwrap();
+
+	expect_channel_pending_event!(service_node, client_node.node_id());
+	expect_channel_ready_event!(service_node, client_node.node_id());
+	expect_event!(service_node, PaymentForwarded);
+	expect_channel_pending_event!(client_node, service_node.node_id());
+	expect_channel_ready_event!(client_node, service_node.node_id());
+
+	// Before the fix, this event never arrives: the client instead sees the HTLC failed back and
+	// `payer_node` gets `PaymentFailed`, because the client's own fee-ceiling check rejected the
+	// LSP's (correctly computed) skimmed fee.
+	let service_fee_msat = (jit_amount_msat * channel_opening_fee_ppm as u64) / 1_000_000;
+	let expected_received_amount_msat = jit_amount_msat - service_fee_msat;
+	expect_payment_successful_event!(payer_node, payer_payment_id, None);
+	let client_payment_id =
+		expect_payment_received_event!(client_node, expected_received_amount_msat);
+
+	let client_payment = client_node.payment(&client_payment_id).unwrap().unwrap();
+	match client_payment.kind {
+		PaymentKind::Bolt11 { counterparty_skimmed_fee_msat, .. } => {
+			assert_eq!(counterparty_skimmed_fee_msat, Some(service_fee_msat));
+		},
+		_ => panic!("Unexpected payment kind"),
+	}
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn facade_logging() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();


### PR DESCRIPTION
## Summary

Fixes a bug in `EventHandler::lsps2_max_total_opening_fee_msat` where the admissible-fee ceiling for the **variable-amount** LSPS2 JIT-channel flow (`receive_variable_amount_via_jit_channel[_for_hash]`) was computed from the *post-skim* `PaymentClaimable::amount_msat` instead of the amount the payer actually sent.

Per [bLIP-52](https://github.com/lightning/blips/blob/master/blip-0052.md#computing-the-opening_fee):

```
opening_fee = max(min_fee_msat, ceil(payment_size_msat * proportional / 1_000_000))
```

`payment_size_msat` is what the payer sent; the LSP forwards `payment_size_msat - opening_fee`, which is the `amount_msat` we observe in `PaymentClaimable`. The buggy code computed the ceiling as `compute_opening_fee(amount_msat, 0, max_prop_fee)` — over the already-discounted amount — which is a strictly smaller base than the fee was actually charged against. As a result, for **every** `channel_opening_fee_ppm > 0` the computed ceiling ends up below the LSP's correctly-computed fee, and `fail_claimable_payment()` is called, **after the LSP has already opened and funded the JIT channel**.

### Example (`channel_opening_fee_ppm = 10_000`, i.e. 1%)

| | msat |
|---|---:|
| Payer sends | 1,000,000 |
| LSP's correct fee — `ceil(1,000,000 × 10,000 / 1,000,000)` | 10,000 |
| `amount_msat` delivered to us (post-skim) | 990,000 |
| Ceiling computed on `main` — `ceil(990,000 × 10,000 / 1,000,000)` | 9,900 |
| Check: `10,000 > 9,900` → | **refused** |

Because the fixed-amount JIT flow stores an absolute `max_total_opening_fee_msat` cap (unaffected by this bug), none of the existing integration tests — which all use `receive_via_jit_channel[_for_hash]` — exercise the broken branch.

## Fix

Reconstruct the pre-skim payment size the same way the handler already does a few lines below (when recording the invoice amount): `amount_msat.saturating_add(counterparty_skimmed_fee_msat)`.

```rust
fn lsps2_max_total_opening_fee_msat(
    payment_metadata: &[u8], amount_msat: u64, counterparty_skimmed_fee_msat: u64,
) -> Option<u64> {
    ...
    let payment_size_msat = amount_msat.saturating_add(counterparty_skimmed_fee_msat);
    compute_opening_fee(payment_size_msat, 0, max_prop_fee)
    ...
}
```

`min_fee_msat` remains hardcoded to `0` here (pre-existing, out of scope for this PR — `LSPS2Parameters` doesn't currently carry the agreed `min_fee_msat` for the variable-amount flow; happy to follow up separately if useful).

## Testing

**Unit tests** (`src/event.rs`, all passing on this branch, `cargo test --lib`):
- `lsps2_proportional_fee_limit_admits_the_agreed_fee` — reproduces the bug across a range of payment sizes (100k–1B msat). Confirmed this fails on unmodified `main` (`ceiling 9900 rejects the agreed 1% fee`) and passes with the fix; also asserts the recomputed ceiling matches the LSP's fee exactly, not just as an upper bound.
- `lsps2_proportional_fee_limit_of_zero_admits_no_skimmed_fee` — zero-ppm / zero-skim regression guard.
- `lsps2_absolute_fee_limit_ignores_skimmed_fee_argument` — `max_total_opening_fee_msat`, when set, stays an unconditional cap and doesn't get the skimmed-fee argument threaded into it.
- `lsps2_proportional_fee_limit_saturates_instead_of_panicking_on_overflow` — `u64::MAX`-adjacent inputs don't panic; an internal `compute_opening_fee` overflow fails closed (`None` → payment refused) rather than wrapping.

I manually reverted just the fix (keeping the new tests) and confirmed exactly `lsps2_proportional_fee_limit_admits_the_agreed_fee` fails, while the other three pass either way — they pin separate properties, not this specific reconstruction bug.

**Integration test** (`tests/integration_tests_rust.rs`):
- `lsps2_variable_amount_jit_channel_with_proportional_fee_succeeds` — mirrors `lsps2_client_service_integration` but drives the flow through `receive_variable_amount_via_jit_channel` + `send_using_amount` end-to-end (service/client/payer nodes, real channel open, real `PaymentForwarded`/`PaymentReceived`), asserting the payment succeeds and `counterparty_skimmed_fee_msat` matches the LSP's fee. This test compiles and is believed correct (built directly from the working, executed `lsps2_client_service_integration` template with matching macros/helpers), but I wasn't able to execute it in my sandbox — the `corepc-node`/`electrsd` downloaded `bitcoind`/`electrs` binaries fail macOS code-signature validation there (unrelated to this repo). Happy to have CI confirm, or iterate if it needs adjustment.


